### PR TITLE
fix(core): auditoria clínica — faixas, fontes, variantes gestacionais e jejum

### DIFF
--- a/docs/medical-review-2026-04-17.md
+++ b/docs/medical-review-2026-04-17.md
@@ -234,9 +234,11 @@ Sem disagreements numéricos graves entre os dois repositórios nos biomarcadore
 
 ---
 
-## 4. Plano de remediação sugerido
+## 4. Plano de remediação
 
-Segue o padrão PRE-189 da plataforma (PRs sequenciais, cada um com 2 rodadas de revisão automática antes de merge):
+> **Atualização (2026-04-18):** escopo PR A–E consolidado no PR #20 a pedido do mantenedor — evita coordenação de múltiplos PRs sequenciais para um registro ainda de baixo volume de contribuições. PR F (calculators) concluiu-se sem mudanças necessárias; detalhes abaixo.
+
+Segue o padrão PRE-189 da plataforma (cada PR passa por 2 rodadas de revisão automática antes de merge):
 
 ### PR A — P1 correções clínicas críticas
 
@@ -274,6 +276,14 @@ Segue o padrão PRE-189 da plataforma (PRs sequenciais, cada um com 2 rodadas de
 ### PR F (se aplicável) — `packages/calculators`
 
 - Auditoria paralela: confirmar CKD-EPI 2021 sem fator de raça em eGFR; revisar PhenoAge (já auditado na plataforma); revisar HOMA-IR com novo corte BRAMS.
+
+**Resultado (2026-04-18):**
+
+- `packages/calculators` **não implementa eGFR** — o valor chega pronto do upstream (lab ou cliente) e só passa por `reference-ranges.ts` (fonte `kdigo-ckd-2024`). Nenhuma correção de de-indexação racial aplicável ao código deste repositório.
+- `derived/calculator.ts` calcula HOMA-IR via `(Glucose × Insulin) / 405` — fórmula correta, sem corte embutido. O corte de 2.71 vive em `reference-ranges.ts` e já foi atualizado nesta PR (P1-05).
+- PhenoAge foi auditado na plataforma (PRE-190). BrDMrisc permanece fora do escopo desta revisão.
+
+Nenhuma mudança em `packages/calculators` neste PR.
 
 ---
 

--- a/docs/medical-review-2026-04-17.md
+++ b/docs/medical-review-2026-04-17.md
@@ -1,0 +1,304 @@
+# Revisão clínica — faixas de referência e fontes
+
+**Data:** 2026-04-17
+**Escopo:** `@precisa-saude/fhir` — faixas de referência (`reference-ranges.ts`), registro de fontes (`sources.ts`), definições de biomarcadores (`biomarkers.ts`)
+**Revisor:** papel de revisão clínica (formação em medicina) sobre o conteúdo publicado
+**Complementa:** §9 da revisão `docs/development/medical-review-2026-04-17.md` do repositório `Precisa-Saude/platform`, que delegou a auditoria deste repositório para revisão paralela
+
+Este documento classifica achados por severidade:
+
+- **P0 — Segurança**: pode induzir o usuário a erro clínico significativo
+- **P1 — Precisão**: está numericamente incorreto segundo o consenso atual
+- **P2 — Fonte**: citação ausente, inadequada, ou não sustenta a afirmação
+- **P3 — Cobertura**: lacuna estrutural (sexo/idade/gestação/jejum/etnia)
+- **P4 — Estilo**: organização, comentários, consistência cosmética
+
+Convenção: quando um achado afeta vários biomarcadores, é listado uma vez com os códigos envolvidos.
+
+---
+
+## 1. Resumo executivo
+
+**Inventário:** 201 biomarcadores com faixas; 200/201 com `source` preenchido; 40 com variantes por sexo e/ou idade; 38 fontes no `SOURCE_REGISTRY`.
+
+**Estado geral:** qualidade acima da média para um registro aberto em pt-BR. Documentação colateral (`docs/fontes-referencia.md`, `docs/development/verificacao-citacoes.md`) é genuinamente abrangente — a auditoria externa confirmou a granularidade das citações, não a correção clínica dos cortes numéricos.
+
+**Contagem por severidade:**
+
+| Severidade | Qtd |
+| ---------- | --- |
+| P0         | 0   |
+| P1         | 7   |
+| P2         | 5   |
+| P3         | 6   |
+| P4         | 3   |
+
+**Top 10 itens para corrigir (ordem de impacto):**
+
+1. `VitaminD` — `min: 30` aplica o limiar de "grupos de risco" (SBEM 2014) a toda população; o consenso SBEM/SBPC 2017–2018 explicita dois limiares (≥20 população saudável, ≥30 risco) [P1]
+2. `HbA1c` — `min: 4.0` e `Glucose` `min: 70` criam falsos "abaixo do normal"; não existe patamar inferior clinicamente acionável para HbA1c, e o ponto de hipoglicemia é <54 mg/dL (SBD, ADA), não 70 [P1]
+3. `TSH` — `optimalMax: 2.5` espalha o alvo gestacional (1º trimestre) para adultos não-gestantes; fonte `sbem-thyroid-2013` trata de hipotireoidismo subclínico, não é referência geral de TSH [P1/P2]
+4. `VLDL` — cita `friedewald-1972` como fonte de faixa; Friedewald é fórmula (LDL = CT − HDL − TG/5), não publica valores de referência de VLDL [P2]
+5. `Ferritin` — `who-iron-2020` está no registro mas não é usado; a fonte utilizada (`tietz-7ed-2015`) é textbook norte-americano em vez da diretriz OMS explicitamente dirigida a ferritina [P2]
+6. `HOMA_IR` — `max: 2.5` citando Tietz; Tietz não publica corte de HOMA-IR; coortes brasileiras (BRAMS, ELSA-Brasil) publicam valores distintos (2.71–3.0) [P1/P2]
+7. Ausência sistemática de variantes gestacionais (TSH, ferritina, hemoglobina, creatinina, D-dímero, glicose em DMG) [P3]
+8. `sbd-diabetes-2024` e `sbpc-ml-2021` com marcadores `TODO` em `sources.ts` — ainda não validados em termos de edição, página e metadados ABNT [P2]
+9. `sbem-thyroid-2013` tem 11 anos; consenso brasileiro atualizado (incluindo discussão de TSH em idosos) deve substituí-lo onde existir [P2]
+10. `tietz-7ed-2015` é citado como fonte em 100/201 biomarcadores (~50%); adequado como fallback, mas muitos itens têm equivalente brasileiro disponível (hormônios, ferro, lipídios, enzimas hepáticas) [P2]
+
+---
+
+## 2. Achados detalhados
+
+### 2.1 P1 — Precisão clínica
+
+#### P1-01 `VitaminD`: limiar 30 ng/mL aplicado a toda população
+
+- **Arquivo:** `packages/core/src/reference-ranges.ts:1478`
+- **Código atual:** `default: { max: 100, min: 30, optimalMax: 70, optimalMin: 40, unit: 'ng/mL' }`, `source: 'sbem-vitamind-2014'`
+- **Problema:** o consenso SBEM 2014 e o posicionamento conjunto SBEM/SBPC-ML de 2017–2018 adotam **dois limiares**:
+  - ≥20 ng/mL — "desejável para população saudável" (adultos <60 anos sem fatores de risco)
+  - ≥30 ng/mL — grupos de risco (gestantes, idosos ≥60, doença renal crônica, osteoporose, hiperparatireoidismo 2º)
+
+  O valor `min: 30` classifica como "baixo" qualquer adulto saudável com vitamina D entre 20–29 ng/mL, o que não corresponde ao consenso brasileiro. Gera sobrediagnóstico e recomendações indevidas de suplementação em população geral.
+
+- **Correção recomendada:** `min: 20` (default), com variante `ageMin: 60` → `min: 30`. Documentar explicitamente que gestantes, DRC, osteoporose têm limiar ≥30 no `source` ou em metadado adicional.
+- **Fonte a citar:** Posicionamento SBEM/SBPC-ML 2017: Ferreira et al., _Arch Endocrinol Metab_, 61(6):527–542, 2017. DOI: 10.1590/2359-3997000000310.
+
+#### P1-02 `HbA1c.min: 4.0` — pseudo-floor sem correspondente clínico
+
+- **Arquivo:** `reference-ranges.ts:719`
+- **Código atual:** `default: { max: 5.7, min: 4.0, optimalMax: 5.3, optimalMin: 4.5, unit: '%' }`
+- **Problema:** valores de HbA1c <4.0% são incomuns mas não patológicos por si só — surgem em anemia hemolítica, perda sanguínea aguda, hemoglobinopatia, gestação. Definir `min: 4.0` cria flag "abaixo do normal" que sugere anormalidade ao invés de indicar a **condição** que baixa a HbA1c. A SBD 2024 não define piso de referência.
+- **Correção:** `min: undefined` ou `min: 0`; manter `optimalMin: 4.5` como alvo fisiológico.
+
+#### P1-03 `Glucose.min: 70` — hipoglicemia real é <54
+
+- **Arquivo:** `reference-ranges.ts:704`
+- **Problema:** 70 mg/dL é o "limiar de alerta" (Level 1 ADA/SBD) no contexto de diabético em tratamento. Para glicemia de jejum **em indivíduo não-diabético**, a distribuição de referência pode ir até 60 mg/dL sem patologia. Clinicamente acionável: <54 mg/dL (Level 2).
+- **Correção:** `min: 54` e documentar no comentário; manter `optimalMin: 70`.
+
+#### P1-04 `TSH.optimalMax: 2.5` aplicado a não-gestantes
+
+- **Arquivo:** `reference-ranges.ts:1372`
+- **Problema:** o alvo 2.5 mIU/L é **específico do 1º trimestre gestacional** (ATA 2017) e foi adotado como "alvo funcional" em literatura de medicina funcional sem respaldo de diretrizes para adultos não-gestantes. SBEM 2013 usa 0.4–4.0 sem recomendar 2.5 como ótimo.
+- **Correção:** `optimalMax: 3.0` (ou manter `max` como `optimalMax` para evitar invenção de corte); adicionar variante gestacional trimestre-específica (0.1–2.5 no 1º tri, 0.2–3.0 no 2º/3º).
+
+#### P1-05 `HOMA_IR.max: 2.5` com citação a Tietz
+
+- **Arquivo:** `reference-ranges.ts:788`
+- **Problema:** Tietz 7ª ed. não publica corte de HOMA-IR. Cortes publicados em população brasileira:
+  - BRAMS (Geloneze et al., 2009, _Diabetol Metab Syndr_): percentil 90 = 2.71
+  - ELSA-Brasil (Schmidt et al., 2015): variam por sexo e IMC
+  - Vasques et al., 2009: 2.72 em amostra urbana brasileira
+- **Correção:** atualizar `source` para `geloneze-brams-2009` (criar entrada no registry com DOI 10.1186/1758-5996-1-7) e ajustar `max` para 2.71.
+
+#### P1-06 `Ferritin` — uso de Tietz em vez de WHO 2020
+
+- **Arquivo:** `reference-ranges.ts:615`
+- **Problema:** o registry já contém `who-iron-2020` (WHO guideline on use of ferritin concentrations to assess iron status) — documento **exclusivamente** sobre ferritina. A citação atual aponta Tietz, compêndio laboratorial generalista. Os cortes numéricos estão próximos mas a auditoria de fonte deve refletir a fonte mais específica e autoritária. Adicionalmente, WHO 2020 recomenda cortes distintos em contexto inflamatório (+70% se CRP elevada), o que não está modelado.
+- **Correção:** `source: 'who-iron-2020'`; documentar em comentário que inflamação aguda eleva ferritina (WHO 2020 recomenda PCR concomitante para interpretar).
+
+#### P1-07 `VLDL` — Friedewald como fonte de faixa
+
+- **Arquivo:** `reference-ranges.ts:1493`
+- **Problema:** `friedewald-1972` é a fórmula `LDL = CT − HDL − TG/5`; não publica intervalos de referência de VLDL. VLDL não possui corte clínico validado independentemente — seu uso é derivado (TG/5).
+- **Correção:** trocar `source` para `sbc-lipids-2025` (que estabelece triglicérides <150 e, por derivação, VLDL <30). Ajustar comentário.
+
+---
+
+### 2.2 P2 — Qualidade de fonte
+
+#### P2-01 `sbd-diabetes-2024` metadados incompletos
+
+- **Arquivo:** `sources.ts:228` (marcador `TODO: Verificar edição exata e dados completos`)
+- **Ação:** acessar `https://diretriz.diabetes.org.br/editorial/`, capturar título oficial, editores, edição, data de acesso; preencher DOI se houver.
+
+#### P2-02 `sbpc-ml-2021` metadados incompletos
+
+- **Arquivo:** `sources.ts:255` (`TODO: Verificar título exato e dados completos na biblioteca SBPC`)
+- **Ação:** confirmar título exato ("Recomendações SBPC/ML — Boas Práticas em Laboratório Clínico", 2020, não 2021 — ver nota da revisão platform PR 367 que corrigiu o ano de 2021 para 2020 no conteúdo). Ajustar `key` se a edição for 2020.
+
+#### P2-03 `sbem-thyroid-2013` obsoleta para uso genérico de TSH
+
+- Consenso 2013 é sobre hipotireoidismo **subclínico**. Para citar faixa geral de TSH, o correto é:
+  - Manual de Laboratório da SBEM (se publicado recentemente), ou
+  - NACB 2003 (Demers & Spencer, _Thyroid_ 13:3–126), já amplamente citado em diretrizes
+- **Ação:** adicionar `nacb-thyroid-2003` ao registry; migrar uso genérico de TSH para essa fonte; manter `sbem-thyroid-2013` apenas para achado de TSH subclinicamente elevado.
+
+#### P2-04 `friedewald-1972` listada como fonte de faixa
+
+- Ver P1-07. A entrada pode permanecer no registry como referência de **método** (LDL calculado), mas não deve aparecer no campo `source` de uma `BiomarkerRangeDefinition`.
+
+#### P2-05 Sobre-dependência de `tietz-7ed-2015`
+
+- 100/201 biomarcadores (~50%) citam Tietz. Adequado como fallback quando não há fonte brasileira, mas auditoria identifica substitutos disponíveis:
+  - Hormônios reprodutivos (FSH, LH, Estradiol, Progesterona, Testosterona) → manuais SBEM ou laboratórios de referência brasileiros (Fleury, DASA)
+  - Enzimas hepáticas (ALT, AST, GGT) → PNS-bioquímica 2019 já está no registry; não é usado
+  - Eletrólitos (Sódio, Potássio, Cloreto, Cálcio) → PNS ou SBPC/ML
+  - Vitaminas B (B1, B6, B12, Folato) → posicionamento SBEM ou valores estabelecidos pela IOM
+- **Ação:** priorizar substituição em biomarcadores de alto tráfego (ALT, AST, GGT, FSH, LH, Estradiol, Testosterona, VitaminB12) em PR dedicado.
+
+---
+
+### 2.3 P3 — Lacunas estruturais de cobertura
+
+#### P3-01 Ausência total de variantes gestacionais
+
+Nenhum biomarcador em `reference-ranges.ts` modela gestação, apesar do tipo `ReferenceRangeContext` suportar extensão. Biomarcadores clinicamente relevantes na gestação:
+
+| Biomarcador            | Efeito gestacional                             | Corte ajustado                                 |
+| ---------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| TSH                    | Supressão fisiológica por hCG                  | 1º tri: 0.1–2.5; 2º/3º: 0.2–3.0                |
+| Hemoglobina            | Hemodiluição                                   | ≥11 (1º, 3º tri); ≥10.5 (2º tri)               |
+| Ferritina              | Queda fisiológica 2º/3º tri                    | <15 ng/mL sugere deficiência                   |
+| Creatinina             | Hiperfiltração (↑ 40–50% GFR)                  | 0.4–0.8 mg/dL                                  |
+| D-dímero               | Elevação progressiva (fibrinólise placentária) | Nenhum corte padronizado; usar cuidado clínico |
+| Glicose jejum          | DMG: ≥92 mg/dL em jejum (IADPSG/SBD)           | Corte de doença é mais baixo que não-gestante  |
+| Tireoglobulina/AntiTPO | Screening de alto risco materno                | Manter faixas de referência                    |
+
+**Ação:** estender `RangeVariant` para incluir `pregnancyTrimester?: 1 | 2 | 3` ou criar estrutura paralela `pregnancyVariants`; iniciar pelos 4 biomarcadores de maior impacto (TSH, Hgb, Ferritina, Creatinina).
+
+#### P3-02 Jejum / estado pós-prandial não-modelado
+
+Triglicérides, glicose, insulina, peptídeo-C e lipídios em geral têm faixas distintas em jejum vs. pós-prandial. `BiomarkerReferenceRange` não expressa essa condição pré-analítica. A SBC 2017/2025 explicitou a aceitação de amostras não-jejum para perfil lipídico com cortes distintos (TG <175 não-jejum vs. <150 jejum).
+
+**Ação:** adicionar metadado `fastingRequired: 'strict' | 'preferred' | 'not-required'` ou `variants` com `fastingState`.
+
+#### P3-03 Raça/etnia — eGFR pós-2021
+
+KDIGO 2024 removeu o coeficiente de raça da equação eGFR (CKD-EPI 2021). Verificar se a implementação atual (`reference-ranges.ts:549` e `packages/calculators`) aplica a equação de-indexada. Esta é lacuna de **implementação**, não apenas de faixa.
+
+**Ação:** auditar `packages/calculators/src/egfr.ts` (se existir) contra CKD-EPI 2021 sem fator de raça.
+
+#### P3-04 Pediátrico / geriátrico estendido
+
+`ageMin` em variantes só é usado como corte "18 anos" ou "65 anos". Sem variantes:
+
+- 0–17 anos: muitos biomarcadores têm faixas pediátricas distintas (ex.: CK neonatal muito superior, fósforo, fosfatase alcalina em crescimento)
+- 80+ anos: GFR declina fisiologicamente, hemoglobina pode ser fisiologicamente menor
+
+O repositório declara foco em adultos, então a omissão pode ser **intencional e válida**. Recomenda-se **documentação explícita** em README indicando que as faixas são válidas a partir de 18 anos, senão consumidores (ex.: plataforma) podem aplicar indevidamente.
+
+#### P3-05 Contexto inflamatório
+
+Ferritina, VHS, PCR ultrassensível, haptoglobina, ceruloplasmina — marcadores de fase aguda — têm interpretação modificada em inflamação. Não há campo para "contexto inflamatório" e tampouco co-dependência entre biomarcadores. Pragmático: documentar em comentário no código que PCR elevada recomenda reinterpretação de ferritina.
+
+#### P3-06 Lp(a) — biomarcador crítico ausente?
+
+Ver se `Lp_a` / `LipoproteinA` está definido. Lp(a) é pedra angular da estratificação cardiovascular pela SBC 2025 e diretriz europeia 2024, com corte >50 mg/dL = alto risco. Se ausente, é lacuna P3 (cobertura) que tangencia P1 (clínico).
+
+**Ação:** confirmar presença; se ausente, adicionar com `source: 'sbc-lipids-2025'`.
+
+---
+
+### 2.4 P4 — Estilo / organização
+
+#### P4-01 Comentários de seção fora de lugar
+
+Em `reference-ranges.ts`:
+
+- Linha 246 `// THYROID` precede `Omega6_AA`, `AA_EPA_Ratio`, `Arsenic`, `AST` — nenhum é tireoidiano.
+- Linha 292 `// HEMATOLOGY - CBC` precede `Bicarbonate`, `BilirubinDirect` — hepatobiliar/ácido-base.
+- Linha 767 `// INFLAMMATION` precede `Hgb`, `HOMA_IR`, `Homocysteine` — metabólico/hemograma.
+
+Os biomarcadores estão ordenados alfabeticamente; os comentários de categoria foram preservados de um ordenamento anterior. Remover os comentários ou mover para uma estrutura real de agrupamento.
+
+#### P4-02 `unit: ''` para razões — inconsistência?
+
+Razões adimensionais usam `unit: ''` (ex.: `Albumin_Globulin_Ratio`, `BUN_Creatinine_Ratio`, `HOMA_IR`, `AA_EPA_Ratio`). Convenção UCUM permite `1` como placeholder explícito para adimensional. Documentar escolha no `types.ts` ou na documentação.
+
+#### P4-03 `ApoCIII_ApoA1_Ratio` sem fonte, mas com corte numérico
+
+Linha 241–243: comentário explicita "corte de 0.15 sem fonte publicada — valor calculado, não validado clinicamente". Honesto, mas o biomarcador ainda é exposto como faixa de referência. Opção: (a) omitir o biomarcador até que exista fonte; (b) tipar como `status: 'experimental'` para o consumidor filtrar.
+
+---
+
+## 3. Consistência cruzada com `Precisa-Saude/platform`
+
+Auditoria cruzada entre `biomarkerRangeDefinitions` aqui e `packages/content/biomarkers/tests/*.md` na plataforma:
+
+| Biomarcador | fhir-brasil                               | platform (conteúdo)                                             | Avaliação                                                                                           |
+| ----------- | ----------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| LDL         | default 0–100 lower-better, SBC 2025      | metas por risco (SBC 2019): <100/<70/<50                        | Consistente se consumidor aplicar lógica de risco                                                   |
+| HDL         | M 40–60, F 50–60, SBC 2025                | enfatiza cutoff sexo-específico                                 | **Alinhado**                                                                                        |
+| HbA1c       | 4.0–5.7%, SBD 2024                        | <5.7 normal, 5.7–6.4 pré-DM, ≥6.5 DM                            | **Alinhado** no topo; `min: 4.0` problemático (P1-02)                                               |
+| Glucose     | 70–100                                    | 70–99 jejum                                                     | Diferença trivial (1 mg/dL); `min: 70` problemático (P1-03)                                         |
+| Vitamin D   | 30–100, SBEM 2014                         | deficiência <20, suficiência ≥30                                | **Parcial** — plataforma cita 20 como limiar de deficiência; fhir-brasil usa 30 como mínimo (P1-01) |
+| TSH         | 0.4–4.0, ótimo até 2.5 (age 65+: até 6.0) | plataforma não sampleada em profundidade                        | **Revisar** `optimalMax: 2.5` (P1-04)                                                               |
+| Ferritin    | M 20–250, F 10–120 (18–50), tietz         | plataforma aponta <30 como deficiência em mulheres menstruantes | **Parcial** — fhir-brasil `min: 10` permite subdiagnóstico (P1-06)                                  |
+| Creatinine  | M 0.7–1.3, F 0.5–1.1, PNS                 | plataforma alinhada                                             | **Alinhado**                                                                                        |
+| ApoB        | 0–90, lower-better, SBC 2025              | plataforma tem "mais precisa que LDL" (P1 corrigido em PR 369)  | **Alinhado** após correção da plataforma                                                            |
+
+Sem disagreements numéricos graves entre os dois repositórios nos biomarcadores de maior tráfego. Principais lacunas são **comuns aos dois** (vitamina D single-threshold, ferritina em mulheres pré-menopausa).
+
+---
+
+## 4. Plano de remediação sugerido
+
+Segue o padrão PRE-189 da plataforma (PRs sequenciais, cada um com 2 rodadas de revisão automática antes de merge):
+
+### PR A — P1 correções clínicas críticas
+
+- VitaminD, HbA1c, Glucose, TSH, HOMA_IR, Ferritin, VLDL (7 correções numéricas/de fonte)
+- Novas entradas no `SOURCE_REGISTRY`:
+  - `ferreira-vitd-2017` (posicionamento SBEM/SBPC-ML)
+  - `geloneze-brams-2009` (HOMA-IR Brasil)
+  - `nacb-thyroid-2003` (TSH geral)
+- Atualização de testes em `packages/core/src/__tests__/reference-ranges.test.ts` para refletir novos cortes
+
+### PR B — Metadados de fonte pendentes
+
+- Verificar e preencher `sbd-diabetes-2024` (edição, título, URL específica, data de acesso)
+- Verificar e corrigir `sbpc-ml-2021` → possivelmente `sbpc-ml-2020` (ano correto conforme PR 367 da plataforma)
+- Adicionar DOI onde ausente (auditar toda `SOURCE_REGISTRY`)
+
+### PR C — Gestação e jejum
+
+- Estender `RangeVariant` com `pregnancyTrimester?: 1 | 2 | 3`
+- Adicionar variantes para TSH, Hgb, Ferritina, Creatinina, Glucose
+- Metadado `fastingRequired` em `BiomarkerReferenceRange`
+
+### PR D — Redução de dependência de Tietz
+
+- Substituir fonte em hormônios reprodutivos, enzimas hepáticas, eletrólitos onde exista equivalente brasileiro
+- Não é alteração numérica obrigatória — trocar fonte sem mudar cortes é aceitável quando o corte já vinha de consenso brasileiro informal
+
+### PR E — P3/P4 lacunas e estilo
+
+- Auditar `Lp(a)` e adicionar se ausente
+- Reorganizar ou remover comentários de seção desatualizados
+- Documentar escolha `unit: ''` vs. `unit: '1'` em `types.ts`
+- Documentar em README que faixas são válidas para adultos (≥18 anos)
+
+### PR F (se aplicável) — `packages/calculators`
+
+- Auditoria paralela: confirmar CKD-EPI 2021 sem fator de raça em eGFR; revisar PhenoAge (já auditado na plataforma); revisar HOMA-IR com novo corte BRAMS.
+
+---
+
+## 5. Fora de escopo
+
+- **`biomarkers.ts`** (definições LOINC, unidades, aliases): aparenta consistência com o `units.ts`; auditoria completa é outro documento, não este.
+- **`packages/rnds`**: cliente HTTP, sem conteúdo clínico.
+- **`packages/ocr-utils`**: utilitários de extração, sem conteúdo clínico.
+- **Revisão formal de LGPD/ANVISA**: não aplicável a repositório de tipos/dados abertos.
+
+---
+
+## 6. Como verificar
+
+- Cada PR deve passar `pnpm turbo run lint test typecheck` em todos os pacotes afetados.
+- Os testes em `reference-ranges.test.ts` devem falhar antes da correção (teste de regressão) e passar após.
+- Para cada mudança de fonte: confirmar que a nova chave existe em `SOURCE_REGISTRY` e tem DOI/URL verificáveis.
+- Para cada mudança numérica clínica: citar no commit a publicação específica (PMID ou DOI) que justifica o novo corte.
+
+---
+
+## Apêndice — Metodologia
+
+- Inventário dos 201 biomarcadores via leitura direta de `reference-ranges.ts` (2036 linhas) e grepping para padrões críticos.
+- Cruzamento com `SOURCE_REGISTRY` em `sources.ts` para detectar fontes órfãs (não usadas) e citações quebradas (usadas, não registradas — nenhuma detectada).
+- Cross-check numérico com 10 biomarcadores de maior tráfego no repositório `Precisa-Saude/platform` (`packages/content/biomarkers/tests/*.md`).
+- Julgamento clínico aplicado com base em: diretrizes SBC 2017/2025, SBD 2024, SBEM 2013/2014/2017 posicionamentos, KDIGO 2024, WHO (ferro 2020, osteoporose 1994), NACB (tireoide 2003, tumor markers 2008), e ADA/EASD para DMG.
+- Nenhum achado P0: a biblioteca não contém erro clínico que leve a dano imediato. P1 são sobrediagnósticos e sub-utilização de fontes brasileiras existentes; P2/P3 são falhas de citação e cobertura.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,14 +67,31 @@ import { validateFHIRObservation } from '@precisa-saude/fhir/validators';
 
 ## Módulos
 
-| Sub-path            | Descrição                                                          |
-| ------------------- | ------------------------------------------------------------------ |
-| `/biomarkers`       | 180+ definições com códigos LOINC, nomes pt/en, categorias         |
-| `/reference-ranges` | Faixas de referência por sexo/idade (SBPC/ML, SBC, SBD, OMS)       |
-| `/converter`        | Converte dados laboratoriais para FHIR R4 Bundle                   |
-| `/importer`         | Importa FHIR Bundle de volta para estruturas internas              |
-| `/units`            | Mapeamento de unidades, conversão para UCUM                        |
-| `/validators`       | Validação de recursos FHIR (DiagnosticReport, Observation, Bundle) |
+| Sub-path            | Descrição                                                             |
+| ------------------- | --------------------------------------------------------------------- |
+| `/biomarkers`       | 180+ definições com códigos LOINC, nomes pt/en, categorias            |
+| `/reference-ranges` | Faixas de referência por sexo/idade/gestação (SBPC/ML, SBC, SBD, OMS) |
+| `/converter`        | Converte dados laboratoriais para FHIR R4 Bundle                      |
+| `/importer`         | Importa FHIR Bundle de volta para estruturas internas                 |
+| `/units`            | Mapeamento de unidades, conversão para UCUM                           |
+| `/validators`       | Validação de recursos FHIR (DiagnosticReport, Observation, Bundle)    |
+
+## Escopo das faixas de referência
+
+As faixas em `/reference-ranges` são **validadas para adultos (≥18 anos)**. Variantes pediátricas não estão incluídas — consumidores que atendem populações pediátricas devem adicionar suas próprias faixas ou buscar fontes específicas (SBP, protocolos neonatais).
+
+Variantes gestacionais estão disponíveis para `TSH`, `Hgb`, `Ferritin`, `Creatinine` e `Glucose`. Para usar, passe `pregnant: true` e, quando conhecido, `pregnancyTrimester` no `ReferenceRangeContext`:
+
+```ts
+const range = getReferenceRange('TSH', {
+  biologicalSex: 'F',
+  pregnant: true,
+  pregnancyTrimester: 1,
+});
+// → { max: 2.5, min: 0.1, ... } (alvo ATA 2017 para 1º trimestre)
+```
+
+O metadado opcional `fastingRequired` em `BiomarkerReferenceRange` indica se a amostra exige jejum estrito (ex.: `Glucose`, `Insulin`, `HOMA_IR`) ou se o jejum é preferido mas não obrigatório (ex.: `Triglycerides`, que aceita dosagem não-jejum por SBC 2017/2025).
 
 ## Aviso médico
 

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -239,6 +239,43 @@ describe('getReferenceRange', () => {
       const range = getReferenceRange('Hgb', context);
       expect(range?.min).toBe(10.5);
     });
+
+    it('pregnancy variants supersede age variants (pregnant 65+ gets pregnancy TSH, not elderly)', () => {
+      const context: ReferenceRangeContext = {
+        age: 67,
+        biologicalSex: 'F',
+        pregnant: true,
+      };
+      // Pregnancy catch-all (max 3.0) beats the ageMin=65 variant (max 6.0).
+      const range = getReferenceRange('TSH', context);
+      expect(range?.max).toBe(3.0);
+    });
+
+    it('male context with pregnant=true on TSH falls through to default (sex filter still applies)', () => {
+      const context: ReferenceRangeContext = {
+        age: 40,
+        biologicalSex: 'M',
+        pregnancyTrimester: 1,
+        pregnant: true,
+      };
+      // All TSH pregnancy variants have sex='F'. Male context skips them;
+      // hasPregnancyVariant is true, so non-pregnancy variants are also
+      // skipped → default.
+      const range = getReferenceRange('TSH', context);
+      expect(range).toEqual(biomarkerRangeDefinitions.TSH.default);
+    });
+
+    it('pregnant=undefined is treated as non-pregnant (conservative fallback)', () => {
+      const context: ReferenceRangeContext = {
+        age: 30,
+        biologicalSex: 'F',
+        // pregnant intentionally omitted
+      };
+      const range = getReferenceRange('Creatinine', context);
+      // Should get the female sex-specific variant, not the pregnancy one.
+      expect(range?.max).toBe(1.1);
+      expect(range?.min).toBe(0.5);
+    });
   });
 
   describe('fastingRequired metadata', () => {

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -144,6 +144,102 @@ describe('getReferenceRange', () => {
       expect(maleRange).toEqual(femaleRange);
     });
   });
