### PR TITLE
fix(core): realinhar códigos TUSS do BRTUSSProcedimentosLabVS com tabela ANS oficial

### DIFF
--- a/ig/input/fsh/valuesets/BRTUSSProcedimentosLabVS.fsh
+++ b/ig/input/fsh/valuesets/BRTUSSProcedimentosLabVS.fsh
@@ -1,89 +1,92 @@
+// Códigos TUSS realinhados com a tabela oficial ANS (MAPEAMENTO TUSS x SIGTAP 2017 04.xlsx).
+// Fonte: https://www.gov.br/ans/pt-br/arquivos/assuntos/prestadores/padrao-para-troca-de-informacao-de-saude-suplementar-tiss/padrao-tiss-tabelas-relacionadas/padraotiss_mapeamento_tuss_sigtap.zip
+// Ver issue #23 para auditoria completa e justificativa de cada mudança.
+
 ValueSet: BRTUSSProcedimentosLabVS
 Id: tuss-procedimentos-lab-vs
 Title: "TUSS Procedimentos Laboratoriais ValueSet"
-Description: "Subconjunto de códigos TUSS para procedimentos laboratoriais relevantes aos biomarcadores suportados pelo fhir-brasil. Códigos da Tabela 22 (Procedimentos e Eventos em Saúde) da TUSS."
+Description: "Subconjunto de códigos TUSS para procedimentos laboratoriais relevantes aos biomarcadores suportados pelo fhir-brasil. Códigos da Tabela 22 (Procedimentos e Eventos em Saúde) da TUSS, alinhados com a tabela oficial ANS competência 2017-04."
 
 // Hematologia
-* $TUSS#40304361 "Hemograma completo"
-* $TUSS#40304370 "Hemograma completo (eritrograma, leucograma e plaquetas)"
-* $TUSS#40304540 "Reticulócitos, contagem"
-* $TUSS#40304060 "Velocidade de hemossedimentação (VHS)"
+* $TUSS#40304361 "Hemograma com contagem de plaquetas (eritrograma, leucograma, plaquetas)"
+* $TUSS#40304558 "Reticulócitos, contagem"
+* $TUSS#40304370 "Hemossedimentação (VHS)"
 
 // Bioquímica — glicose e metabolismo
-* $TUSS#40301630 "Glicose"
-* $TUSS#40302040 "Hemoglobina glicada (A1C)"
-* $TUSS#40301770 "Insulina"
-* $TUSS#40301354 "Ácido úrico"
-* $TUSS#40301460 "Creatina quinase (CK total)"
+* $TUSS#40302040 "Glicose"
+* $TUSS#40302733 "Hemoglobina glicada (Fração A1c)"
+* $TUSS#40316360 "Insulina"
+* $TUSS#40301150 "Ácido úrico"
+* $TUSS#40301648 "Creatino fosfoquinase total (CK)"
 
 // Bioquímica — perfil lipídico
-* $TUSS#40301397 "Colesterol total"
-* $TUSS#40301400 "Colesterol HDL"
-* $TUSS#40301419 "Colesterol LDL"
-* $TUSS#40302695 "Triglicerídeos"
-* $TUSS#40301427 "Colesterol VLDL"
-* $TUSS#40301338 "Apolipoproteína A-1"
-* $TUSS#40301346 "Apolipoproteína B"
-* $TUSS#40302580 "Lipoproteína (a)"
+* $TUSS#40301605 "Colesterol total"
+* $TUSS#40301583 "Colesterol HDL"
+* $TUSS#40301591 "Colesterol LDL"
+* $TUSS#40302547 "Triglicerídeos"
+* $TUSS#40302695 "Colesterol VLDL"
+* $TUSS#40301354 "Apolipoproteína A (Apo A)"
+* $TUSS#40301362 "Apolipoproteína B (Apo B)"
+* $TUSS#40302210 "Lipoproteína (a) — Lp(a)"
 
 // Bioquímica — função hepática
