### PR TITLE
fix(ci): trocar PAT_TOKEN por GitHub App token no Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,19 @@ jobs:
             );
             core.setOutput('packages_changed', packageChanged ? 'true' : 'false');
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.changes.outputs.packages_changed == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         if: steps.changes.outputs.packages_changed == 'true'
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.packages_changed == 'true'
@@ -117,7 +125,7 @@ jobs:
         id: semantic
         if: steps.changes.outputs.packages_changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: 0
         run: |
           OUTPUT=$(npx semantic-release 2>&1) || true


### PR DESCRIPTION
## Resumo

Quebra apareceu no run [24753606541](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/24753606541/job/72422028116) — o job \`Release\` falhou em \`actions/checkout\` com \`Input required and not supplied: token\` porque \`secrets.PAT_TOKEN\` não está mais disponível.

## Diagnóstico

- O ecossistema migrou para auth via GitHub App (\`actions/create-github-app-token@v1\` com \`RELEASE_APP_ID\` + \`RELEASE_APP_PRIVATE_KEY\`).
- Medbench já usa esse padrão.
- Fhir-brasil ficou com referência pendente a \`PAT_TOKEN\` em dois pontos do \`ci.yml\` (\`token:\` do checkout e \`GITHUB_TOKEN\` do step de semantic-release).
- Não tinha quebrado antes porque o conditional \`packages_changed == 'true'\` só virou true agora — PR #25 (chore) tocou \`packages/*/README.md\` via \`prettier --write\`, disparando o caminho de release pela primeira vez.

## Mudança

- \`actions/checkout\` e \`semantic-release\` agora consomem o token efêmero do GitHub App (mesmo padrão do medbench).
- Removidas as duas referências a \`secrets.PAT_TOKEN\`.

Sem mudança em runtime, behavior, ou pacotes publicados.

## Test plan

- [x] Pre-push verde
- [ ] CI verde no PR (Release vai pular porque \`packages/*\` não muda neste diff)
- [ ] Próximo merge para main que tocar \`packages/*\` vai exercitar o caminho com o app token