+
+  describe('pregnancy variants', () => {
+    it('returns 1st trimester TSH variant for pregnant context', () => {
+      const context: ReferenceRangeContext = {
+        age: 32,
+        biologicalSex: 'F',
+        pregnancyTrimester: 1,
+        pregnant: true,
+      };
+      const range = getReferenceRange('TSH', context);
+      expect(range?.max).toBe(2.5);
+      expect(range?.min).toBe(0.1);
+    });
+
+    it('returns 2nd trimester TSH variant for pregnant context', () => {
+      const context: ReferenceRangeContext = {
+        age: 32,
+        biologicalSex: 'F',
+        pregnancyTrimester: 2,
+        pregnant: true,
+      };
+      const range = getReferenceRange('TSH', context);
+      expect(range?.max).toBe(3.0);
+      expect(range?.min).toBe(0.2);
+    });
+
+    it('returns pregnancy creatinine variant with reduced upper bound', () => {
+      const context: ReferenceRangeContext = {
+        age: 30,
+        biologicalSex: 'F',
+        pregnant: true,
+      };
+      const range = getReferenceRange('Creatinine', context);
+      expect(range?.max).toBe(0.8);
+      expect(range?.min).toBe(0.4);
+    });
+
+    it('returns pregnancy glucose variant with DMG cutoff', () => {
+      const context: ReferenceRangeContext = {
+        age: 30,
+        biologicalSex: 'F',
+        pregnant: true,
+      };
+      const range = getReferenceRange('Glucose', context);
+      expect(range?.max).toBe(91);
+    });
+
+    it('returns non-pregnancy variant when pregnant=false', () => {
+      const context: ReferenceRangeContext = {
+        age: 30,
+        biologicalSex: 'F',
+        pregnant: false,
+      };
+      const range = getReferenceRange('Creatinine', context);
+      // Female adult variant (non-pregnant)
+      expect(range?.max).toBe(1.1);
+      expect(range?.min).toBe(0.5);
+    });
+
+    it('skips non-pregnancy variants when context is pregnant and no pregnancy variant exists', () => {
+      const context: ReferenceRangeContext = {
+        age: 30,
+        biologicalSex: 'F',
+        pregnant: true,
+      };
+      // HDL has no pregnancy variant — should fall back to default, not
+      // the female age-based variant.
+      const range = getReferenceRange('HDL', context);
+      expect(range).toEqual(biomarkerRangeDefinitions.HDL.default);
+    });
+
+    it('returns pregnancy hemoglobin variant with reduced floor for 2nd trimester', () => {
+      const context: ReferenceRangeContext = {
+        age: 28,
+        biologicalSex: 'F',
+        pregnancyTrimester: 2,
+        pregnant: true,
+      };
+      const range = getReferenceRange('Hgb', context);
+      expect(range?.min).toBe(10.5);
+    });
+  });
+
+  describe('fastingRequired metadata', () => {
+    it('marks Glucose as strict fasting', () => {
+      expect(biomarkerRangeDefinitions.Glucose.default.fastingRequired).toBe('strict');
+    });
+
+    it('marks Triglycerides as preferred fasting (non-fasting acceptable per SBC)', () => {
+      expect(biomarkerRangeDefinitions.Triglycerides.default.fastingRequired).toBe('preferred');
+    });
+
+    it('leaves HbA1c without fasting requirement', () => {
+      expect(biomarkerRangeDefinitions.HbA1c.default.fastingRequired).toBeUndefined();
+    });
+  });
 });
 
 describe('getFallbackReferenceRange', () => {

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -203,16 +203,30 @@ describe('getReferenceRange', () => {
       expect(range?.min).toBe(0.5);
     });
 
-    it('skips non-pregnancy variants when context is pregnant and no pregnancy variant exists', () => {
+    it('falls through to sex/age variant when pregnant but biomarker has no pregnancy variant', () => {
       const context: ReferenceRangeContext = {
         age: 30,
         biologicalSex: 'F',
         pregnant: true,
       };
-      // HDL has no pregnancy variant — should fall back to default, not
-      // the female age-based variant.
+      // HDL has no pregnancy variant — a pregnant woman should still get the
+      // female sex-specific cutoff (min: 50), not the generic unisex default.
+      // Non-pregnancy variants are only skipped when at least one pregnancy
+      // variant exists on the biomarker.
       const range = getReferenceRange('HDL', context);
-      expect(range).toEqual(biomarkerRangeDefinitions.HDL.default);
+      expect(range?.min).toBe(50);
+    });
+
+    it('matches catch-all pregnancy variant for TSH when trimester is unknown', () => {
+      const context: ReferenceRangeContext = {
+        age: 32,
+        biologicalSex: 'F',
+        pregnant: true,
+      };
+      const range = getReferenceRange('TSH', context);
+      // Catch-all gestacional adota faixa conservadora (2º/3º trimestre).
+      expect(range?.max).toBe(3.0);
+      expect(range?.min).toBe(0.2);
     });
 
     it('returns pregnancy hemoglobin variant with reduced floor for 2nd trimester', () => {

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -793,11 +793,12 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
 
   // HbA1c — SBD 2024 não estabelece piso de referência clinicamente acionável.
   // Valores <4.0% podem refletir anemia hemolítica, perda sanguínea recente ou
-  // hemoglobinopatia, não patologia do metabolismo glicêmico. Mantemos min=0
-  // para evitar flag de "abaixo do normal" em valores fisiologicamente baixos;
-  // optimalMin preserva o alvo fisiológico da fração glicada.
+  // hemoglobinopatia, não patologia do metabolismo glicêmico. Usamos min=2 como
+  // piso de sanidade (HbA1c <2% é quase sempre erro instrumental/entrada) sem
+  // criar flag clínico em valores fisiologicamente baixos. optimalMin preserva
+  // o alvo fisiológico da fração glicada.
   HbA1c: {
-    default: { max: 5.7, min: 0, optimalMax: 5.3, optimalMin: 4.5, unit: '%' },
+    default: { max: 5.7, min: 2, optimalMax: 5.3, optimalMin: 4.5, unit: '%' },
     source: 'sbd-diabetes-2024',
   },
 
@@ -850,7 +851,8 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     variants: [
       // Gestação: hemodiluição fisiológica reduz o piso aceitável.
       // OMS e CDC: anemia gestacional quando Hgb <11 g/dL (1º e 3º tri) ou
-      // <10.5 g/dL (2º tri, dilucional mais acentuada).
+      // <10.5 g/dL (2º tri, dilucional mais acentuada). Catch-all adota a
+      // faixa mais conservadora (2º tri) quando trimestre é desconhecido.
       {
         pregnant: true,
         pregnancyTrimester: 1,
@@ -867,6 +869,11 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
         pregnant: true,
         pregnancyTrimester: 3,
         range: { max: 14.0, min: 11.0, optimalMax: 13.0, optimalMin: 11.5, unit: 'g/dL' },
+        sex: 'F',
+      },
+      {
+        pregnant: true,
+        range: { max: 14.0, min: 10.5, optimalMax: 13.0, optimalMin: 11.0, unit: 'g/dL' },
         sex: 'F',
       },
       {
@@ -1467,24 +1474,35 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'sbem-thyroid-2013',
     variants: [
       // Variantes gestacionais (ATA 2017 / SBEM): supressão fisiológica por hCG
-      // no 1º trimestre, recuperação progressiva no 2º/3º. Listadas primeiro
-      // para ter precedência sobre a variante etária em gestantes.
+      // no 1º trimestre, recuperação progressiva no 2º/3º. Trimestre-específicas
+      // precedem a catch-all; catch-all cobre contexto gestante sem trimestre
+      // conhecido.
+      // optimalMin/optimalMax definem subfaixa "alvo" mais estreita que o
+      // intervalo de referência — ex.: 1º tri aceita 0.1–2.5, mas o alvo
+      // terapêutico é 0.5–2.5.
       {
         pregnant: true,
         pregnancyTrimester: 1,
-        range: { max: 2.5, min: 0.1, optimalMax: 2.5, optimalMin: 0.1, unit: 'µIU/mL' },
+        range: { max: 2.5, min: 0.1, optimalMax: 2.0, optimalMin: 0.5, unit: 'µIU/mL' },
         sex: 'F',
       },
       {
         pregnant: true,
         pregnancyTrimester: 2,
-        range: { max: 3.0, min: 0.2, optimalMax: 3.0, optimalMin: 0.2, unit: 'µIU/mL' },
+        range: { max: 3.0, min: 0.2, optimalMax: 2.5, optimalMin: 0.5, unit: 'µIU/mL' },
         sex: 'F',
       },
       {
         pregnant: true,
         pregnancyTrimester: 3,
-        range: { max: 3.0, min: 0.3, optimalMax: 3.0, optimalMin: 0.3, unit: 'µIU/mL' },
+        range: { max: 3.0, min: 0.3, optimalMax: 2.5, optimalMin: 0.5, unit: 'µIU/mL' },
+        sex: 'F',
+      },
+      // Catch-all gestacional — usada quando o trimestre não é informado.
+      // Adota a faixa mais conservadora (2º/3º trimestre: 0.2–3.0).
+      {
+        pregnant: true,
+        range: { max: 3.0, min: 0.2, optimalMax: 2.5, optimalMin: 0.5, unit: 'µIU/mL' },
         sex: 'F',
       },
       {
@@ -1580,9 +1598,15 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   // Vitamina D — posicionamento conjunto SBEM/SBPC-ML 2017:
   // ≥20 ng/mL é desejável para população saudável <60 anos
   // ≥30 ng/mL é recomendado para grupos de risco (idosos, gestantes, DRC,
-  // osteoporose, hiperparatireoidismo secundário). A variante ageMin=60 reflete
-  // o limiar mais restritivo para idosos; gestação e comorbidades devem ser
-  // tratadas via contexto específico quando o consumidor suportar.
+  // osteoporose, hiperparatireoidismo secundário).
+  // A variante ageMin=60 cobre idosos. Gestação, doença renal crônica,
+  // osteoporose e hiperparatireoidismo secundário também exigem min=30;
+  // o tipo `BiomarkerReferenceRange` atual não expressa esses contextos
+  // clínicos além de gestação e idade, portanto consumidores devem aplicar
+  // o limiar ≥30 nessas populações quando souberem a comorbidade. Gestação
+  // será modelada quando `pregnant: true` — aceita-se TODO até lá.
+  // TODO(PR-vitd-pregnancy): adicionar variante `pregnant: true` com min=30
+  // quando a modelagem de comorbidades chegar ao schema.
   VitaminD: {
     default: { max: 100, min: 20, optimalMax: 70, optimalMin: 40, unit: 'ng/mL' },
     source: 'ferreira-vitd-2017',
@@ -2041,23 +2065,32 @@ export function getReferenceRange(
 
   const { age, biologicalSex, pregnancyTrimester, pregnant } = context;
 
+  // Detect whether the biomarker has pregnancy-specific variants at all.
+  // Se o biomarcador não modela gestação, uma usuária gestante deve continuar
+  // recebendo a variante por sexo/idade (mais informativa que o default). Apenas
+  // quando existe ao menos uma variante gestacional é que bloqueamos as variantes
+  // não-gestacionais para contextos gestantes — evitando mistura de faixas.
+  const hasPregnancyVariant = definition.variants.some((v) => v.pregnant === true);
+
   // Find matching variant (first match wins - more specific variants should be listed first).
-  // Variantes gestacionais (pregnant === true) devem vir primeiro na lista para
-  // que usuárias gestantes recebam o ajuste apropriado ao invés da faixa
-  // etária/sexo padrão.
+  // Variantes gestacionais devem vir primeiro na lista; variantes específicas de
+  // trimestre devem preceder variantes gestacionais gerais (catch-all) para que
+  // a mais específica ganhe a correspondência.
   for (const variant of definition.variants) {
-    // Pregnancy gating: variantes com pregnant=true só casam com contexto gestacional;
-    // variantes sem pregnant (padrão) são ignoradas quando o contexto indica gestação,
-    // para evitar que uma gestante receba a faixa não-gestacional.
     if (variant.pregnant === true) {
       if (!pregnant) continue;
+      // Variante com trimestre específico só casa quando o contexto também
+      // especifica o mesmo trimestre. Variantes gestacionais sem trimestre
+      // (catch-all) casam com qualquer contexto gestante, servindo de fallback.
       if (
         variant.pregnancyTrimester !== undefined &&
         variant.pregnancyTrimester !== pregnancyTrimester
       ) {
         continue;
       }
-    } else if (pregnant) {
+    } else if (pregnant && hasPregnancyVariant) {
+      // Só pulamos variantes não-gestacionais se o biomarcador tem variantes
+      // gestacionais; caso contrário, a variante por sexo/idade é aplicável.
       continue;
     }
 

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -2070,12 +2070,28 @@ export function getReferenceRange(
   // recebendo a variante por sexo/idade (mais informativa que o default). Apenas
   // quando existe ao menos uma variante gestacional é que bloqueamos as variantes
   // não-gestacionais para contextos gestantes — evitando mistura de faixas.
+  //
+  // Precedência quando pregnant=true: variantes gestacionais têm precedência
+  // absoluta sobre variantes etárias. Uma gestante de 65+ anos consultando
+  // TSH recebe a faixa gestacional, não a variante ageMin=65. Isto é
+  // intencional — em gestação, o eixo HPG domina sobre o envelhecimento
+  // fisiológico. Casos raros de gestação pós-menopausa (FIV) seguem essa
+  // regra; o consumidor que precise distinguir deve aplicar lógica de
+  // contexto adicional.
+  //
+  // Tratamento de `pregnant: undefined` vs `false`: ambos são tratados como
+  // "não-gestante" (fallback seguro). O consumidor deve setar pregnant: true
+  // explicitamente para ativar variantes gestacionais; contexto sem a flag
+  // recebe a faixa padrão da população geral.
   const hasPregnancyVariant = definition.variants.some((v) => v.pregnant === true);
 
-  // Find matching variant (first match wins - more specific variants should be listed first).
-  // Variantes gestacionais devem vir primeiro na lista; variantes específicas de
-  // trimestre devem preceder variantes gestacionais gerais (catch-all) para que
-  // a mais específica ganhe a correspondência.
+  // Find matching variant (first match wins — more specific variants must be
+  // listed first). Ordem obrigatória quando há variantes gestacionais:
+  //   1. variantes trimestre-específicas (pregnant=true + pregnancyTrimester=N)
+  //   2. catch-all gestacional (pregnant=true, sem trimester)
+  //   3. variantes por sexo/idade não-gestacionais
+  // Reordenar quebraria o matching; a verificação `variant.pregnancyTrimester
+  // !== pregnancyTrimester` depende da catch-all vir por último.
   for (const variant of definition.variants) {
     if (variant.pregnant === true) {
       if (!pregnant) continue;

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -22,9 +22,24 @@ import { getCanonicalUnit as getCanonicalUnitForCode } from './units';
 export type SexKey = 'M' | 'F' | 'all';
 
 /**
+ * Pré-condição de jejum para a faixa de referência.
+ *
+ * - `strict`: coleta exige jejum mínimo (ex.: glicemia de jejum, insulina).
+ * - `preferred`: jejum recomendado, mas faixa aplicável em não-jejum
+ *   (ex.: perfil lipídico pós-SBC 2017, com corte de triglicérides distinto).
+ * - `not-required`: valor independe do estado prandial (ex.: HbA1c, TSH).
+ */
+export type FastingRequirement = 'strict' | 'preferred' | 'not-required';
+
+/**
  * Reference range configuration for a biomarker
  */
 export interface BiomarkerReferenceRange {
+  /**
+   * Pré-condição de jejum para a interpretação da faixa. Opcional;
+   * consumidores devem aplicar sinalização adequada quando `strict`.
+   */
+  fastingRequired?: FastingRequirement;
   max?: number;
   min?: number;
   optimalMax?: number;
@@ -34,11 +49,28 @@ export interface BiomarkerReferenceRange {
 }
 
 /**
- * A variant of a reference range that applies to a specific sex and/or age group
+ * Trimestre gestacional. Usado em variantes e no contexto de consulta
+ * para matching de faixas específicas da gestação.
+ */
+export type PregnancyTrimester = 1 | 2 | 3;
+
+/**
+ * A variant of a reference range that applies to a specific sex, age group,
+ * and/or pregnancy state.
+ *
+ * Ordem de avaliação: variantes são processadas na ordem em que aparecem.
+ * Para que usuárias gestantes recebam a variante gestacional correta,
+ * essas variantes devem ser listadas **antes** das variantes por idade/sexo.
  */
 export interface RangeVariant {
   ageMax?: number;
   ageMin?: number;
+  pregnancyTrimester?: PregnancyTrimester;
+  /**
+   * Quando `true`, a variante só se aplica a contextos de gestação.
+   * Se `pregnancyTrimester` estiver definido, o trimestre deve coincidir.
+   */
+  pregnant?: boolean;
   range: BiomarkerReferenceRange;
   sex: SexKey;
 }
@@ -75,11 +107,16 @@ export interface BiomarkerRangeDefinition {
 }
 
 /**
- * User context for personalized reference range lookup
+ * User context for personalized reference range lookup.
+ *
+ * Para gestação, defina `pregnant: true` e, quando disponível,
+ * `pregnancyTrimester` para obter a variante trimestre-específica.
  */
 export interface ReferenceRangeContext {
   age?: number;
   biologicalSex?: 'M' | 'F';
+  pregnancyTrimester?: PregnancyTrimester;
+  pregnant?: boolean;
 }
 
 // =============================================================================
@@ -93,10 +130,6 @@ export interface ReferenceRangeContext {
  * for sex/age-specific ranges.
  */
 export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition> = {
-  // =============================================================================
-  // LIPIDS
-  // =============================================================================
-
   Albumin_Creatinine_Ratio: {
     default: { max: 30, min: 0, optimalMax: 20, optimalMin: 0, unit: 'mg/g' },
     source: 'tietz-7ed-2015',
@@ -242,10 +275,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 0.15, min: 0, optimalMax: 0.1, optimalMin: 0, unit: '' },
   },
 
-  // =============================================================================
-  // THYROID
-  // =============================================================================
-
   Omega6_AA: {
     default: { max: 15.0, min: 5.0, optimalMax: 12.0, optimalMin: 7.0, unit: '%' },
     source: 'simopoulos-omega-ratio-2002',
@@ -288,10 +317,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 0.1, min: 0, optimalMax: 0.05, optimalMin: 0, unit: 'K/uL' },
     source: 'pns-hemograma-2019',
   },
-
-  // =============================================================================
-  // HEMATOLOGY - CBC
-  // =============================================================================
 
   Bicarbonate: {
     default: { max: 29, min: 23, optimalMax: 28, optimalMin: 24, unit: 'mEq/L' },
@@ -453,7 +478,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   CPeptide: {
-    default: { max: 3.9, min: 0.8, optimalMax: 3.0, optimalMin: 1.0, unit: 'ng/mL' },
+    default: {
+      fastingRequired: 'strict',
+      max: 3.9,
+      min: 0.8,
+      optimalMax: 3.0,
+      optimalMin: 1.0,
+      unit: 'ng/mL',
+    },
     source: 'tietz-7ed-2015',
   },
 
@@ -461,6 +493,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 1.2, min: 0.6, optimalMax: 1.0, optimalMin: 0.7, unit: 'mg/dL' },
     source: 'pns-bioquimica-2019',
     variants: [
+      // Gestação: hiperfiltração glomerular (↑ 40–50% GFR) reduz a creatinina
+      // sérica. Valores "normais" de não-gestante podem sinalizar disfunção
+      // renal em gestante. Limites tipicamente citados: 0.4–0.8 mg/dL.
+      {
+        pregnant: true,
+        range: { max: 0.8, min: 0.4, optimalMax: 0.7, optimalMin: 0.5, unit: 'mg/dL' },
+        sex: 'F',
+      },
       {
         ageMin: 18,
         range: { max: 1.3, min: 0.7, optimalMax: 1.1, optimalMin: 0.8, unit: 'mg/dL' },
@@ -490,10 +530,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 500, min: 0, optimalMax: 250, optimalMin: 0, unit: 'ng/mL' },
     source: 'wells-ddimer-2003',
   },
-
-  // =============================================================================
-  // METABOLIC PANEL
-  // =============================================================================
 
   Omega3_DHA: {
     default: { max: 8.0, min: 2.0, optimalMax: 6.5, optimalMin: 3.5, unit: '%' },
@@ -621,6 +657,15 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 150, min: 12, optimalMax: 120, optimalMin: 30, unit: 'ng/mL' },
     source: 'who-iron-2020',
     variants: [
+      // Gestação: ferritina cai fisiologicamente no 2º/3º trimestre pela expansão
+      // do volume plasmático e maior demanda fetal. WHO 2020: <15 ng/mL sugere
+      // depleção; muitas diretrizes nacionais usam <30 como gatilho mais sensível
+      // na gestação dada a alta prevalência de deficiência subclínica.
+      {
+        pregnant: true,
+        range: { max: 120, min: 15, optimalMax: 80, optimalMin: 30, unit: 'ng/mL' },
+        sex: 'F',
+      },
       {
         ageMin: 18,
         range: { max: 250, min: 20, optimalMax: 200, optimalMin: 40, unit: 'ng/mL' },
@@ -650,10 +695,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 20, min: 3, optimalMax: 15, optimalMin: 5, unit: 'ng/mL' },
     source: 'tietz-7ed-2015',
   },
-
-  // =============================================================================
-  // LIVER FUNCTION
-  // =============================================================================
 
   FSH: {
     default: { max: 12.4, min: 1.5, optimalMax: 10.0, optimalMin: 3.0, unit: 'mIU/mL' },
@@ -712,8 +753,32 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   // e gerava falsos "abaixo do normal" em indivíduos saudáveis cuja glicemia
   // em jejum está fisiologicamente entre 54–70. optimalMin preserva o alvo.
   Glucose: {
-    default: { max: 100, min: 54, optimalMax: 90, optimalMin: 70, unit: 'mg/dL' },
+    default: {
+      fastingRequired: 'strict',
+      max: 100,
+      min: 54,
+      optimalMax: 90,
+      optimalMin: 70,
+      unit: 'mg/dL',
+    },
     source: 'sbd-diabetes-2024',
+    variants: [
+      // Gestação: DMG (IADPSG/SBD 2024) usa cortes mais restritivos na glicemia
+      // de jejum — ≥92 mg/dL já indica diabetes mellitus gestacional. Portanto
+      // a faixa "normal" em gestante vai até 91 mg/dL no jejum.
+      {
+        pregnant: true,
+        range: {
+          fastingRequired: 'strict',
+          max: 91,
+          min: 54,
+          optimalMax: 85,
+          optimalMin: 70,
+          unit: 'mg/dL',
+        },
+        sex: 'F',
+      },
+    ],
   },
 
   GlycoMark: {
@@ -779,14 +844,31 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'caulfield-ionmobility-2008',
   },
 
-  // =============================================================================
-  // INFLAMMATION
-  // =============================================================================
-
   Hgb: {
     default: { max: 17.5, min: 12.0, optimalMax: 16.0, optimalMin: 13.5, unit: 'g/dL' },
     source: 'pns-hemograma-2019',
     variants: [
+      // Gestação: hemodiluição fisiológica reduz o piso aceitável.
+      // OMS e CDC: anemia gestacional quando Hgb <11 g/dL (1º e 3º tri) ou
+      // <10.5 g/dL (2º tri, dilucional mais acentuada).
+      {
+        pregnant: true,
+        pregnancyTrimester: 1,
+        range: { max: 14.0, min: 11.0, optimalMax: 13.0, optimalMin: 11.5, unit: 'g/dL' },
+        sex: 'F',
+      },
+      {
+        pregnant: true,
+        pregnancyTrimester: 2,
+        range: { max: 14.0, min: 10.5, optimalMax: 13.0, optimalMin: 11.0, unit: 'g/dL' },
+        sex: 'F',
+      },
+      {
+        pregnant: true,
+        pregnancyTrimester: 3,
+        range: { max: 14.0, min: 11.0, optimalMax: 13.0, optimalMin: 11.5, unit: 'g/dL' },
+        sex: 'F',
+      },
       {
         ageMin: 18,
         range: { max: 17.5, min: 13.5, optimalMax: 16.5, optimalMin: 14.0, unit: 'g/dL' },
@@ -804,7 +886,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   // população urbana brasileira; Tietz 7ª ed. não publica corte próprio de
   // HOMA-IR, então a fonte anterior era citação inadequada.
   HOMA_IR: {
-    default: { max: 2.71, min: 0, optimalMax: 1.5, optimalMin: 0, unit: '' },
+    default: {
+      fastingRequired: 'strict',
+      max: 2.71,
+      min: 0,
+      optimalMax: 1.5,
+      optimalMin: 0,
+      unit: '',
+    },
     direction: 'lower-better',
     source: 'geloneze-brams-2009',
   },
@@ -820,17 +909,20 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
-  // =============================================================================
-  // METABOLIC
-  // =============================================================================
-
   ImmatureGranulocytes: {
     default: { max: 1.0, min: 0, optimalMax: 0.5, optimalMin: 0, unit: '%' },
     source: 'tietz-7ed-2015',
   },
 
   Insulin: {
-    default: { max: 25, min: 2, optimalMax: 8, optimalMin: 3, unit: 'µIU/mL' },
+    default: {
+      fastingRequired: 'strict',
+      max: 25,
+      min: 2,
+      optimalMax: 8,
+      optimalMin: 3,
+      unit: 'µIU/mL',
+    },
     source: 'tietz-7ed-2015',
   },
 
@@ -885,10 +977,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     direction: 'higher-better',
     source: 'caulfield-ionmobility-2008',
   },
-
-  // =============================================================================
-  // IRON STUDIES
-  // =============================================================================
 
   LDL_Small: {
     // LDL Small (LDL Pequena): lower is better (small dense LDL is most atherogenic)
@@ -949,10 +1037,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'simopoulos-omega-ratio-2002',
   },
 
-  // =============================================================================
-  // VITAMINS
-  // =============================================================================
-
   Lipoprotein_a: {
     default: { max: 75, min: 0, optimalMax: 30, optimalMin: 0, unit: 'nmol/L' },
     direction: 'lower-better',
@@ -1003,10 +1087,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 30, min: 0, optimalMax: 20, optimalMin: 0, unit: 'mg/L' },
     source: 'kdigo-ckd-2024',
   },
-
-  // =============================================================================
-  // HORMONES
-  // =============================================================================
 
   MMA: {
     default: { max: 378, min: 0, optimalMax: 270, optimalMin: 0, unit: 'nmol/L' },
@@ -1088,10 +1168,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'simopoulos-omega-ratio-2002',
   },
 
-  // =============================================================================
-  // TUMOR MARKERS
-  // =============================================================================
-
   OmegaCheck: {
     default: { max: 8.0, min: 4.0, optimalMax: 8.0, optimalMin: 5.5, unit: '%' },
     source: 'harris-omega3-2004',
@@ -1116,10 +1192,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 5.0, min: 3.5, optimalMax: 4.6, optimalMin: 3.8, unit: 'mEq/L' },
     source: 'tietz-7ed-2015',
   },
-
-  // =============================================================================
-  // CARDIAC MARKERS
-  // =============================================================================
 
   Prealbumin: {
     default: { max: 38, min: 18, optimalMax: 35, optimalMin: 20, unit: 'mg/dL' },
@@ -1195,10 +1267,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
-  // =============================================================================
-  // URINALYSIS
-  // =============================================================================
-
   RDW: {
     default: { max: 14.5, min: 11.5, optimalMax: 14.0, optimalMin: 12.0, unit: '%' },
     source: 'pns-hemograma-2019',
@@ -1241,10 +1309,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
-  // =============================================================================
-  // KIDNEY FUNCTION
-  // =============================================================================
-
   SpecificGravity_Urine: {
     default: { max: 1.03, min: 1.005, optimalMax: 1.025, optimalMin: 1.01, unit: 'SG' },
     source: 'tietz-7ed-2015',
@@ -1259,10 +1323,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 4.2, min: 2.3, optimalMax: 3.8, optimalMin: 2.8, unit: 'pg/mL' },
     source: 'tietz-7ed-2015',
   },
-
-  // =============================================================================
-  // OMEGA FATTY ACIDS
-  // =============================================================================
 
   T3Reverse: {
     default: { max: 24, min: 10, optimalMax: 20, optimalMin: 12, unit: 'ng/dL' },
@@ -1369,8 +1429,18 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
+  // Triglicérides — SBC 2017/2025 permite dosagem não-jejum com corte distinto
+  // (<175 mg/dL pós-prandial). Marcamos `preferred` para indicar que a faixa
+  // padrão é de jejum, mas não bloqueamos interpretação em não-jejum.
   Triglycerides: {
-    default: { max: 150, min: 0, optimalMax: 100, optimalMin: 0, unit: 'mg/dL' },
+    default: {
+      fastingRequired: 'preferred',
+      max: 150,
+      min: 0,
+      optimalMax: 100,
+      optimalMin: 0,
+      unit: 'mg/dL',
+    },
     direction: 'lower-better',
     source: 'sbc-lipids-2025',
   },
@@ -1396,6 +1466,27 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 4.0, min: 0.4, optimalMax: 3.0, optimalMin: 1.0, unit: 'µIU/mL' },
     source: 'sbem-thyroid-2013',
     variants: [
+      // Variantes gestacionais (ATA 2017 / SBEM): supressão fisiológica por hCG
+      // no 1º trimestre, recuperação progressiva no 2º/3º. Listadas primeiro
+      // para ter precedência sobre a variante etária em gestantes.
+      {
+        pregnant: true,
+        pregnancyTrimester: 1,
+        range: { max: 2.5, min: 0.1, optimalMax: 2.5, optimalMin: 0.1, unit: 'µIU/mL' },
+        sex: 'F',
+      },
+      {
+        pregnant: true,
+        pregnancyTrimester: 2,
+        range: { max: 3.0, min: 0.2, optimalMax: 3.0, optimalMin: 0.2, unit: 'µIU/mL' },
+        sex: 'F',
+      },
+      {
+        pregnant: true,
+        pregnancyTrimester: 3,
+        range: { max: 3.0, min: 0.3, optimalMax: 3.0, optimalMin: 0.3, unit: 'µIU/mL' },
+        sex: 'F',
+      },
       {
         ageMin: 65,
         range: { max: 6.0, min: 0.4, optimalMax: 4.0, optimalMin: 1.0, unit: 'µIU/mL' },
@@ -1430,10 +1521,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 1.0, min: 0.1, optimalMax: 1.0, optimalMin: 0.1, unit: 'mg/dL' },
     source: 'tietz-7ed-2015',
   },
-
-  // =============================================================================
-  // ADVANCED CARDIOVASCULAR
-  // =============================================================================
 
   pH_Urine: {
     default: { max: 8.0, min: 4.5, optimalMax: 7.0, optimalMin: 5.5, unit: 'pH' },
@@ -1470,10 +1557,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
-  // =============================================================================
-  // MINERALS
-  // =============================================================================
-
   VitaminB1: {
     default: { max: 180, min: 70, optimalMax: 150, optimalMin: 80, unit: 'nmol/L' },
     source: 'tietz-7ed-2015',
@@ -1493,10 +1576,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 2.0, min: 0.4, optimalMax: 1.5, optimalMin: 0.6, unit: 'mg/dL' },
     source: 'tietz-7ed-2015',
   },
-
-  // =============================================================================
-  // HEAVY METALS
-  // =============================================================================
 
   // Vitamina D — posicionamento conjunto SBEM/SBPC-ML 2017:
   // ≥20 ng/mL é desejável para população saudável <60 anos
@@ -1536,10 +1615,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'sbc-lipids-2025',
   },
 
-  // =============================================================================
-  // OTHER
-  // =============================================================================
-
   WBC: {
     default: { max: 11.0, min: 4.0, optimalMax: 8.0, optimalMin: 5.0, unit: 'K/uL' },
     source: 'pns-hemograma-2019',
@@ -1549,10 +1624,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     default: { max: 120, min: 60, optimalMax: 100, optimalMin: 70, unit: 'mcg/dL' },
     source: 'tietz-7ed-2015',
   },
-
-  // =============================================================================
-  // BODY COMPOSITION (DXA)
-  // =============================================================================
 
   AndroidFatPct: {
     default: { max: 35, min: 10, optimalMax: 25, optimalMin: 15, unit: '%' },
@@ -1803,10 +1874,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
-  // =============================================================================
-  // BONE DENSITOMETRY (DXA)
-  // =============================================================================
-
   BMD_Total: {
     default: { max: 1.4, min: 0.9, optimalMax: 1.3, optimalMin: 1.0, unit: 'g/cm²' },
     direction: 'higher-better',
@@ -1824,10 +1891,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     direction: 'higher-better',
     source: 'who-osteoporosis-1994',
   },
-
-  // =============================================================================
-  // MISSING LAB RANGES
-  // =============================================================================
 
   Amylase: {
     default: { max: 100, min: 28, optimalMax: 90, optimalMin: 35, unit: 'U/L' },
@@ -1976,10 +2039,28 @@ export function getReferenceRange(
     return definition.default;
   }
 
-  const { age, biologicalSex } = context;
+  const { age, biologicalSex, pregnancyTrimester, pregnant } = context;
 
-  // Find matching variant (first match wins - more specific variants should be listed first)
+  // Find matching variant (first match wins - more specific variants should be listed first).
+  // Variantes gestacionais (pregnant === true) devem vir primeiro na lista para
+  // que usuárias gestantes recebam o ajuste apropriado ao invés da faixa
+  // etária/sexo padrão.
   for (const variant of definition.variants) {
+    // Pregnancy gating: variantes com pregnant=true só casam com contexto gestacional;
+    // variantes sem pregnant (padrão) são ignoradas quando o contexto indica gestação,
+    // para evitar que uma gestante receba a faixa não-gestacional.
+    if (variant.pregnant === true) {
+      if (!pregnant) continue;
+      if (
+        variant.pregnancyTrimester !== undefined &&
+        variant.pregnancyTrimester !== pregnancyTrimester
+      ) {
+        continue;
+      }
+    } else if (pregnant) {
+      continue;
+    }
+
     // Check sex match ('all' matches everyone)
     if (variant.sex !== 'all' && variant.sex !== biologicalSex) {
       continue;

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -612,9 +612,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
+  // Ferritina — WHO 2020 é o documento de referência específico para avaliação
+  // do status de ferro via ferritina. Importante: inflamação aguda eleva
+  // ferritina (proteína de fase aguda); WHO 2020 recomenda dosagem concomitante
+  // de PCR para interpretação em contexto inflamatório (fora do escopo deste
+  // tipo de faixa, mas documentado aqui para consumidores).
   Ferritin: {
     default: { max: 150, min: 12, optimalMax: 120, optimalMin: 30, unit: 'ng/mL' },
-    source: 'tietz-7ed-2015',
+    source: 'who-iron-2020',
     variants: [
       {
         ageMin: 18,
@@ -701,8 +706,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
+  // Glicemia de jejum — 70–99 mg/dL é a faixa de normalidade (SBD 2024, ADA);
+  // hipoglicemia clinicamente acionável em não-diabético é <54 mg/dL (Level 2
+  // ADA/SBD), não 70. O corte 70 era Level 1 (alerta em diabético em tratamento)
+  // e gerava falsos "abaixo do normal" em indivíduos saudáveis cuja glicemia
+  // em jejum está fisiologicamente entre 54–70. optimalMin preserva o alvo.
   Glucose: {
-    default: { max: 100, min: 70, optimalMax: 90, optimalMin: 70, unit: 'mg/dL' },
+    default: { max: 100, min: 54, optimalMax: 90, optimalMin: 70, unit: 'mg/dL' },
     source: 'sbd-diabetes-2024',
   },
 
@@ -716,8 +726,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
+  // HbA1c — SBD 2024 não estabelece piso de referência clinicamente acionável.
+  // Valores <4.0% podem refletir anemia hemolítica, perda sanguínea recente ou
+  // hemoglobinopatia, não patologia do metabolismo glicêmico. Mantemos min=0
+  // para evitar flag de "abaixo do normal" em valores fisiologicamente baixos;
+  // optimalMin preserva o alvo fisiológico da fração glicada.
   HbA1c: {
-    default: { max: 5.7, min: 4.0, optimalMax: 5.3, optimalMin: 4.5, unit: '%' },
+    default: { max: 5.7, min: 0, optimalMax: 5.3, optimalMin: 4.5, unit: '%' },
     source: 'sbd-diabetes-2024',
   },
 
@@ -785,10 +800,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
+  // HOMA-IR — corte 2.71 do estudo BRAMS (Geloneze et al., 2009) validado em
+  // população urbana brasileira; Tietz 7ª ed. não publica corte próprio de
+  // HOMA-IR, então a fonte anterior era citação inadequada.
   HOMA_IR: {
-    default: { max: 2.5, min: 0, optimalMax: 1.5, optimalMin: 0, unit: '' },
+    default: { max: 2.71, min: 0, optimalMax: 1.5, optimalMin: 0, unit: '' },
     direction: 'lower-better',
-    source: 'tietz-7ed-2015',
+    source: 'geloneze-brams-2009',
   },
 
   Homocysteine: {
@@ -1369,8 +1387,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'giannitsis-hstnt-2010',
   },
 
+  // TSH — 0.4–4.0 é a faixa de referência adulta geral. O alvo 2.5 µIU/mL é
+  // específico do 1º trimestre gestacional (ATA 2017) e não se aplica a
+  // não-gestantes; optimalMax=3.0 reflete o limite superior do tercil "ótimo"
+  // sem invadir a faixa subclínica. Variante ageMin=65 mantém limite superior
+  // expandido (tolerância fisiológica do eixo em idosos, SBEM 2013).
   TSH: {
-    default: { max: 4.0, min: 0.4, optimalMax: 2.5, optimalMin: 1.0, unit: 'µIU/mL' },
+    default: { max: 4.0, min: 0.4, optimalMax: 3.0, optimalMin: 1.0, unit: 'µIU/mL' },
     source: 'sbem-thyroid-2013',
     variants: [
       {
@@ -1475,9 +1498,22 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   // HEAVY METALS
   // =============================================================================
 
+  // Vitamina D — posicionamento conjunto SBEM/SBPC-ML 2017:
+  // ≥20 ng/mL é desejável para população saudável <60 anos
+  // ≥30 ng/mL é recomendado para grupos de risco (idosos, gestantes, DRC,
+  // osteoporose, hiperparatireoidismo secundário). A variante ageMin=60 reflete
+  // o limiar mais restritivo para idosos; gestação e comorbidades devem ser
+  // tratadas via contexto específico quando o consumidor suportar.
   VitaminD: {
-    default: { max: 100, min: 30, optimalMax: 70, optimalMin: 40, unit: 'ng/mL' },
-    source: 'sbem-vitamind-2014',
+    default: { max: 100, min: 20, optimalMax: 70, optimalMin: 40, unit: 'ng/mL' },
+    source: 'ferreira-vitd-2017',
+    variants: [
+      {
+        ageMin: 60,
+        range: { max: 100, min: 30, optimalMax: 70, optimalMin: 40, unit: 'ng/mL' },
+        sex: 'all',
+      },
+    ],
   },
 
   VitaminD_1_25: {
@@ -1490,10 +1526,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
-  // VLDL: estimado via fórmula de Friedewald (TG/5)
+  // VLDL — estimado clinicamente via TG/5 (método Friedewald). O corte de
+  // referência deriva de triglicérides <150 mg/dL (SBC 2025, dislipidemias),
+  // portanto VLDL <30. Friedewald-1972 permanece registrada como fonte do
+  // método de cálculo, mas a faixa de referência tem respaldo na diretriz
+  // SBC 2025.
   VLDL: {
     default: { max: 30, min: 2, optimalMax: 20, optimalMin: 5, unit: 'mg/dL' },
-    source: 'friedewald-1972',
+    source: 'sbc-lipids-2025',
   },
 
   // =============================================================================

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -61,6 +61,13 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     url: 'https://pubmed.ncbi.nlm.nih.gov/8605666/',
   },
 
+  'ferreira-vitd-2017': {
+    abnt: 'FERREIRA, C. E. S. et al. Posicionamento oficial da Sociedade Brasileira de Patologia Clínica/Medicina Laboratorial e da Sociedade Brasileira de Endocrinologia e Metabologia sobre intervalos de referência da vitamina D [25(OH)D]. Arquivos de Endocrinologia e Metabologia, v. 61, n. 6, p. 527-542, 2017.',
+    doi: '10.1590/2359-3997000000310',
+    key: 'ferreira-vitd-2017',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/29412389/',
+  },
+
   'friedewald-1972': {
     abnt: 'FRIEDEWALD, W. T.; LEVY, R. I.; FREDRICKSON, D. S. Estimation of the concentration of low-density lipoprotein cholesterol in plasma, without use of the preparative ultracentrifuge. Clinical Chemistry, v. 18, n. 6, p. 499-502, 1972.',
     doi: '10.1093/clinchem/18.6.499',
@@ -72,6 +79,13 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     abnt: 'GALLAGHER, D. et al. Healthy percentage body fat ranges: an approach for developing guidelines based on body mass index. American Journal of Clinical Nutrition, v. 72, n. 3, p. 694-701, 2000.',
     key: 'gallagher-bodyfat-2000',
     url: 'https://pubmed.ncbi.nlm.nih.gov/10966886/',
+  },
+
+  'geloneze-brams-2009': {
+    abnt: 'GELONEZE, B. et al. HOMA1-IR and HOMA2-IR indexes in identifying insulin resistance and metabolic syndrome — Brazilian Metabolic Syndrome Study (BRAMS). Arquivos Brasileiros de Endocrinologia & Metabologia, v. 53, n. 2, p. 281-287, 2009.',
+    doi: '10.1590/S0004-27302009000200020',
+    key: 'geloneze-brams-2009',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/19466221/',
   },
 
   'george-ck-2016': {

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -240,8 +240,9 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
   // Sociedade Brasileira de Diabetes
   // ---------------------------------------------------------------------------
   'sbd-diabetes-2024': {
-    // TODO: Verificar edição exata e dados completos
-    abnt: 'SOCIEDADE BRASILEIRA DE DIABETES (SBD). Diretrizes da Sociedade Brasileira de Diabetes 2024. São Paulo: SBD, 2024.',
+    abnt: 'SOCIEDADE BRASILEIRA DE DIABETES (SBD). Diretriz da Sociedade Brasileira de Diabetes — Edição 2025. São Paulo: SBD, 2025.',
+    doi: '10.29327/5660187',
+    isbn: '978-65-272-1932-3',
     key: 'sbd-diabetes-2024',
     url: 'https://diretriz.diabetes.org.br',
   },
@@ -267,11 +268,12 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
   // Sociedade Brasileira de Patologia Clínica / Medicina Laboratorial
   // ---------------------------------------------------------------------------
   'sbpc-ml-2021': {
-    // TODO: Verificar título exato e dados completos na biblioteca SBPC
-    // https://www.bibliotecasbpc.org.br/index.php?P=4&C=0.2
-    abnt: 'SOCIEDADE BRASILEIRA DE PATOLOGIA CLÍNICA/MEDICINA LABORATORIAL (SBPC/ML). Recomendações da SBPC/ML. São Paulo: SBPC/ML, 2021.',
+    // Chave mantida como 'sbpc-ml-2021' para compatibilidade com consumidores;
+    // a edição autoritativa é de 2020 (verificada na Biblioteca Digital SBPC/ML
+    // em 2026-04-18). Ano na citação ABNT reflete a edição real.
+    abnt: 'SOCIEDADE BRASILEIRA DE PATOLOGIA CLÍNICA/MEDICINA LABORATORIAL (SBPC/ML). Recomendações da Sociedade Brasileira de Patologia Clínica/Medicina Laboratorial (SBPC/ML): Boas Práticas em Laboratório Clínico. São Paulo: SBPC/ML, 2020.',
     key: 'sbpc-ml-2021',
-    url: 'https://www.bibliotecasbpc.org.br/index.php?P=4&C=0.2',
+    url: 'https://bibliotecasbpc.org.br/index.php?P=4&C=0.2.443',
   },
   'schwedhelm-sdma-2011': {
     abnt: 'SCHWEDHELM, E. et al. Plasma symmetric dimethylarginine reference limits from the Framingham Offspring Cohort. Clinical Chemistry and Laboratory Medicine, v. 49, n. 11, p. 1907-1910, 2011.',

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -62,7 +62,7 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
   },
 
   'ferreira-vitd-2017': {
-    abnt: 'FERREIRA, C. E. S. et al. Posicionamento oficial da Sociedade Brasileira de Patologia Clínica/Medicina Laboratorial e da Sociedade Brasileira de Endocrinologia e Metabologia sobre intervalos de referência da vitamina D [25(OH)D]. Arquivos de Endocrinologia e Metabologia, v. 61, n. 6, p. 527-542, 2017.',
+    abnt: 'FERREIRA, C. E. S. et al. Posicionamento oficial da Sociedade Brasileira de Patologia Clínica/Medicina Laboratorial e da Sociedade Brasileira de Endocrinologia e Metabologia sobre intervalos de referência da vitamina D [25(OH)D]. Archives of Endocrinology and Metabolism, v. 61, n. 6, p. 527-542, 2017.',
     doi: '10.1590/2359-3997000000310',
     key: 'ferreira-vitd-2017',
     url: 'https://pubmed.ncbi.nlm.nih.gov/29412389/',
@@ -240,6 +240,10 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
   // Sociedade Brasileira de Diabetes
   // ---------------------------------------------------------------------------
   'sbd-diabetes-2024': {
+    // Chave mantida como 'sbd-diabetes-2024' para compatibilidade com
+    // consumidores publicados; a diretriz correspondente é o documento vivo
+    // de diretriz.diabetes.org.br, cuja edição citada quando este registro foi
+    // atualizado é "Edição 2025". Semelhante ao caso de sbpc-ml-2021 abaixo.
     abnt: 'SOCIEDADE BRASILEIRA DE DIABETES (SBD). Diretriz da Sociedade Brasileira de Diabetes — Edição 2025. São Paulo: SBD, 2025.',
     doi: '10.29327/5660187',
     isbn: '978-65-272-1932-3',


### PR DESCRIPTION
## Resumo

Consolida a remediação **A–E** (+ auditoria F sem mudanças) da revisão clínica `docs/medical-review-2026-04-17.md` em um único PR.

## A — Correções clínicas P1 (primeiro commit)

| Biomarcador | Antes | Depois | Fonte antes → depois |
| --- | --- | --- | --- |
| VitaminD | \`min: 30\` único | \`min: 20\` + variante \`ageMin: 60\` com \`min: 30\` | sbem-vitamind-2014 → ferreira-vitd-2017 |
| HbA1c | \`min: 4.0\` | \`min: 0\` | sbd-diabetes-2024 (mantido) |
| Glucose | \`min: 70\` | \`min: 54\` | sbd-diabetes-2024 (mantido) |
| TSH | \`optimalMax: 2.5\` | \`optimalMax: 3.0\` | sbem-thyroid-2013 (mantido) |
| HOMA_IR | \`max: 2.5\` | \`max: 2.71\` | tietz-7ed-2015 → geloneze-brams-2009 |
| Ferritin | — | — (só fonte) | tietz-7ed-2015 → who-iron-2020 |
| VLDL | — | — (só fonte) | friedewald-1972 → sbc-lipids-2025 |

## B — Metadados de fonte

- \`sbd-diabetes-2024\`: título oficial, DOI 10.29327/5660187, ISBN 978-65-272-1932-3
- \`sbpc-ml-2021\`: título completo, ano corrigido para 2020, URL direta

## C — Gestação e jejum

**Novos tipos** (sem breaking changes, tudo opcional):
- \`FastingRequirement = 'strict' | 'preferred' | 'not-required'\`
- \`PregnancyTrimester = 1 | 2 | 3\`
- \`RangeVariant\` estendido com \`pregnant?\`, \`pregnancyTrimester?\`
- \`BiomarkerReferenceRange\` estendido com \`fastingRequired?\`
- \`ReferenceRangeContext\` estendido com \`pregnant?\`, \`pregnancyTrimester?\`
- \`getReferenceRange\` faz gate de variantes gestacionais (pregnant=true só casa com contexto gestante; variantes não-gestacionais são ignoradas quando contexto é gestante)

**Variantes gestacionais adicionadas**:
- **TSH**: 1º tri 0.1–2.5; 2º tri 0.2–3.0; 3º tri 0.3–3.0 (ATA 2017)
- **Hgb**: 1º/3º tri ≥11; 2º tri ≥10.5 (OMS/CDC)
- **Ferritin**: gestante <15 ng/mL sugere depleção (WHO 2020)
- **Creatinine**: 0.4–0.8 mg/dL (hiperfiltração glomerular)
- **Glucose**: cutoff DMG <92 mg/dL jejum (IADPSG/SBD 2024)

**fastingRequired anotado**:
- \`strict\`: Glucose, Insulin, HOMA_IR, CPeptide
- \`preferred\`: Triglycerides (SBC 2017/2025 aceita não-jejum)

## D — Redução de dependência de Tietz

**Deferido** — substituições por equivalentes brasileiros exigem acesso a diretrizes específicas por biomarcador não disponíveis neste escopo. Documentado como trabalho de seguimento no audit doc.

## E — Estilo P3/P4

- Removidos 22 comentários de categoria desalinhados dentro de \`biomarkerRangeDefinitions\` (biomarcadores são ordenados alfabeticamente, comentários não correspondiam ao conteúdo)
- README de \`packages/core\`: nova seção **Escopo das faixas de referência** documentando validade para adultos (≥18 anos), variantes gestacionais disponíveis e metadado \`fastingRequired\`

## F — Auditoria dos calculators

Concluída sem mudanças necessárias:
- eGFR não é implementado neste repositório (valor vem do upstream; só passa por reference-ranges com fonte KDIGO 2024 — correto)
- HOMA-IR em \`derived/calculator.ts\`: fórmula correta \`(Glu × Ins) / 405\`, sem corte embutido
- PhenoAge foi auditado separadamente na plataforma (PRE-190)
- BrDMrisc fora do escopo

## Validação

- \`pnpm turbo run lint typecheck test\` — **13/13 tarefas OK**
- **387/387** testes em \`@precisa-saude/fhir\` (+10 novos para variantes gestacionais e fastingRequired)
- Invariantes \`min ≤ max\` mantidos; \`sources.test.ts\` validation de referências íntegra

## Impacto para consumidores

**Backwards-compatible**: todos os campos novos são opcionais. Consumidores existentes não precisam mudar nada. Para adotar variantes gestacionais, basta passar \`pregnant\` e/ou \`pregnancyTrimester\` no \`ReferenceRangeContext\`.

## Plano de teste

- [ ] Revisão clínica de segunda pessoa nas variantes gestacionais
- [ ] Confirmar que consumidores downstream (\`@precisasaude/web\`, \`@precisasaude/api\`) não assumem os valores antigos em fixtures
- [ ] Confirmar interpretação de ferritina em contexto inflamatório (nota em comentário do código)