-* $TUSS#40301311 "Albumina"
-* $TUSS#40301370 "Bilirrubina total e frações"
-* $TUSS#40302610 "Proteínas totais"
-* $TUSS#40301575 "Fosfatase alcalina"
-* $TUSS#40302903 "Gama-glutamil transferase (GGT)"
-* $TUSS#40301680 "Transaminase glutâmico-oxalacética (TGO/AST)"
-* $TUSS#40301699 "Transaminase glutâmico-pirúvica (TGP/ALT)"
+* $TUSS#40301222 "Albumina"
+* $TUSS#40301397 "Bilirrubinas (direta, indireta e total)"
+* $TUSS#40302377 "Proteínas totais"
+* $TUSS#40301885 "Fosfatase alcalina"
+* $TUSS#40301990 "Gama-glutamil transferase (GGT)"
+* $TUSS#40302504 "Transaminase oxalacética (TGO/AST)"
+* $TUSS#40302512 "Transaminase pirúvica (TGP/ALT)"
 
 // Bioquímica — função renal
-* $TUSS#40301443 "Creatinina"
-* $TUSS#40302709 "Ureia"
-* $TUSS#40301885 "Potássio"
-* $TUSS#40301915 "Sódio"
-* $TUSS#40302857 "Clearance de creatinina"
+* $TUSS#40301630 "Creatinina"
+* $TUSS#40302580 "Ureia"
+* $TUSS#40302318 "Potássio"
+* $TUSS#40302423 "Sódio"
+* $TUSS#40301508 "Clearance de creatinina"
 
 // Bioquímica — minerais e eletrólitos
-* $TUSS#40301389 "Cálcio"
-* $TUSS#40301826 "Magnésio"
-* $TUSS#40301567 "Ferro sérico"
-* $TUSS#40301559 "Ferritina"
-* $TUSS#40301362 "Capacidade de ligação do ferro (TIBC)"
+* $TUSS#40301400 "Cálcio"
+* $TUSS#40302237 "Magnésio"
+* $TUSS#40301842 "Ferro sérico"
+* $TUSS#40316270 "Ferritina"
+* $TUSS#40301427 "Capacidade de fixação de ferro (TIBC)"
 
 // Hormônios — tireoide
-* $TUSS#40316491 "TSH"
-* $TUSS#40316556 "T4 livre"
-* $TUSS#40316548 "T3 livre"
-* $TUSS#40316130 "Anticorpos anti-tireoglobulina"
-* $TUSS#40316122 "Anticorpos anti-peroxidase tireoidiana (anti-TPO)"
+* $TUSS#40316521 "Tireoestimulante, hormônio (TSH)"
+* $TUSS#40316491 "T4 livre"
+* $TUSS#40316467 "T3 livre"
+* $TUSS#40316530 "Tireoglobulina (anti-TG)"
+* $TUSS#40316157 "Anti-TPO"
 
 // Hormônios — reprodutivos
-* $TUSS#40316220 "Estradiol"
-* $TUSS#40316360 "FSH — Hormônio folículo-estimulante"
-* $TUSS#40316378 "LH — Hormônio luteinizante"
-* $TUSS#40316440 "Progesterona"
-* $TUSS#40316459 "Prolactina"
-* $TUSS#40316521 "Testosterona total"
-* $TUSS#40316530 "Testosterona livre"
+* $TUSS#40316246 "Estradiol"
+* $TUSS#40316289 "Folículo estimulante, hormônio (FSH)"
+* $TUSS#40316335 "Hormônio luteinizante (LH)"
+* $TUSS#40316408 "Progesterona"
+* $TUSS#40316416 "Prolactina"
+* $TUSS#40316513 "Testosterona total"
+* $TUSS#40316505 "Testosterona livre"
 
 // Hormônios — outros
 * $TUSS#40316190 "Cortisol"
