### PR TITLE
feat(docs,ci): preparar publicação do IG no Simplifier (PRE-181)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,9 +222,12 @@ jobs:
           if [ "$STATUS" = "200" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Versão ${PKG_NAME}@${VERSION} já publicada — pulando upload"
-          else
+          elif [ "$STATUS" = "404" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Versão ${PKG_NAME}@${VERSION} não encontrada — publicando"
+          else
+            echo "::error::Status inesperado do Simplifier: HTTP ${STATUS}"
+            exit 1
           fi
 
       - name: Publicar no Simplifier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
   publish-ig:
     name: Publish FHIR IG
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && secrets.SIMPLIFIER_API_KEY != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,56 @@ jobs:
           publish_if_needed packages/ocr-utils
           publish_if_needed packages/rnds
 
+  # ── Publicar FHIR IG no Simplifier ──────────────────────────
+  publish-ig:
+    name: Publish FHIR IG
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Instalar dependências
+        run: pnpm install --frozen-lockfile
+
+      - name: Compilar IG (SUSHI)
+        run: pnpm exec sushi ig/ -o ig/output
+
+      - name: Montar pacote FHIR (.tgz)
+        run: node ig/scripts/build-package-tgz.js
+
+      - name: Verificar se versão já foi publicada
+        id: check
+        run: |
+          VERSION=$(node -p "JSON.parse(require('fs').readFileSync('ig/output/package/package.json','utf8')).version")
+          PKG_NAME=$(node -p "JSON.parse(require('fs').readFileSync('ig/output/package/package.json','utf8')).name")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://packages.simplifier.net/${PKG_NAME}/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Versão ${PKG_NAME}@${VERSION} já publicada — pulando upload"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Versão ${PKG_NAME}@${VERSION} não encontrada — publicando"
+          fi
+
+      - name: Publicar no Simplifier
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          curl -X POST "https://packages.simplifier.net" \
+            -H "Authorization: Bearer ${{ secrets.SIMPLIFIER_API_KEY }}" \
+            -F "file=@ig/output/package.tgz" \
+            --fail --silent --show-error
+
   # ── Deploy site (main only, after checks pass) ─────────────
   build-site:
     name: Build Site

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm @precisa-saude/fhir-calculators](https://img.shields.io/npm/v/@precisa-saude/fhir-calculators?label=fhir-calculators)](https://www.npmjs.com/package/@precisa-saude/fhir-calculators)
 [![npm @precisa-saude/fhir-ocr-utils](https://img.shields.io/npm/v/@precisa-saude/fhir-ocr-utils?label=fhir-ocr-utils)](https://www.npmjs.com/package/@precisa-saude/fhir-ocr-utils)
 [![npm @precisa-saude/fhir-rnds](https://img.shields.io/npm/v/@precisa-saude/fhir-rnds?label=fhir-rnds)](https://www.npmjs.com/package/@precisa-saude/fhir-rnds)
+[![FHIR IG](https://img.shields.io/badge/FHIR_IG-br.dev.fhir--brasil.core-orange)](https://simplifier.net/packages/br.dev.fhir-brasil.core)
 
 Toolkit FHIR R4 para o ecossistema de saúde brasileiro — definições de biomarcadores, faixas de referência, calculadoras clínicas, normalização de aliases e cliente RNDS.
 
@@ -53,6 +54,21 @@ npm install @precisa-saude/fhir-ocr-utils
 
 # Cliente RNDS (Rede Nacional de Dados em Saúde)
 npm install @precisa-saude/fhir-rnds
+```
+
+### Implementation Guide (perfis FHIR)
+
+Os perfis, extensões e terminologias brasileiras estão disponíveis como pacote FHIR no [Simplifier Package Registry](https://simplifier.net/packages/br.dev.fhir-brasil.core):
+
+```bash
+fhir install br.dev.fhir-brasil.core
+```
+
+Ou como dependência em outro IG (`sushi-config.yaml`):
+
+```yaml
+dependencies:
+  br.dev.fhir-brasil.core: 0.9.0
 ```
 
 ---

--- a/docs/development/adr/003-package-id-simplifier.md
+++ b/docs/development/adr/003-package-id-simplifier.md
@@ -1,0 +1,49 @@
+# ADR-003: Package ID e publicação no FHIR Package Registry (Simplifier)
+
+**Data:** 2026-04-07
+**Status:** Aceito
+
+## Contexto
+
+O Implementation Guide do fhir-brasil (perfis, extensões, terminologias FSH) precisa ser distribuído como pacote FHIR para que ferramentas como SUSHI, IG Publisher, HAPI FHIR, Medplum e Firely Terminal possam consumi-lo via o mecanismo padrão de dependência FHIR. Isso requer um package ID permanente e a escolha de um registry.
+
+O FHIR NPM Package Spec define que pacotes usam namespaces separados por ponto (ex: `hl7.fhir.us.core`), e ferramentas FHIR **não** procuram pacotes no npmjs.com — o canal correto é um FHIR Package Registry como o Simplifier.
+
+O package ID anterior era `br.fhir-brasil`, que não seguia a convenção reverse-DNS e não permitia expansão para sub-IGs.
+
+## Decisão
+
+1. Adotar `br.dev.fhir-brasil.core` como package ID.
+2. Publicar no Simplifier (packages.simplifier.net) como registry primário.
+3. Automatizar publicação no CI via API REST do Simplifier em cada release.
+
+## Argumentos a favor
+
+### Package ID `br.dev.fhir-brasil.core`
+
+- **Reverse-DNS de `fhir-brasil.dev.br`**: torna a origem do pacote imediatamente identificável, seguindo a convenção da comunidade FHIR.
+- **Prefixo `br`**: alinha com IGs nacionais (`hl7.fhir.us.core`, `hl7.fhir.uk.core`). Identifica como infraestrutura FHIR brasileira ao navegar registries.
+- **Sufixo `.core`**: permite expansão futura para sub-IGs (ex: `br.dev.fhir-brasil.lab`, `br.dev.fhir-brasil.rnds`) sob o mesmo namespace.
+- **Disponibilidade verificada**: nenhum conflito com pacotes existentes no Simplifier.
+
+### Simplifier como registry
+
+- **Registry mais estabelecido** da comunidade FHIR, usado pela HL7 e IGs nacionais (US Core, UK NHS, Suíça, Holanda).
+- **Conta gratuita** para projetos open-source.
+- **API REST** para automação de publicação.
+- **Integração nativa** com `fhir install` CLI e SUSHI `dependencies`.
+
+## Argumentos contra
+
+- **Self-hosted em fhir-brasil.dev.br**: daria controle total, mas o custo de manter um package registry próprio não se justifica no estágio atual do projeto.
+- **`br.com.precisa-saude.fhir`**: vincularia o pacote à empresa em vez do projeto open-source. `fhir-brasil.dev.br` é o domínio do projeto, não da empresa.
+- **Sufixo `.core` pode ser prematuro**: se nenhum sub-IG for criado, o `.core` é redundante. Porém, remover depois é impossível (porta sem volta), e adicionar é trivial no namespace.
+- **packages.fhir.org / registry.fhir.org**: são catálogos oficiais HL7, mas requerem processo de submissão separado. Podem ser adicionados depois que a publicação no Simplifier estiver estável.
+
+## Consequências
+
+- **Porta sem volta**: uma vez publicado, renomear o package ID quebra todos os consumidores downstream. A decisão está documentada aqui para referência futura.
+- **CI**: o workflow de release precisa de um secret `SIMPLIFIER_API_KEY` para upload automático.
+- **Versionamento independente**: a versão do IG (`0.9.0`) é gerenciada manualmente em `sushi-config.yaml`, independente do semantic-release que versiona os pacotes npm. Isso é intencional — o IG segue seu próprio ritmo de publicação.
+- **ig.ini e outputs**: todos os arquivos gerados pelo SUSHI agora referenciam `br.dev.fhir-brasil.core` em vez de `br.fhir-brasil`.
+- **registry.fhir.org**: inclusão no catálogo oficial HL7 fica para ticket futuro, após validação da publicação no Simplifier.

--- a/ig/README.md
+++ b/ig/README.md
@@ -2,6 +2,19 @@
 
 Este diretório contém o Implementation Guide (IG) do fhir-brasil, escrito em [FHIR Shorthand (FSH)](https://build.fhir.org/ig/HL7/fhir-shorthand/) e compilado com [SUSHI](https://fshschool.org/docs/sushi/).
 
+## Como instalar
+
+O pacote FHIR está disponível no [Simplifier FHIR Package Registry](https://simplifier.net/packages/br.dev.fhir-brasil.core).
+
+```bash
+# Via FHIR CLI
+fhir install br.dev.fhir-brasil.core 0.9.0
+
+# Ou como dependência em outro IG (sushi-config.yaml)
+# dependencies:
+#   br.dev.fhir-brasil.core: 0.9.0
+```
+
 ## Conteúdo
 
 ### Perfis

--- a/ig/ig.ini
+++ b/ig/ig.ini
@@ -1,3 +1,3 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-br.fhir-brasil.json
+ig = fsh-generated/resources/ImplementationGuide-br.dev.fhir-brasil.core.json
 template = fhir.base.template

--- a/ig/scripts/build-package-tgz.js
+++ b/ig/scripts/build-package-tgz.js
@@ -35,7 +35,8 @@ const configPath = join(ROOT, 'sushi-config.yaml');
 const configText = readFileSync(configPath, 'utf8');
 
 function yamlValue(key) {
-  const re = new RegExp(`^${key}:\\s+(.+)$`, 'm');
+  // Ancorar em início de linha sem indentação para não capturar chaves nested
+  const re = new RegExp(`^(?!\\s)${key}:\\s+(.+)$`, 'm');
   const m = configText.match(re);
   return m ? m[1].trim().replace(/^['"]|['"]$/g, '') : undefined;
 }
@@ -49,7 +50,8 @@ const name = yamlValue('name');
 const title = yamlValue('title');
 
 // Extrair description (multiline >-)
-const descMatch = configText.match(/^description:\s*>-\n([\s\S]*?)(?=^\w)/m);
+// Termina na próxima chave top-level (sem indentação) ou no fim do arquivo
+const descMatch = configText.match(/^description:\s*>-\n([\s\S]*?)(?=^[^\s]|\z)/m);
 const description = descMatch
   ? descMatch[1]
       .split('\n')

--- a/ig/scripts/build-package-tgz.js
+++ b/ig/scripts/build-package-tgz.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+/**
+ * Monta um pacote FHIR NPM (.tgz) a partir do output do SUSHI.
+ *
+ * Entrada: ig/output/fsh-generated/resources/*.json + ig/sushi-config.yaml
+ * Saída:   ig/output/package.tgz
+ *
+ * Segue a FHIR NPM Package Spec:
+ * https://confluence.hl7.org/display/FHIR/NPM+Package+Specification
+ */
+
+import { execSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  cpSync,
+  rmSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const RESOURCES_DIR = join(ROOT, 'output', 'fsh-generated', 'resources');
+const PACKAGE_DIR = join(ROOT, 'output', 'package');
+const OUTPUT_TGZ = join(ROOT, 'output', 'package.tgz');
+
+// ---------------------------------------------------------------------------
+// 1. Ler sushi-config.yaml (parsing minimalista — sem dep de YAML parser)
+// ---------------------------------------------------------------------------
+
+const configPath = join(ROOT, 'sushi-config.yaml');
+const configText = readFileSync(configPath, 'utf8');
+
+function yamlValue(key) {
+  const re = new RegExp(`^${key}:\\s+(.+)$`, 'm');
+  const m = configText.match(re);
+  return m ? m[1].trim().replace(/^['"]|['"]$/g, '') : undefined;
+}
+
+const id = yamlValue('id');
+const version = yamlValue('version');
+const canonical = yamlValue('canonical');
+const fhirVersion = yamlValue('fhirVersion');
+const license = yamlValue('license');
+const name = yamlValue('name');
+const title = yamlValue('title');
+
+// Extrair description (multiline >-)
+const descMatch = configText.match(/^description:\s*>-\n([\s\S]*?)(?=^\w)/m);
+const description = descMatch
+  ? descMatch[1]
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .join(' ')
+  : '';
+
+if (!id || !version || !canonical || !fhirVersion) {
+  console.error(
+    'Campos obrigatórios faltando em sushi-config.yaml (id, version, canonical, fhirVersion)',
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Preparar diretório package/
+// ---------------------------------------------------------------------------
+
+if (existsSync(PACKAGE_DIR)) {
+  rmSync(PACKAGE_DIR, { recursive: true });
+}
+mkdirSync(PACKAGE_DIR, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// 3. Copiar recursos JSON
+// ---------------------------------------------------------------------------
+
+if (!existsSync(RESOURCES_DIR)) {
+  console.error(`Diretório de recursos não encontrado: ${RESOURCES_DIR}`);
+  console.error('Execute "pnpm exec sushi ig/ -o ig/output" antes deste script.');
+  process.exit(1);
+}
+
+const jsonFiles = readdirSync(RESOURCES_DIR).filter((f) => f.endsWith('.json'));
+
+for (const file of jsonFiles) {
+  cpSync(join(RESOURCES_DIR, file), join(PACKAGE_DIR, file));
+}
+
+console.log(`Copiados ${jsonFiles.length} recursos para package/`);
+
+// ---------------------------------------------------------------------------
+// 4. Gerar package.json (FHIR NPM Package Spec)
+// ---------------------------------------------------------------------------
+
+const packageJson = {
+  name: id,
+  version,
+  canonical,
+  url: canonical,
+  title: title || name,
+  description,
+  fhirVersions: [fhirVersion],
+  dependencies: {
+    'hl7.fhir.r4.core': fhirVersion,
+  },
+  license,
+  author: 'Precisa Saúde',
+  type: 'fhir.ig',
+};
+
+writeFileSync(join(PACKAGE_DIR, 'package.json'), JSON.stringify(packageJson, null, 2) + '\n');
+console.log('Gerado package/package.json');
+
+// ---------------------------------------------------------------------------
+// 5. Gerar .index.json
+// ---------------------------------------------------------------------------
+
+const index = { 'index-version': 1, files: [] };
+
+for (const file of jsonFiles) {
+  const content = JSON.parse(readFileSync(join(PACKAGE_DIR, file), 'utf8'));
+  if (content.resourceType) {
+    index.files.push({
+      filename: file,
+      resourceType: content.resourceType,
+      id: content.id,
+      url: content.url,
+      version: content.version,
+    });
+  }
+}
+
+writeFileSync(join(PACKAGE_DIR, '.index.json'), JSON.stringify(index, null, 2) + '\n');
+console.log(`Gerado package/.index.json com ${index.files.length} entradas`);
+
+// ---------------------------------------------------------------------------
+// 6. Criar tarball
+// ---------------------------------------------------------------------------
+
+execSync(`tar czf package.tgz package`, {
+  cwd: join(ROOT, 'output'),
+  stdio: 'inherit',
+});
+
+console.log(`\nPacote criado: ${OUTPUT_TGZ}`);

--- a/ig/scripts/build-package-tgz.js
+++ b/ig/scripts/build-package-tgz.js
@@ -51,7 +51,7 @@ const title = yamlValue('title');
 
 // Extrair description (multiline >-)
 // Termina na próxima chave top-level (sem indentação) ou no fim do arquivo
-const descMatch = configText.match(/^description:\s*>-\n([\s\S]*?)(?=^[^\s]|\z)/m);
+const descMatch = (configText + '\n\0').match(/^description:\s*>-\n([\s\S]*?)(?=^\S)/m);
 const description = descMatch
   ? descMatch[1]
       .split('\n')

--- a/ig/sushi-config.yaml
+++ b/ig/sushi-config.yaml
@@ -1,15 +1,22 @@
-id: br.fhir-brasil
+id: br.dev.fhir-brasil.core
 canonical: https://fhir-brasil.dev.br/ig
 name: FHIRBrasil
 title: fhir-brasil Implementation Guide
 status: draft
-version: 0.1.0
+version: 0.9.0
 fhirVersion: 4.0.1
 copyrightYear: 2026+
 releaseLabel: draft
 publisher:
   name: Precisa Saúde
   url: https://precisa-saude.com.br
+contact:
+  - name: Precisa Saúde
+    telecom:
+      - system: url
+        value: https://precisa-saude.com.br
+      - system: email
+        value: contato@precisa-saude.com.br
 jurisdiction: urn:iso:std:iso:3166#BR "Brazil"
 license: Apache-2.0
 description: >-


### PR DESCRIPTION
## Resumo

- Alterar package ID de `br.fhir-brasil` para `br.dev.fhir-brasil.core` (reverse-DNS de `fhir-brasil.dev.br`)
- Alinhar versão do IG com `0.9.0` e adicionar campo `contact` no `sushi-config.yaml`
- Criar script `build-package-tgz.js` para montar pacote FHIR NPM conforme a spec
- Adicionar job `publish-ig` no CI para publicar automaticamente no Simplifier via API REST
- Documentar decisão de package ID e registry em ADR-003
- Adicionar instruções de instalação FHIR no `ig/README.md` e badge no `README.md`

## Tarefas manuais pós-merge

1. Criar conta organizacional no Simplifier para "Precisa Saúde"
2. Criar projeto público `fhir-brasil` no Simplifier
3. Gerar API key e adicionar `SIMPLIFIER_API_KEY` nos GitHub Actions secrets
4. (Opcional) Upload manual da v0.9.0 para validar o fluxo

## Plano de teste

- [x] SUSHI compila com sucesso gerando `ImplementationGuide-br.dev.fhir-brasil.core.json`
- [x] Script `build-package-tgz.js` gera `package.tgz` com estrutura válida (21 recursos + package.json + .index.json)
- [x] Lint e typecheck passam
- [x] Testes existentes do IG passam (28 testes)
- [ ] CI verde no PR

Closes PRE-181