-* $TUSS#40316203 "DHEA-Sulfato"
+* $TUSS#40316459 "Sulfato de dehidroepiandrosterona (S-DHEA)"
 
 // Vitaminas
-* $TUSS#40302750 "Vitamina B12"
-* $TUSS#40301583 "Folato (ácido fólico)"
-* $TUSS#40302717 "Vitamina D (25-hidroxi)"
+* $TUSS#40316572 "Vitamina B12"
+* $TUSS#40301087 "Ácido fólico (eritrocitário)"
+* $TUSS#40302830 "Vitamina D 25 hidroxi"
 
 // Marcadores tumorais
-* $TUSS#40308014 "Alfa-fetoproteína (AFP)"
-* $TUSS#40308049 "CA-125"
-* $TUSS#40308120 "Antígeno carcinoembrionário (CEA)"
-* $TUSS#40308189 "PSA total"
-* $TUSS#40308197 "PSA livre"
+* $TUSS#40316068 "Alfa-fetoproteína (AFP)"
+* $TUSS#40316378 "Marcadores tumorais (CA 19.9, CA 125, CA 72-4, CA 15-3, etc.)"
+* $TUSS#40316122 "Antígeno carcinoembriogênico (CEA)"
+* $TUSS#40316149 "Antígeno específico prostático total (PSA)"
+* $TUSS#40316130 "Antígeno específico prostático livre (PSA livre)"
 
 // Marcadores inflamatórios
-* $TUSS#40302466 "Proteína C-reativa (PCR)"
+* $TUSS#40308391 "Proteína C reativa, quantitativa"
 
 // Urinálise
-* $TUSS#40311104 "Urina tipo I (EAS)"
-* $TUSS#40311295 "Microalbuminúria"
+* $TUSS#40311210 "Rotina de urina (EAS — caracteres físicos, elementos anormais e sedimentoscopia)"
+* $TUSS#40311171 "Microalbuminúria"


### PR DESCRIPTION
Resolve #23.

## Mudanças

Realinha os 59 códigos TUSS do `BRTUSSProcedimentosLabVS.fsh` contra a tabela oficial **MAPEAMENTO TUSS x SIGTAP 2017 04.xlsx** publicada pela ANS. Resultado: 58 entradas (uma duplicata removida — ver abaixo).

| | Antes | Depois |
| --- | ---: | ---: |
| Entradas | 59 | 58 |
| Códigos alinhados com nome ANS | 1 | 58 |
| Códigos divergentes da ANS | 58 | 0 |
| Códigos duplicados dentro do VS | 1 par | 0 |

## Decisões clínicas que merecem revisão

A maior parte das correções é direta (busca por nome na tabela ANS). Estas merecem atenção do reviewer:

### 1. Hemograma — duplicata removida
O ValueSet listava duas linhas para hemograma:
- `40304361 "Hemograma completo"`
- `40304370 "Hemograma completo (eritrograma, leucograma e plaquetas)"`

Na ANS, **`40304361`** é o "Hemograma com contagem de plaquetas (eritrograma, leucograma, plaquetas)" — e **`40304370`** é "Hemossedimentação (VHS)", que não tem nada a ver com hemograma. Consolido tudo em uma única linha `40304361` e movo o VHS pra sua própria linha (`40304370`).

### 2. Folato — único candidato é eritrocitário
Na tabela ANS, o único código relacionado a folato é `40301087` "Ácido fólico, pesquisa e/ou dosagem **nos eritrócitos**" (RBC folate). Não há um TUSS oficial pra folato sérico. Mantenho `40301087` mas atualizo o display pra deixar explícito ("(eritrocitário)"). Se o intento original do VS era folato sérico, precisamos decidir se removemos ou aceitamos o eritrocitário como proxy.

### 3. Marcadores tumorais (CA-125)
Na ANS não existe entrada específica pra CA-125 — apenas `40316378` "Marcadores tumorais (CA 19.9, CA 125, CA 72-4, CA 15-3, etc.) cada". Aplico esse código com display agregado.

### 4. Anti-tireoglobulina vs Tireoglobulina
A entrada original "Anticorpos anti-tireoglobulina" (anti-TG) não tem código próprio na ANS — só existe `40316530` "Tireoglobulina" (a proteína em si, não o anticorpo). Mantenho esse código mas o display vira "Tireoglobulina (anti-TG)" pra deixar a ambiguidade visível.

### 5. PSA livre — código colide com uso anterior
- Antes: \`40308189 "PSA total"\` e \`40308197 "PSA livre"\` (códigos antigos/CBHPM, ambos errados na ANS).
- Depois: \`40316149 "PSA total"\` e \`40316130 "PSA livre"\`. **Atenção**: \`40316130\` era o código que o VS antigo usava pra "Anticorpos anti-tireoglobulina" — então qualquer cliente que dependesse desse comportamento vai mudar.

## Fonte autoritativa

- Arquivo: \`MAPEAMENTO TUSS x SIGTAP 2017 04.xlsx\`
- Publicador: ANS (Agência Nacional de Saúde Suplementar)
- Página oficial: https://www.gov.br/ans/pt-br/assuntos/prestadores/padrao-para-troca-de-informacao-de-saude-suplementar-2013-tiss/padrao-tiss-tabelas-relacionadas
- Download direto: https://www.gov.br/ans/pt-br/arquivos/assuntos/prestadores/padrao-para-troca-de-informacao-de-saude-suplementar-tiss/padrao-tiss-tabelas-relacionadas/padraotiss_mapeamento_tuss_sigtap.zip
- Licença: dado aberto (Lei 12.527/2011)
- Competência: 2017-04

## Tabela completa antes/depois

| Display | Antes | Depois | Nome oficial ANS |
| --- | --- | --- | --- |
| Hemograma com contagem de plaquetas | \`40304361\` + \`40304370\` (dup) | \`40304361\` | Hemograma com contagem de plaquetas (eritrograma, leucograma, plaquetas) |
| Reticulócitos, contagem | \`40304540\` | \`40304558\` | Reticulócitos, contagem |
| Hemossedimentação (VHS) | \`40304060\` | \`40304370\` | Hemossedimentação, (VHS) |
| Glicose | \`40301630\` | \`40302040\` | Glicose |
| Hemoglobina glicada (A1c) | \`40302040\` | \`40302733\` | Hemoglobina glicada (Fração A1c) |
| Insulina | \`40301770\` | \`40316360\` | Insulina |
| Ácido úrico | \`40301354\` | \`40301150\` | Ácido úrico |
| CK total | \`40301460\` | \`40301648\` | Creatino fosfoquinase total (CK) |
| Colesterol total | \`40301397\` | \`40301605\` | Colesterol total |
| Colesterol HDL | \`40301400\` | \`40301583\` | Colesterol (HDL) |
| Colesterol LDL | \`40301419\` | \`40301591\` | Colesterol (LDL) |
| Triglicerídeos | \`40302695\` | \`40302547\` | Triglicerídeos |
| Colesterol VLDL | \`40301427\` | \`40302695\` | Colesterol (VLDL) |
| Apolipoproteína A | \`40301338\` | \`40301354\` | Apolipoproteína A (Apo A) |
| Apolipoproteína B | \`40301346\` | \`40301362\` | Apolipoproteína B (Apo B) |
| Lipoproteína (a) | \`40302580\` | \`40302210\` | Lipoproteína (a) - Lp (a) |
| Albumina | \`40301311\` | \`40301222\` | Albumina |
| Bilirrubinas (direta, indireta e total) | \`40301370\` | \`40301397\` | Bilirrubinas (direta, indireta e total) |
| Proteínas totais | \`40302610\` | \`40302377\` | Proteínas totais |
| Fosfatase alcalina | \`40301575\` | \`40301885\` | Fosfatase alcalina |
| GGT | \`40302903\` | \`40301990\` | Gama-glutamil transferase |
| TGO/AST | \`40301680\` | \`40302504\` | Transaminase oxalacética (amino transferase aspartato) |
| TGP/ALT | \`40301699\` | \`40302512\` | Transaminase pirúvica (amino transferase de alanina) |
| Creatinina | \`40301443\` | \`40301630\` | Creatinina |
| Ureia | \`40302709\` | \`40302580\` | Uréia |
| Potássio | \`40301885\` | \`40302318\` | Potássio |
| Sódio | \`40301915\` | \`40302423\` | Sódio |
| Clearance de creatinina | \`40302857\` | \`40301508\` | Clearance de creatinina |
| Cálcio | \`40301389\` | \`40301400\` | Cálcio |
| Magnésio | \`40301826\` | \`40302237\` | Magnésio |
| Ferro sérico | \`40301567\` | \`40301842\` | Ferro sérico |
| Ferritina | \`40301559\` | \`40316270\` | Ferritina |
| TIBC | \`40301362\` | \`40301427\` | Capacidade de fixação de ferro |
| TSH | \`40316491\` | \`40316521\` | Tireoestimulante, hormônio (TSH) |
| T4 livre | \`40316556\` | \`40316491\` | T4 livre |
| T3 livre | \`40316548\` | \`40316467\` | T3 livre |
| Tireoglobulina (anti-TG) | \`40316130\` | \`40316530\` | Tireoglobulina |
| Anti-TPO | \`40316122\` | \`40316157\` | Anti-TPO |
| Estradiol | \`40316220\` | \`40316246\` | Estradiol |
| FSH | \`40316360\` | \`40316289\` | Folículo estimulante (FSH) |
| LH | \`40316378\` | \`40316335\` | Hormônio luteinizante (LH) |
| Progesterona | \`40316440\` | \`40316408\` | Progesterona |
| Prolactina | \`40316459\` | \`40316416\` | Prolactina |
| Testosterona total | \`40316521\` | \`40316513\` | Testosterona total |
| Testosterona livre | \`40316530\` | \`40316505\` | Testosterona livre |
| Cortisol | \`40316190\` | \`40316190\` | Cortisol *(único já correto)* |
| S-DHEA | \`40316203\` | \`40316459\` | Sulfato de dehidroepiandrosterona (S-DHEA) |
| Vitamina B12 | \`40302750\` | \`40316572\` | Vitamina B12 |
| Ácido fólico | \`40301583\` | \`40301087\` | Ácido fólico nos eritrócitos *(ver decisão #2)* |
| Vitamina D 25 hidroxi | \`40302717\` | \`40302830\` | Vitamina "D" 25 HIDROXI |
| AFP | \`40308014\` | \`40316068\` | Alfa-fetoproteína |
| CA-125 | \`40308049\` | \`40316378\` | Marcadores tumorais (CA 19.9, CA 125...) *(ver decisão #3)* |
| CEA | \`40308120\` | \`40316122\` | Antígeno carcinoembriogênico (CEA) |
| PSA total | \`40308189\` | \`40316149\` | Antígeno específico prostático total (PSA) |
| PSA livre | \`40308197\` | \`40316130\` | Antígeno específico prostático livre (PSA livre) *(ver decisão #5)* |
| PCR | \`40302466\` | \`40308391\` | Proteína C reativa, quantitativa |
| Urina I (EAS) | \`40311104\` | \`40311210\` | Rotina de urina (caracteres físicos, elementos anormais e sedimentoscopia) |
| Microalbuminúria | \`40311295\` | \`40311171\` | Microalbuminúria |

## Próximo passo (não nesse PR)

Sugestão de issue separada: adicionar teste no CI que cruza cada \`\$TUSS#code\` declarado em ValueSets contra a planilha oficial ANS. Evita regressão e detecta deriva quando a ANS publicar novas competências.