### PR TITLE
feat: rnds-sandbox + 200 biomarcadores + taxonomia de 10 categorias

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ Documentação completa e contexto do projeto em [fhir-brasil.dev.br](https://fh
 
 O sistema de saúde brasileiro opera como redes paralelas com troca mínima de dados — laboratórios privados entregam PDFs sem padrão, laboratórios do SUS usam sistemas internos, e nenhum enxerga o outro. O **fhir-brasil** fornece a infraestrutura de código aberto para resolver essa fragmentação via FHIR R4:
 
-- **180+ biomarcadores** com códigos LOINC, nomes em pt-BR/en-US, categorias e unidades UCUM
-- **180+ faixas de referência** com variantes por sexo/idade, baseadas em diretrizes SBPC/ML, SBC e SBD
+- **200+ biomarcadores** com códigos LOINC, nomes em pt-BR/en-US, unidades UCUM, organizados em 10 categorias clínicas
+- **200+ faixas de referência** com variantes por sexo/idade, baseadas em diretrizes SBPC/ML, SBC e SBD
 - **Normalização de aliases** — cada laboratório usa nomes diferentes para o mesmo exame; `normalizeCode('colesterol HDL')` retorna `'HDL'`
 - **Calculadoras clínicas** — PhenoAge (idade biológica), BrDMrisc (risco de diabetes), HOMA-IR, VLDL, IMC
 - **Utilitários OCR** — ancoragem de texto para extração de biomarcadores de PDFs de resultados de laboratório
 - **Cliente RNDS** — cliente HTTP para a Rede Nacional de Dados em Saúde (DATASUS), com autenticação mTLS e zero dependências externas
+- **Sandbox RNDS** — mock local da RNDS para desenvolvimento, ensino e demos sem certificado ICP-Brasil
 
 > 580+ testes automatizados, cobertura acima de 80%, revisão contínua de faixas de referência.
 
@@ -32,10 +33,11 @@ O sistema de saúde brasileiro opera como redes paralelas com troca mínima de d
 
 | Pacote                                                     | Descrição                                                                                     | Deps                  |
 | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------- |
-| [`@precisa-saude/fhir`](packages/core/)                    | Tipos FHIR R4, 180+ biomarcadores, faixas de referência, conversores, normalização de aliases | 0 runtime deps        |
-| [`@precisa-saude/fhir-calculators`](packages/calculators/) | PhenoAge, BrDMrisc, HOMA-IR, VLDL, IMC                                                        | `@precisa-saude/fhir` |
-| [`@precisa-saude/fhir-ocr-utils`](packages/ocr-utils/)     | Ancoragem OCR para extração de biomarcadores                                                  | `@precisa-saude/fhir` |
-| [`@precisa-saude/fhir-rnds`](packages/rnds/)               | Cliente HTTP para a RNDS (DATASUS) — autenticação mTLS, FHIR R4                               | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir`](packages/core/)                       | Tipos FHIR R4, 200+ biomarcadores, faixas de referência, conversores, normalização de aliases | 0 runtime deps        |
+| [`@precisa-saude/fhir-calculators`](packages/calculators/)    | PhenoAge, BrDMrisc, HOMA-IR, VLDL, IMC                                                        | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir-ocr-utils`](packages/ocr-utils/)        | Ancoragem OCR para extração de biomarcadores                                                  | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir-rnds`](packages/rnds/)                  | Cliente HTTP para a RNDS (DATASUS) — autenticação mTLS, FHIR R4                               | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir-rnds-sandbox`](packages/rnds-sandbox/)  | Mock local da RNDS — endpoints FHIR R4 e cenários sintéticos para dev/ensino                  | `@precisa-saude/fhir` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ O sistema de saúde brasileiro opera como redes paralelas com troca mínima de d
 
 ## Pacotes
 
-| Pacote                                                     | Descrição                                                                                     | Deps                  |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------- |
-| [`@precisa-saude/fhir`](packages/core/)                       | Tipos FHIR R4, 200+ biomarcadores, faixas de referência, conversores, normalização de aliases | 0 runtime deps        |
-| [`@precisa-saude/fhir-calculators`](packages/calculators/)    | PhenoAge, BrDMrisc, HOMA-IR, VLDL, IMC                                                        | `@precisa-saude/fhir` |
-| [`@precisa-saude/fhir-ocr-utils`](packages/ocr-utils/)        | Ancoragem OCR para extração de biomarcadores                                                  | `@precisa-saude/fhir` |
-| [`@precisa-saude/fhir-rnds`](packages/rnds/)                  | Cliente HTTP para a RNDS (DATASUS) — autenticação mTLS, FHIR R4                               | `@precisa-saude/fhir` |
-| [`@precisa-saude/fhir-rnds-sandbox`](packages/rnds-sandbox/)  | Mock local da RNDS — endpoints FHIR R4 e cenários sintéticos para dev/ensino                  | `@precisa-saude/fhir` |
+| Pacote                                                       | Descrição                                                                                     | Deps                  |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | --------------------- |
+| [`@precisa-saude/fhir`](packages/core/)                      | Tipos FHIR R4, 200+ biomarcadores, faixas de referência, conversores, normalização de aliases | 0 runtime deps        |
+| [`@precisa-saude/fhir-calculators`](packages/calculators/)   | PhenoAge, BrDMrisc, HOMA-IR, VLDL, IMC                                                        | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir-ocr-utils`](packages/ocr-utils/)       | Ancoragem OCR para extração de biomarcadores                                                  | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir-rnds`](packages/rnds/)                 | Cliente HTTP para a RNDS (DATASUS) — autenticação mTLS, FHIR R4                               | `@precisa-saude/fhir` |
+| [`@precisa-saude/fhir-rnds-sandbox`](packages/rnds-sandbox/) | Mock local da RNDS — endpoints FHIR R4 e cenários sintéticos para dev/ensino                  | `@precisa-saude/fhir` |
 
 ---
 

--- a/examples/rnds-sandbox-express/README.md
+++ b/examples/rnds-sandbox-express/README.md
@@ -26,10 +26,10 @@ Abra <http://127.0.0.1:3000>.
 
 Variáveis de ambiente opcionais:
 
-| Variável  | Padrão                | Efeito                                                   |
-| --------- | --------------------- | -------------------------------------------------------- |
-| `PORT`    | `3000`                | Porta do Express                                         |
-| `SCENARIO`| `paciente-com-exames` | Cenário do sandbox (`internacao`, `vacina`, `vazio`)     |
+| Variável   | Padrão                | Efeito                                               |
+| ---------- | --------------------- | ---------------------------------------------------- |
+| `PORT`     | `3000`                | Porta do Express                                     |
+| `SCENARIO` | `paciente-com-exames` | Cenário do sandbox (`internacao`, `vacina`, `vazio`) |
 
 ## Arquitetura
 
@@ -69,6 +69,10 @@ O frontend é HTML/CSS/JS puro — `<script>` tradicional, sem build.
 - **API programática** do sandbox: como bootar e parar via código.
 - **Forma das chamadas RNDS**: paths, headers, body — exatamente o
   que um cliente em produção envia/recebe.
+- **Round-trip submit→search**: clique em "Buscar Observations"
+  para ver o histórico, depois "Submeter" e clique de novo — o total
+  sobe e o novo código LOINC aparece na lista (mesma semântica que a
+  RNDS expõe via `GET /Observation?subject=...`).
 - **Renderização de respostas FHIR**: o `<pre>` mostra Patient,
   Organization, Practitioner, Bundle e OperationOutcome cruas, sem
   abstração — útil para inspeção e ensino.

--- a/examples/rnds-sandbox-express/README.md
+++ b/examples/rnds-sandbox-express/README.md
@@ -1,0 +1,96 @@
+# Exemplo: rnds-sandbox + Express + HTML/JS
+
+Backend Node/Express que usa `@precisa-saude/fhir-rnds-sandbox`
+em-processo, e um frontend HTML/JS sem framework que dispara as
+chamadas e renderiza a resposta JSON na tela.
+
+Roda inteiramente local: zero credencial, zero certificado.
+
+## Como rodar
+
+A partir da raiz do monorepo:
+
+```bash
+pnpm install
+pnpm --filter @fhir-brasil-examples/rnds-sandbox-express start
+```
+
+Ou direto neste diretório:
+
+```bash
+pnpm install
+node server.mjs
+```
+
+Abra <http://127.0.0.1:3000>.
+
+Variáveis de ambiente opcionais:
+
+| Variável  | Padrão                | Efeito                                                   |
+| --------- | --------------------- | -------------------------------------------------------- |
+| `PORT`    | `3000`                | Porta do Express                                         |
+| `SCENARIO`| `paciente-com-exames` | Cenário do sandbox (`internacao`, `vacina`, `vazio`)     |
+
+## Arquitetura
+
+```
+                ┌─────────────────────┐
+                │  Browser            │
+   GET /        │  index.html + app.js│
+   GET /api/... │                     │
+                └──────────┬──────────┘
+                           │ fetch()
+                           ▼
+       ┌───────────────────────────────────┐
+       │  Express (server.mjs)             │
+       │  ┌───────────────────────────┐   │
+       │  │ rnds-sandbox em-processo  │   │
+       │  │  (porta efêmera)          │   │
+       │  └───────────────────────────┘   │
+       │  • busca token no boot           │
+       │  • forwarda fetch(sandbox)       │
+       │    com bearer + CNS headers      │
+       └───────────────────────────────────┘
+```
+
+O backend Express:
+
+1. Inicializa o sandbox em-processo via `createSandboxServer({ port: 0 })`.
+2. Faz `POST /api/token` no sandbox e guarda o JWT.
+3. Expõe endpoints `/api/...` que o frontend chama; cada um repassa a
+   chamada para o sandbox adicionando os headers que um cliente RNDS
+   real envia: `X-Authorization-Server: Bearer <jwt>` +
+   `Authorization: <CNS>`.
+
+O frontend é HTML/CSS/JS puro — `<script>` tradicional, sem build.
+
+## O que o exemplo demonstra
+
+- **API programática** do sandbox: como bootar e parar via código.
+- **Forma das chamadas RNDS**: paths, headers, body — exatamente o
+  que um cliente em produção envia/recebe.
+- **Renderização de respostas FHIR**: o `<pre>` mostra Patient,
+  Organization, Practitioner, Bundle e OperationOutcome cruas, sem
+  abstração — útil para inspeção e ensino.
+- **JWKS**: o botão "JWKS" mostra o documento de chave pública que
+  permitiria validar a assinatura do token via `jose`/`jwt.io`.
+
+## O que NÃO está aqui (de propósito)
+
+- Sem React/Vue/Svelte/etc — HTML+JS puro.
+- Sem CSS framework — um único arquivo `style.css` enxuto.
+- Sem mTLS no exemplo — o sandbox roda em modo permissivo para
+  simplicidade de demo. Para exercitar mTLS, suba o sandbox
+  separadamente com `--mtls` e ajuste o `sandboxBase` em `server.mjs`.
+
+## Próximos passos
+
+- Trocar `SCENARIO` para ver outras formas de Bundle pré-carregado.
+- Editar o `sampleBundle()` em `server.mjs` para experimentar outros
+  recursos FHIR (DiagnosticReport, Immunization, Encounter).
+- Adicionar endpoints novos no Express e botões no frontend para
+  cobrir mais cenários do seu caso de uso.
+
+## Licença
+
+Apache-2.0 — mesmo do monorepo.

--- a/examples/rnds-sandbox-express/package.json
+++ b/examples/rnds-sandbox-express/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fhir-brasil-examples/rnds-sandbox-express",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Exemplo: backend Express que consome o rnds-sandbox + frontend HTML/JS que renderiza as respostas",
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "@precisa-saude/fhir-rnds-sandbox": "workspace:^",
+    "express": "^4.21.2"
+  }
+}

--- a/examples/rnds-sandbox-express/public/app.js
+++ b/examples/rnds-sandbox-express/public/app.js
@@ -23,8 +23,14 @@ const ACTIONS = {
     const cns = document.getElementById('cns-pract').value.trim();
     return fetchAndRender(`/api/practitioner/${encodeURIComponent(cns)}`, `Practitioner ${cns}`);
   },
-  bundle: () =>
-    fetchAndRender(`/api/bundle`, 'POST /api/fhir/r4/Bundle', { method: 'POST' }),
+  observations: () => {
+    const cns = document.getElementById('cns-obs').value.trim();
+    return fetchAndRender(
+      `/api/observations/${encodeURIComponent(cns)}`,
+      `Observation?subject=Patient/${cns}`,
+    );
+  },
+  bundle: () => fetchAndRender(`/api/bundle`, 'POST /api/fhir/r4/Bundle', { method: 'POST' }),
   info: () => fetchAndRender(`/api/info`, 'GET /api/info'),
   jwks: () => fetchAndRender(`/api/jwks`, 'GET /.well-known/jwks.json'),
 };

--- a/examples/rnds-sandbox-express/public/app.js
+++ b/examples/rnds-sandbox-express/public/app.js
@@ -87,18 +87,44 @@ function setBusy(busy, title) {
   }
 }
 
-// Carrega info do backend ao abrir a página
+// Carrega info do backend ao abrir a página.
+// Construído via DOM API + textContent para evitar XSS caso algum campo
+// contenha caracteres HTML (paranoia defensiva — backend é nosso, mas
+// o hábito vale).
 fetch('/api/info')
   .then((r) => r.json())
   .then((info) => {
     const banner = document.getElementById('info-banner');
-    banner.innerHTML = `
-      <strong>backend:</strong> ${info.backend} ·
-      <strong>cenário:</strong> ${info.scenario} ·
-      <strong>profissional:</strong> CNS ${info.profissionalCns} ·
-      <strong>token:</strong> <code>${info.tokenPreview}</code>
-    `;
+    banner.replaceChildren(
+      labeled('backend:', info.backend),
+      sep(),
+      labeled('cenário:', info.scenario),
+      sep(),
+      labeled('profissional:', `CNS ${info.profissionalCns}`),
+      sep(),
+      labeled('token:', info.tokenPreview, { mono: true }),
+    );
   })
   .catch((err) => {
     document.getElementById('info-banner').textContent = `erro ao carregar /api/info: ${err}`;
   });
+
+function labeled(label, value, opts = {}) {
+  const wrap = document.createElement('span');
+  const k = document.createElement('strong');
+  k.textContent = label;
+  wrap.appendChild(k);
+  wrap.appendChild(document.createTextNode(' '));
+  if (opts.mono) {
+    const code = document.createElement('code');
+    code.textContent = value;
+    wrap.appendChild(code);
+  } else {
+    wrap.appendChild(document.createTextNode(value));
+  }
+  return wrap;
+}
+
+function sep() {
+  return document.createTextNode(' · ');
+}

--- a/examples/rnds-sandbox-express/public/app.js
+++ b/examples/rnds-sandbox-express/public/app.js
@@ -1,0 +1,98 @@
+/**
+ * Frontend de exemplo — JS puro, sem build, sem framework.
+ *
+ * Cada botão tem `data-action`; o handler dispara a chamada
+ * correspondente ao backend Express, que por sua vez fala com o
+ * sandbox. A resposta JSON crua é renderizada no <pre id="result-body">.
+ */
+
+const ACTIONS = {
+  'patient-cpf': () => {
+    const cpf = document.getElementById('cpf').value.trim();
+    return fetchAndRender(`/api/patient/cpf/${encodeURIComponent(cpf)}`, `Patient (CPF ${cpf})`);
+  },
+  'patient-cns': () => {
+    const cns = document.getElementById('cns-patient').value.trim();
+    return fetchAndRender(`/api/patient/cns/${encodeURIComponent(cns)}`, `Patient (CNS ${cns})`);
+  },
+  organization: () => {
+    const cnes = document.getElementById('cnes').value.trim();
+    return fetchAndRender(`/api/organization/${encodeURIComponent(cnes)}`, `Organization ${cnes}`);
+  },
+  practitioner: () => {
+    const cns = document.getElementById('cns-pract').value.trim();
+    return fetchAndRender(`/api/practitioner/${encodeURIComponent(cns)}`, `Practitioner ${cns}`);
+  },
+  bundle: () =>
+    fetchAndRender(`/api/bundle`, 'POST /api/fhir/r4/Bundle', { method: 'POST' }),
+  info: () => fetchAndRender(`/api/info`, 'GET /api/info'),
+  jwks: () => fetchAndRender(`/api/jwks`, 'GET /.well-known/jwks.json'),
+};
+
+document.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-action]');
+  if (!button) return;
+  const action = button.dataset.action;
+  const handler = ACTIONS[action];
+  if (!handler) return;
+  void handler();
+});
+
+async function fetchAndRender(url, title, init = {}) {
+  setBusy(true, title);
+  try {
+    const res = await fetch(url, init);
+    let body;
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('json')) {
+      body = await res.json();
+    } else {
+      body = await res.text();
+    }
+    renderResult(title, res.status, body);
+  } catch (err) {
+    renderResult(title, '— (erro)', { error: String(err) });
+  } finally {
+    setBusy(false);
+  }
+}
+
+function renderResult(title, status, body) {
+  document.getElementById('result-title').textContent = title;
+  const statusEl = document.getElementById('result-status');
+  statusEl.textContent = `status ${status}`;
+  statusEl.dataset.kind = statusKind(status);
+  document.getElementById('result-body').textContent =
+    typeof body === 'string' ? body : JSON.stringify(body, null, 2);
+}
+
+function statusKind(status) {
+  if (typeof status !== 'number') return 'neutral';
+  if (status >= 200 && status < 300) return 'ok';
+  if (status >= 400 && status < 500) return 'warn';
+  if (status >= 500) return 'err';
+  return 'neutral';
+}
+
+function setBusy(busy, title) {
+  document.body.dataset.busy = busy ? '1' : '';
+  if (busy) {
+    document.getElementById('result-title').textContent = `${title} (em andamento...)`;
+  }
+}
+
+// Carrega info do backend ao abrir a página
+fetch('/api/info')
+  .then((r) => r.json())
+  .then((info) => {
+    const banner = document.getElementById('info-banner');
+    banner.innerHTML = `
+      <strong>backend:</strong> ${info.backend} ·
+      <strong>cenário:</strong> ${info.scenario} ·
+      <strong>profissional:</strong> CNS ${info.profissionalCns} ·
+      <strong>token:</strong> <code>${info.tokenPreview}</code>
+    `;
+  })
+  .catch((err) => {
+    document.getElementById('info-banner').textContent = `erro ao carregar /api/info: ${err}`;
+  });

--- a/examples/rnds-sandbox-express/public/index.html
+++ b/examples/rnds-sandbox-express/public/index.html
@@ -11,9 +11,9 @@
       <h1>rnds-sandbox · exemplo Express</h1>
       <p>
         Backend Node/Express boota o
-        <code>@precisa-saude/fhir-rnds-sandbox</code> em-processo, busca um
-        token e age como cliente RNDS para o frontend. Dispare uma das
-        ações abaixo — a resposta JSON da RNDS aparece no painel à direita.
+        <code>@precisa-saude/fhir-rnds-sandbox</code> em-processo, busca um token e age como cliente
+        RNDS para o frontend. Dispare uma das ações abaixo — a resposta JSON da RNDS aparece no
+        painel à direita.
       </p>
       <div id="info-banner">carregando informações do backend...</div>
     </header>
@@ -59,8 +59,8 @@
         <fieldset>
           <legend>Submeter Bundle (LOINC 2345-7)</legend>
           <p class="muted">
-            Envia um Observation FHIR R4 com glicemia para a paciente Joana,
-            codificado em LOINC. A RNDS responde com transaction-response.
+            Envia um Observation FHIR R4 com glicemia para a paciente Joana, codificado em LOINC. A
+            RNDS responde com transaction-response.
           </p>
           <button data-action="bundle">Submeter</button>
         </fieldset>
@@ -68,9 +68,8 @@
         <fieldset>
           <legend>Observations por paciente</legend>
           <p class="muted">
-            Lista todas as Observations já submetidas para o CNS abaixo
-            (incluindo as pré-carregadas pelo cenário). Submeta uma nova
-            acima e clique de novo para ver o total subir.
+            Lista todas as Observations já submetidas para o CNS abaixo (incluindo as pré-carregadas
+            pelo cenário). Submeta uma nova acima e clique de novo para ver o total subir.
           </p>
           <label>
             CNS (15 dígitos)

--- a/examples/rnds-sandbox-express/public/index.html
+++ b/examples/rnds-sandbox-express/public/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>rnds-sandbox — exemplo Express</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>rnds-sandbox · exemplo Express</h1>
+      <p>
+        Backend Node/Express boota o
+        <code>@precisa-saude/fhir-rnds-sandbox</code> em-processo, busca um
+        token e age como cliente RNDS para o frontend. Dispare uma das
+        ações abaixo — a resposta JSON da RNDS aparece no painel à direita.
+      </p>
+      <div id="info-banner">carregando informações do backend...</div>
+    </header>
+
+    <main>
+      <section class="actions">
+        <fieldset>
+          <legend>Paciente por CPF</legend>
+          <label>
+            CPF
+            <input id="cpf" type="text" value="12345678901" />
+          </label>
+          <button data-action="patient-cpf">Buscar</button>
+        </fieldset>
+
+        <fieldset>
+          <legend>Paciente por CNS</legend>
+          <label>
+            CNS (15 dígitos)
+            <input id="cns-patient" type="text" value="700000000000001" />
+          </label>
+          <button data-action="patient-cns">Buscar</button>
+        </fieldset>
+
+        <fieldset>
+          <legend>Estabelecimento por CNES</legend>
+          <label>
+            CNES (7 dígitos)
+            <input id="cnes" type="text" value="2345678" />
+          </label>
+          <button data-action="organization">Buscar</button>
+        </fieldset>
+
+        <fieldset>
+          <legend>Profissional por CNS</legend>
+          <label>
+            CNS (15 dígitos)
+            <input id="cns-pract" type="text" value="700000000000010" />
+          </label>
+          <button data-action="practitioner">Buscar</button>
+        </fieldset>
+
+        <fieldset>
+          <legend>Submeter Bundle (LOINC 2345-7)</legend>
+          <p class="muted">
+            Envia um Observation FHIR R4 com glicemia para a paciente Joana,
+            codificado em LOINC. A RNDS responde com transaction-response.
+          </p>
+          <button data-action="bundle">Submeter</button>
+        </fieldset>
+
+        <fieldset>
+          <legend>Infra de auth</legend>
+          <button data-action="info">/api/info (token + cenário)</button>
+          <button data-action="jwks">/.well-known/jwks.json</button>
+        </fieldset>
+      </section>
+
+      <section class="result">
+        <div class="result-header">
+          <h2 id="result-title">Resposta</h2>
+          <span id="result-status"></span>
+        </div>
+        <pre id="result-body">Aguardando ação...</pre>
+      </section>
+    </main>
+
+    <footer>
+      <small>
+        Apache-2.0 ·
+        <a href="https://github.com/Precisa-Saude/fhir-brasil/tree/main/packages/rnds-sandbox"
+          >fhir-brasil/packages/rnds-sandbox</a
+        >
+      </small>
+    </footer>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/examples/rnds-sandbox-express/public/index.html
+++ b/examples/rnds-sandbox-express/public/index.html
@@ -66,6 +66,20 @@
         </fieldset>
 
         <fieldset>
+          <legend>Observations por paciente</legend>
+          <p class="muted">
+            Lista todas as Observations já submetidas para o CNS abaixo
+            (incluindo as pré-carregadas pelo cenário). Submeta uma nova
+            acima e clique de novo para ver o total subir.
+          </p>
+          <label>
+            CNS (15 dígitos)
+            <input id="cns-obs" type="text" value="700000000000001" />
+          </label>
+          <button data-action="observations">Buscar Observations</button>
+        </fieldset>
+
+        <fieldset>
           <legend>Infra de auth</legend>
           <button data-action="info">/api/info (token + cenário)</button>
           <button data-action="jwks">/.well-known/jwks.json</button>

--- a/examples/rnds-sandbox-express/public/style.css
+++ b/examples/rnds-sandbox-express/public/style.css
@@ -20,7 +20,12 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
   line-height: 1.45;
 }
 

--- a/examples/rnds-sandbox-express/public/style.css
+++ b/examples/rnds-sandbox-express/public/style.css
@@ -1,0 +1,207 @@
+:root {
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --panel-2: #273449;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --ok: #22c55e;
+  --warn: #f59e0b;
+  --err: #ef4444;
+  --border: #334155;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  line-height: 1.45;
+}
+
+header {
+  padding: 1.5rem 2rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+header p {
+  margin: 0 0 0.75rem;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+#info-banner {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+#info-banner code {
+  color: var(--accent);
+}
+
+main {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) 2fr;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem;
+}
+
+@media (max-width: 900px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+}
+
+fieldset {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+label {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+}
+
+input[type='text'] {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', 'Cascadia Mono', monospace;
+}
+
+input[type='text']:focus {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 1px;
+}
+
+button {
+  background: var(--accent-strong);
+  border: none;
+  color: #04263b;
+  padding: 0.45rem 0.9rem;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+button:hover {
+  background: var(--accent);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0 0 0.75rem;
+}
+
+.result {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  min-height: 60vh;
+}
+
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.result-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--accent);
+}
+
+#result-status {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: var(--panel-2);
+}
+
+#result-status[data-kind='ok'] {
+  color: var(--ok);
+  border: 1px solid var(--ok);
+}
+
+#result-status[data-kind='warn'] {
+  color: var(--warn);
+  border: 1px solid var(--warn);
+}
+
+#result-status[data-kind='err'] {
+  color: var(--err);
+  border: 1px solid var(--err);
+}
+
+#result-body {
+  margin: 0;
+  padding: 1rem;
+  flex: 1;
+  overflow: auto;
+  font-family: ui-monospace, 'SF Mono', 'Cascadia Mono', monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+
+footer {
+  padding: 1rem 2rem;
+  text-align: center;
+  color: var(--muted);
+  border-top: 1px solid var(--border);
+}
+
+footer a {
+  color: var(--accent);
+}
+
+body[data-busy='1'] {
+  cursor: progress;
+}

--- a/examples/rnds-sandbox-express/server.mjs
+++ b/examples/rnds-sandbox-express/server.mjs
@@ -60,6 +60,11 @@ const app = express();
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
+// Wrapper que repassa erros para o middleware de erro do Express,
+// evitando unhandled promise rejection se o sandbox cair ou a resposta
+// não for JSON válido.
+const wrap = (handler) => (req, res, next) => Promise.resolve(handler(req, res, next)).catch(next);
+
 app.get('/api/info', (_req, res) => {
   res.json({
     backend: 'express',
@@ -70,46 +75,83 @@ app.get('/api/info', (_req, res) => {
   });
 });
 
-app.get('/api/jwks', async (_req, res) => {
-  const r = await fetch(`${sandboxBase}/.well-known/jwks.json`);
-  res.status(r.status).json(await r.json());
-});
+app.get(
+  '/api/jwks',
+  wrap(async (_req, res) => {
+    const r = await fetch(`${sandboxBase}/.well-known/jwks.json`);
+    res.status(r.status).json(await r.json());
+  }),
+);
 
-app.get('/api/patient/cpf/:cpf', async (req, res) => {
-  const id = `http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|${req.params.cpf}`;
-  const r = await rndsFetch(`/api/fhir/r4/Patient?identifier=${encodeURIComponent(id)}`);
-  res.status(r.status).json(await r.json());
-});
+app.get(
+  '/api/patient/cpf/:cpf',
+  wrap(async (req, res) => {
+    const id = `http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|${req.params.cpf}`;
+    const r = await rndsFetch(`/api/fhir/r4/Patient?identifier=${encodeURIComponent(id)}`);
+    res.status(r.status).json(await r.json());
+  }),
+);
 
-app.get('/api/patient/cns/:cns', async (req, res) => {
-  const r = await rndsFetch(`/api/fhir/r4/Patient/${encodeURIComponent(req.params.cns)}`);
-  res.status(r.status).json(await r.json());
-});
+app.get(
+  '/api/patient/cns/:cns',
+  wrap(async (req, res) => {
+    const r = await rndsFetch(`/api/fhir/r4/Patient/${encodeURIComponent(req.params.cns)}`);
+    res.status(r.status).json(await r.json());
+  }),
+);
 
-app.get('/api/organization/:cnes', async (req, res) => {
-  const r = await rndsFetch(`/api/fhir/r4/Organization/${encodeURIComponent(req.params.cnes)}`);
-  res.status(r.status).json(await r.json());
-});
+app.get(
+  '/api/organization/:cnes',
+  wrap(async (req, res) => {
+    const r = await rndsFetch(`/api/fhir/r4/Organization/${encodeURIComponent(req.params.cnes)}`);
+    res.status(r.status).json(await r.json());
+  }),
+);
 
-app.get('/api/practitioner/:cns', async (req, res) => {
-  const r = await rndsFetch(`/api/fhir/r4/Practitioner/${encodeURIComponent(req.params.cns)}`);
-  res.status(r.status).json(await r.json());
-});
+app.get(
+  '/api/practitioner/:cns',
+  wrap(async (req, res) => {
+    const r = await rndsFetch(`/api/fhir/r4/Practitioner/${encodeURIComponent(req.params.cns)}`);
+    res.status(r.status).json(await r.json());
+  }),
+);
 
-app.get('/api/observations/:cns', async (req, res) => {
-  const subject = `Patient/${encodeURIComponent(req.params.cns)}`;
-  const r = await rndsFetch(`/api/fhir/r4/Observation?subject=${encodeURIComponent(subject)}`);
-  res.status(r.status).json(await r.json());
-});
+app.get(
+  '/api/observations/:cns',
+  wrap(async (req, res) => {
+    const subject = `Patient/${encodeURIComponent(req.params.cns)}`;
+    const r = await rndsFetch(`/api/fhir/r4/Observation?subject=${encodeURIComponent(subject)}`);
+    res.status(r.status).json(await r.json());
+  }),
+);
 
-app.post('/api/bundle', async (req, res) => {
-  const bundle = req.body && req.body.resourceType === 'Bundle' ? req.body : sampleBundle();
-  const r = await rndsFetch(`/api/fhir/r4/Bundle`, {
-    body: JSON.stringify(bundle),
-    headers: { 'Content-Type': 'application/fhir+json' },
-    method: 'POST',
+app.post(
+  '/api/bundle',
+  wrap(async (req, res) => {
+    const bundle = req.body && req.body.resourceType === 'Bundle' ? req.body : sampleBundle();
+    const r = await rndsFetch(`/api/fhir/r4/Bundle`, {
+      body: JSON.stringify(bundle),
+      headers: { 'Content-Type': 'application/fhir+json' },
+      method: 'POST',
+    });
+    res.status(r.status).json(await r.json());
+  }),
+);
+
+// Middleware de erro — devolve OperationOutcome FHIR com o motivo da falha.
+// eslint-disable-next-line no-unused-vars
+app.use((err, _req, res, _next) => {
+  console.error('[backend] erro no handler:', err);
+  res.status(502).json({
+    issue: [
+      {
+        code: 'transient',
+        diagnostics: `Backend Express falhou ao falar com o sandbox: ${err?.message ?? err}`,
+        severity: 'error',
+      },
+    ],
+    resourceType: 'OperationOutcome',
   });
-  res.status(r.status).json(await r.json());
 });
 
 function sampleBundle() {

--- a/examples/rnds-sandbox-express/server.mjs
+++ b/examples/rnds-sandbox-express/server.mjs
@@ -31,22 +31,36 @@ const sandbox = createSandboxServer({
 const { host: sbHost, port: sbPort } = await sandbox.start();
 const sandboxBase = `http://${sbHost}:${sbPort}`;
 
-// 2. Busca um token logo no boot — em produção um job recurrente faria isso
-//    antes da expiração; aqui simplificamos.
+// 2. Token bearer com auto-refresh.
+//    O sandbox emite tokens com TTL de 30 min. Renovamos antes de expirar
+//    (margem de 60s) para que sessões longas de demo não falhem com 401.
+const TOKEN_REFRESH_MARGIN_MS = 60_000;
+let token = '';
+let tokenExpiresAt = 0;
+
 async function fetchToken() {
   const res = await fetch(`${sandboxBase}/api/token`, { method: 'POST' });
   if (!res.ok) {
     throw new Error(`Falha ao obter token: ${res.status}`);
   }
   const body = await res.json();
-  return body.access_token;
+  token = body.access_token;
+  tokenExpiresAt = Date.now() + body.expires_in * 1000;
+  console.log(`[backend] token obtido (exp em ~${Math.round(body.expires_in / 60)}min)`);
 }
-let token = await fetchToken();
-console.log(`[backend] token obtido (${token.slice(0, 24)}...)`);
+
+async function ensureToken() {
+  if (!token || Date.now() >= tokenExpiresAt - TOKEN_REFRESH_MARGIN_MS) {
+    await fetchToken();
+  }
+}
+
+await fetchToken();
 
 // 3. Helper que faz proxy ao sandbox usando bearer + CNS, igual a um
-//    cliente RNDS real faria.
+//    cliente RNDS real faria. Garante token válido antes de cada chamada.
 async function rndsFetch(pathSuffix, init = {}) {
+  await ensureToken();
   const headers = {
     'X-Authorization-Server': `Bearer ${token}`,
     Authorization: PROFISSIONAL_CNS,

--- a/examples/rnds-sandbox-express/server.mjs
+++ b/examples/rnds-sandbox-express/server.mjs
@@ -77,9 +77,7 @@ app.get('/api/jwks', async (_req, res) => {
 
 app.get('/api/patient/cpf/:cpf', async (req, res) => {
   const id = `http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|${req.params.cpf}`;
-  const r = await rndsFetch(
-    `/api/fhir/r4/Patient?identifier=${encodeURIComponent(id)}`,
-  );
+  const r = await rndsFetch(`/api/fhir/r4/Patient?identifier=${encodeURIComponent(id)}`);
   res.status(r.status).json(await r.json());
 });
 
@@ -89,16 +87,12 @@ app.get('/api/patient/cns/:cns', async (req, res) => {
 });
 
 app.get('/api/organization/:cnes', async (req, res) => {
-  const r = await rndsFetch(
-    `/api/fhir/r4/Organization/${encodeURIComponent(req.params.cnes)}`,
-  );
+  const r = await rndsFetch(`/api/fhir/r4/Organization/${encodeURIComponent(req.params.cnes)}`);
   res.status(r.status).json(await r.json());
 });
 
 app.get('/api/practitioner/:cns', async (req, res) => {
-  const r = await rndsFetch(
-    `/api/fhir/r4/Practitioner/${encodeURIComponent(req.params.cns)}`,
-  );
+  const r = await rndsFetch(`/api/fhir/r4/Practitioner/${encodeURIComponent(req.params.cns)}`);
   res.status(r.status).json(await r.json());
 });
 

--- a/examples/rnds-sandbox-express/server.mjs
+++ b/examples/rnds-sandbox-express/server.mjs
@@ -194,15 +194,21 @@ function sampleBundle() {
 }
 
 const PORT = Number(process.env.PORT ?? 3000);
-app.listen(PORT, () => {
+const httpServer = app.listen(PORT, () => {
   console.log(`[backend] http://127.0.0.1:${PORT}`);
 });
 
-// Graceful shutdown
+// Graceful shutdown — fecha primeiro o Express (para de aceitar
+// requisições novas), depois o sandbox em-processo.
 const shutdown = async (sig) => {
   console.log(`[backend] recebido ${sig}, encerrando...`);
+  await new Promise((resolve) => httpServer.close(() => resolve()));
   await sandbox.stop();
   process.exit(0);
 };
-process.on('SIGINT', () => void shutdown('SIGINT'));
-process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => {
+  void shutdown('SIGINT');
+});
+process.on('SIGTERM', () => {
+  void shutdown('SIGTERM');
+});

--- a/examples/rnds-sandbox-express/server.mjs
+++ b/examples/rnds-sandbox-express/server.mjs
@@ -102,8 +102,14 @@ app.get('/api/practitioner/:cns', async (req, res) => {
   res.status(r.status).json(await r.json());
 });
 
+app.get('/api/observations/:cns', async (req, res) => {
+  const subject = `Patient/${encodeURIComponent(req.params.cns)}`;
+  const r = await rndsFetch(`/api/fhir/r4/Observation?subject=${encodeURIComponent(subject)}`);
+  res.status(r.status).json(await r.json());
+});
+
 app.post('/api/bundle', async (req, res) => {
-  const bundle = req.body ?? sampleBundle();
+  const bundle = req.body && req.body.resourceType === 'Bundle' ? req.body : sampleBundle();
   const r = await rndsFetch(`/api/fhir/r4/Bundle`, {
     body: JSON.stringify(bundle),
     headers: { 'Content-Type': 'application/fhir+json' },

--- a/examples/rnds-sandbox-express/server.mjs
+++ b/examples/rnds-sandbox-express/server.mjs
@@ -1,0 +1,152 @@
+/**
+ * Servidor de exemplo — Express + rnds-sandbox.
+ *
+ * Boota o sandbox em-processo, busca um token logo na inicialização e
+ * expõe endpoints simples (`/api/...`) que o frontend HTML/JS consome.
+ * Cada endpoint apenas repassa a resposta bruta da API FHIR — o objetivo
+ * é demonstrar o shape das chamadas RNDS, não esconder JSON do usuário.
+ *
+ * Uso:
+ *   node server.mjs            → permissivo (sem auth, demo rápida)
+ *   STRICT=1 node server.mjs   → strict + token bearer + CNS header
+ */
+
+import express from 'express';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { createSandboxServer } from '@precisa-saude/fhir-rnds-sandbox';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SCENARIO = process.env.SCENARIO ?? 'paciente-com-exames';
+const PROFISSIONAL_CNS = '700000000000010';
+
+// 1. Sobe o sandbox em-processo numa porta efêmera.
+const sandbox = createSandboxServer({
+  log: (msg) => console.log(`[sandbox] ${msg}`),
+  port: 0,
+  scenario: SCENARIO,
+});
+const { host: sbHost, port: sbPort } = await sandbox.start();
+const sandboxBase = `http://${sbHost}:${sbPort}`;
+
+// 2. Busca um token logo no boot — em produção um job recurrente faria isso
+//    antes da expiração; aqui simplificamos.
+async function fetchToken() {
+  const res = await fetch(`${sandboxBase}/api/token`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Falha ao obter token: ${res.status}`);
+  }
+  const body = await res.json();
+  return body.access_token;
+}
+let token = await fetchToken();
+console.log(`[backend] token obtido (${token.slice(0, 24)}...)`);
+
+// 3. Helper que faz proxy ao sandbox usando bearer + CNS, igual a um
+//    cliente RNDS real faria.
+async function rndsFetch(pathSuffix, init = {}) {
+  const headers = {
+    'X-Authorization-Server': `Bearer ${token}`,
+    Authorization: PROFISSIONAL_CNS,
+    ...(init.headers ?? {}),
+  };
+  return fetch(`${sandboxBase}${pathSuffix}`, { ...init, headers });
+}
+
+// 4. Express
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/info', (_req, res) => {
+  res.json({
+    backend: 'express',
+    profissionalCns: PROFISSIONAL_CNS,
+    sandboxBase,
+    scenario: SCENARIO,
+    tokenPreview: `${token.slice(0, 32)}…`,
+  });
+});
+
+app.get('/api/jwks', async (_req, res) => {
+  const r = await fetch(`${sandboxBase}/.well-known/jwks.json`);
+  res.status(r.status).json(await r.json());
+});
+
+app.get('/api/patient/cpf/:cpf', async (req, res) => {
+  const id = `http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|${req.params.cpf}`;
+  const r = await rndsFetch(
+    `/api/fhir/r4/Patient?identifier=${encodeURIComponent(id)}`,
+  );
+  res.status(r.status).json(await r.json());
+});
+
+app.get('/api/patient/cns/:cns', async (req, res) => {
+  const r = await rndsFetch(`/api/fhir/r4/Patient/${encodeURIComponent(req.params.cns)}`);
+  res.status(r.status).json(await r.json());
+});
+
+app.get('/api/organization/:cnes', async (req, res) => {
+  const r = await rndsFetch(
+    `/api/fhir/r4/Organization/${encodeURIComponent(req.params.cnes)}`,
+  );
+  res.status(r.status).json(await r.json());
+});
+
+app.get('/api/practitioner/:cns', async (req, res) => {
+  const r = await rndsFetch(
+    `/api/fhir/r4/Practitioner/${encodeURIComponent(req.params.cns)}`,
+  );
+  res.status(r.status).json(await r.json());
+});
+
+app.post('/api/bundle', async (req, res) => {
+  const bundle = req.body ?? sampleBundle();
+  const r = await rndsFetch(`/api/fhir/r4/Bundle`, {
+    body: JSON.stringify(bundle),
+    headers: { 'Content-Type': 'application/fhir+json' },
+    method: 'POST',
+  });
+  res.status(r.status).json(await r.json());
+});
+
+function sampleBundle() {
+  return {
+    entry: [
+      {
+        request: { method: 'POST', url: 'Observation' },
+        resource: {
+          code: { coding: [{ code: '2345-7', display: 'Glicose', system: 'http://loinc.org' }] },
+          effectiveDateTime: new Date().toISOString().slice(0, 10),
+          resourceType: 'Observation',
+          status: 'final',
+          subject: { reference: 'Patient/700000000000001' },
+          valueQuantity: {
+            code: 'mg/dL',
+            system: 'http://unitsofmeasure.org',
+            unit: 'mg/dL',
+            value: 102,
+          },
+        },
+      },
+    ],
+    resourceType: 'Bundle',
+    type: 'transaction',
+  };
+}
+
+const PORT = Number(process.env.PORT ?? 3000);
+app.listen(PORT, () => {
+  console.log(`[backend] http://127.0.0.1:${PORT}`);
+});
+
+// Graceful shutdown
+const shutdown = async (sig) => {
+  console.log(`[backend] recebido ${sig}, encerrando...`);
+  await sandbox.stop();
+  process.exit(0);
+};
+process.on('SIGINT', () => void shutdown('SIGINT'));
+process.on('SIGTERM', () => void shutdown('SIGTERM'));

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @precisa-saude/fhir
 
-Tipos FHIR R4, 180+ definições de biomarcadores com códigos LOINC, faixas de referência (SBPC/ML, SBC, SBD), conversores e importadores para o contexto clínico brasileiro.
+Tipos FHIR R4, 200+ definições de biomarcadores com códigos LOINC, faixas de referência (SBPC/ML, SBC, SBD), conversores e importadores para o contexto clínico brasileiro.
 
 ## Instalação
 
@@ -49,7 +49,7 @@ import { getDefinitionByCode, getAllDefinitions } from '@precisa-saude/fhir';
 const def = getDefinitionByCode('HDL');
 // { code: 'HDL', loinc: '2085-9', names: { pt: [...], en: [...] }, ... }
 
-const all = getAllDefinitions(); // 180+ definições
+const all = getAllDefinitions(); // 200+ definições
 ```
 
 ## Sub-path imports
@@ -69,7 +69,8 @@ import { validateFHIRObservation } from '@precisa-saude/fhir/validators';
 
 | Sub-path            | Descrição                                                             |
 | ------------------- | --------------------------------------------------------------------- |
-| `/biomarkers`       | 180+ definições com códigos LOINC, nomes pt/en, categorias            |
+| `/biomarkers`       | 200+ definições com códigos LOINC, nomes pt/en, sub-categorias        |
+| `/category-groups`  | Agrupamento de 10 categorias clínicas top-level sobre as 20 sub       |
 | `/reference-ranges` | Faixas de referência por sexo/idade/gestação (SBPC/ML, SBC, SBD, OMS) |
 | `/converter`        | Converte dados laboratoriais para FHIR R4 Bundle                      |
 | `/importer`         | Importa FHIR Bundle de volta para estruturas internas                 |

--- a/packages/core/src/__tests__/category-groups.test.ts
+++ b/packages/core/src/__tests__/category-groups.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { BIOMARKER_DEFINITIONS } from '../biomarkers';
+import {
+  CATEGORY_GROUPS,
+  getCategoryGroup,
+  listMappedSubcategories,
+} from '../category-groups';
+
+describe('agrupamento de categorias (10 buckets)', () => {
+  it('expõe exatamente 10 grupos', () => {
+    expect(Object.keys(CATEGORY_GROUPS)).toHaveLength(10);
+  });
+
+  it('cada grupo tem rótulos pt/en não vazios', () => {
+    for (const group of Object.values(CATEGORY_GROUPS)) {
+      expect(group.pt).not.toBe('');
+      expect(group.en).not.toBe('');
+      expect(group.subcategories.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('cobre todas as 20 sub-categorias usadas em BIOMARKER_DEFINITIONS', () => {
+    const usedSubcategories = new Set<string>();
+    for (const def of BIOMARKER_DEFINITIONS) {
+      const cats = Array.isArray(def.category) ? def.category : [def.category];
+      for (const cat of cats) {
+        usedSubcategories.add(cat);
+      }
+    }
+    const mapped = new Set(listMappedSubcategories());
+    for (const cat of usedSubcategories) {
+      expect(mapped.has(cat), `sub-categoria não mapeada: ${cat}`).toBe(true);
+    }
+  });
+
+  it('nenhuma sub-categoria pertence a dois grupos', () => {
+    const seen = new Set<string>();
+    for (const group of Object.values(CATEGORY_GROUPS)) {
+      for (const sub of group.subcategories) {
+        expect(seen.has(sub), `sub-categoria duplicada: ${sub}`).toBe(false);
+        seen.add(sub);
+      }
+    }
+  });
+
+  it('getCategoryGroup retorna undefined para slug desconhecido', () => {
+    expect(getCategoryGroup('slug-inexistente')).toBeUndefined();
+  });
+
+  it('getCategoryGroup mapeia exemplos conhecidos corretamente', () => {
+    expect(getCategoryGroup('coracao')).toBe('cardiovascular');
+    expect(getCategoryGroup('pancreas')).toBe('metabolico-endocrino');
+    expect(getCategoryGroup('saude-feminina')).toBe('saude-reprodutiva');
+    expect(getCategoryGroup('toxinas-ambientais')).toBe('nutricional-ambiental');
+  });
+});

--- a/packages/core/src/__tests__/category-groups.test.ts
+++ b/packages/core/src/__tests__/category-groups.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { BIOMARKER_DEFINITIONS } from '../biomarkers';
-import {
-  CATEGORY_GROUPS,
-  getCategoryGroup,
-  listMappedSubcategories,
-} from '../category-groups';
+import { CATEGORY_GROUPS, getCategoryGroup, listMappedSubcategories } from '../category-groups';
 
 describe('agrupamento de categorias (10 buckets)', () => {
   it('expõe exatamente 10 grupos', () => {

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -2442,6 +2442,219 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
     },
     unit: 'score',
   },
+
+  // ============================================================================
+  // CARDIOVASCULAR MARKERS — Insuficiência cardíaca e dano miocárdico
+  // ============================================================================
+  {
+    category: 'coracao',
+    code: 'NTproBNP',
+    loinc: '33762-6',
+    names: {
+      en: ['NT-proBNP', 'N-Terminal pro B-Type Natriuretic Peptide', 'NT-pro-BNP'],
+      pt: ['NT-proBNP', 'Peptídeo Natriurético Tipo B N-Terminal', 'Pró-BNP N-Terminal'],
+    },
+    unit: 'pg/mL',
+  },
+  {
+    category: 'coracao',
+    code: 'BNP',
+    loinc: '30934-4',
+    names: {
+      en: ['BNP', 'B-Type Natriuretic Peptide', 'Brain Natriuretic Peptide'],
+      pt: ['BNP', 'Peptídeo Natriurético Tipo B', 'Peptídeo Natriurético Cerebral'],
+    },
+    unit: 'pg/mL',
+  },
+  {
+    category: 'coracao',
+    code: 'TroponinI',
+    loinc: '49563-0',
+    names: {
+      en: ['Troponin I', 'cTnI', 'Cardiac Troponin I', 'hs-TnI', 'High-Sensitivity Troponin I'],
+      pt: ['Troponina I', 'cTnI', 'Troponina I Cardíaca', 'Troponina I Ultrassensível'],
+    },
+    unit: 'ng/mL',
+  },
+  {
+    category: 'coracao',
+    code: 'TroponinT',
+    loinc: '6598-7',
+    names: {
+      en: ['Troponin T', 'cTnT', 'Cardiac Troponin T', 'hs-TnT', 'High-Sensitivity Troponin T'],
+      pt: ['Troponina T', 'cTnT', 'Troponina T Cardíaca', 'Troponina T Ultrassensível'],
+    },
+    unit: 'ng/mL',
+  },
+
+  // ============================================================================
+  // COAGULATION — Coagulação
+  // ============================================================================
+  {
+    category: 'sangue',
+    code: 'DDimer',
+    loinc: '48066-5',
+    names: {
+      en: ['D-Dimer', 'D Dimer', 'Fibrin D-Dimer'],
+      pt: ['Dímero-D', 'Dímero D', 'D-Dímero'],
+    },
+    unit: 'ng/mL',
+  },
+  {
+    category: 'sangue',
+    code: 'Fibrinogen',
+    loinc: '3255-7',
+    names: {
+      en: ['Fibrinogen', 'Fibrinogen Activity'],
+      pt: ['Fibrinogênio', 'Atividade do Fibrinogênio'],
+    },
+    unit: 'mg/dL',
+  },
+
+  // ============================================================================
+  // HEMATOLOGY — Hematologia adicional
+  // ============================================================================
+  {
+    category: 'figado',
+    code: 'LDH',
+    loinc: '2532-0',
+    names: {
+      en: ['Lactate Dehydrogenase', 'LDH', 'LD'],
+      pt: ['Desidrogenase Lática', 'DHL', 'LDH', 'Lactato Desidrogenase'],
+    },
+    unit: 'U/L',
+  },
+
+  // ============================================================================
+  // ENDOCRINE — Eixo cálcio/fósforo
+  // ============================================================================
+  {
+    category: 'hormonios',
+    code: 'PTH',
+    loinc: '2731-8',
+    names: {
+      en: ['Parathyroid Hormone', 'PTH', 'Intact PTH'],
+      pt: ['Paratormônio', 'PTH', 'Hormônio da Paratireoide', 'PTH Intacto'],
+    },
+    unit: 'pg/mL',
+  },
+
+  // ============================================================================
+  // IMMUNOLOGY — Complemento e imunoglobulinas
+  // ============================================================================
+  {
+    category: 'autoimunidade',
+    code: 'IgM',
+    loinc: '2472-9',
+    names: {
+      en: ['Immunoglobulin M', 'IgM', 'Total IgM'],
+      pt: ['Imunoglobulina M', 'IgM', 'IgM Total'],
+    },
+    unit: 'mg/dL',
+  },
+  {
+    category: 'autoimunidade',
+    code: 'C3',
+    loinc: '4485-3',
+    names: {
+      en: ['Complement C3', 'C3'],
+      pt: ['Complemento C3', 'C3', 'Fração C3 do Complemento'],
+    },
+    unit: 'mg/dL',
+  },
+  {
+    category: 'autoimunidade',
+    code: 'C4',
+    loinc: '4498-6',
+    names: {
+      en: ['Complement C4', 'C4'],
+      pt: ['Complemento C4', 'C4', 'Fração C4 do Complemento'],
+    },
+    unit: 'mg/dL',
+  },
+
+  // ============================================================================
+  // TUMOR MARKERS — Marcadores tumorais adicionais
+  // ============================================================================
+  {
+    category: 'marcadores-tumorais',
+    code: 'CA199',
+    loinc: '24108-3',
+    names: {
+      en: ['CA 19-9', 'Carbohydrate Antigen 19-9', 'CA19-9'],
+      pt: ['CA 19-9', 'Antígeno Carboidrato 19-9', 'CA19-9'],
+    },
+    unit: 'U/mL',
+  },
+  {
+    category: 'marcadores-tumorais',
+    code: 'CA153',
+    loinc: '6875-9',
+    names: {
+      en: ['CA 15-3', 'Cancer Antigen 15-3', 'CA15-3'],
+      pt: ['CA 15-3', 'Antígeno Câncer 15-3', 'CA15-3'],
+    },
+    sex: 'female',
+    unit: 'U/mL',
+  },
+  {
+    category: ['saude-feminina', 'marcadores-tumorais'],
+    code: 'BetaHCG',
+    loinc: '19080-1',
+    names: {
+      en: ['Beta-hCG', 'Beta Human Chorionic Gonadotropin', 'β-hCG Quantitative', 'hCG'],
+      pt: [
+        'Beta-hCG',
+        'Beta Gonadotrofina Coriônica Humana',
+        'β-hCG Quantitativo',
+        'hCG',
+        'Gonadotrofina Coriônica',
+      ],
+    },
+    unit: 'mIU/mL',
+  },
+
+  // ============================================================================
+  // RENAL — Filtração glomerular alternativa
+  // ============================================================================
+  {
+    category: 'rins',
+    code: 'CystatinC',
+    loinc: '33863-2',
+    names: {
+      en: ['Cystatin C', 'Cystatin-C'],
+      pt: ['Cistatina C', 'Cistatina-C'],
+    },
+    unit: 'mg/L',
+  },
+
+  // ============================================================================
+  // NUTRIENTS — Oligoelementos adicionais
+  // ============================================================================
+  {
+    category: 'nutrientes',
+    code: 'Selenium',
+    loinc: '5697-7',
+    names: {
+      en: ['Selenium', 'Se'],
+      pt: ['Selênio', 'Se'],
+    },
+    unit: 'µg/L',
+  },
+
+  // ============================================================================
+  // METABOLIC — Cetonas séricas
+  // ============================================================================
+  {
+    category: 'pancreas',
+    code: 'BetaHydroxybutyrate',
+    loinc: '53060-0',
+    names: {
+      en: ['Beta-Hydroxybutyrate', 'β-Hydroxybutyrate', 'BHB', 'Ketone Bodies'],
+      pt: ['Beta-Hidroxibutirato', 'β-Hidroxibutirato', 'BHB', 'Corpos Cetônicos'],
+    },
+    unit: 'mmol/L',
+  },
 ];
 
 // ============================================================================

--- a/packages/core/src/category-groups.ts
+++ b/packages/core/src/category-groups.ts
@@ -1,0 +1,118 @@
+/**
+ * Agrupamento de categorias clínicas em 10 grupos de alto nível.
+ *
+ * `BiomarkerDefinition.category` armazena 20 sub-categorias (granularidade
+ * fina, ex: `tireoide`, `pancreas`). Este módulo agrupa essas
+ * sub-categorias em 10 buckets clínicos amplos para apresentação no
+ * site, na API pública e em material de divulgação.
+ *
+ * As sub-categorias permanecem como fonte da verdade nos dados; este
+ * agrupamento é uma camada derivada.
+ */
+
+export type CategoryGroup =
+  | 'cardiovascular'
+  | 'metabolico-endocrino'
+  | 'renal-eletrolitico'
+  | 'hepatico-biliar'
+  | 'hematologico'
+  | 'imunologico'
+  | 'oncologico'
+  | 'nutricional-ambiental'
+  | 'saude-reprodutiva'
+  | 'composicao-envelhecimento';
+
+export interface CategoryGroupInfo {
+  /** Sub-categorias da fonte agrupadas neste bucket */
+  subcategories: readonly string[];
+  /** Slug (kebab-case, sem acento) */
+  slug: CategoryGroup;
+  /** Rótulo em português */
+  pt: string;
+  /** Rótulo em inglês */
+  en: string;
+}
+
+export const CATEGORY_GROUPS: Record<CategoryGroup, CategoryGroupInfo> = {
+  cardiovascular: {
+    en: 'Cardiovascular',
+    pt: 'Cardiovascular',
+    slug: 'cardiovascular',
+    subcategories: ['coracao'],
+  },
+  'metabolico-endocrino': {
+    en: 'Metabolic & Endocrine',
+    pt: 'Metabólico e Endócrino',
+    slug: 'metabolico-endocrino',
+    subcategories: ['metabolico', 'pancreas', 'hormonios', 'tireoide'],
+  },
+  'renal-eletrolitico': {
+    en: 'Renal & Electrolytes',
+    pt: 'Renal e Eletrolítico',
+    slug: 'renal-eletrolitico',
+    subcategories: ['rins', 'urina', 'eletrolitos'],
+  },
+  'hepatico-biliar': {
+    en: 'Hepatic & Biliary',
+    pt: 'Hepático e Biliar',
+    slug: 'hepatico-biliar',
+    subcategories: ['figado'],
+  },
+  hematologico: {
+    en: 'Hematology',
+    pt: 'Hematológico',
+    slug: 'hematologico',
+    subcategories: ['sangue'],
+  },
+  imunologico: {
+    en: 'Immunology',
+    pt: 'Imunológico',
+    slug: 'imunologico',
+    subcategories: ['autoimunidade', 'regulacao-imunologica'],
+  },
+  oncologico: {
+    en: 'Oncology',
+    pt: 'Oncológico',
+    slug: 'oncologico',
+    subcategories: ['marcadores-tumorais'],
+  },
+  'nutricional-ambiental': {
+    en: 'Nutrition & Environmental Exposure',
+    pt: 'Nutricional e Exposição Ambiental',
+    slug: 'nutricional-ambiental',
+    subcategories: ['nutrientes', 'toxinas-ambientais'],
+  },
+  'saude-reprodutiva': {
+    en: 'Reproductive Health',
+    pt: 'Saúde Reprodutiva',
+    slug: 'saude-reprodutiva',
+    subcategories: ['saude-feminina', 'saude-masculina'],
+  },
+  'composicao-envelhecimento': {
+    en: 'Body Composition & Aging',
+    pt: 'Composição Corporal e Envelhecimento',
+    slug: 'composicao-envelhecimento',
+    subcategories: ['composicao-corporal', 'densidade-ossea', 'estresse-envelhecimento'],
+  },
+};
+
+const SUBCATEGORY_TO_GROUP = new Map<string, CategoryGroup>();
+for (const group of Object.values(CATEGORY_GROUPS)) {
+  for (const sub of group.subcategories) {
+    SUBCATEGORY_TO_GROUP.set(sub, group.slug);
+  }
+}
+
+/**
+ * Resolve a sub-categoria (granular) para o grupo de alto nível (10 buckets).
+ */
+export function getCategoryGroup(subcategory: string): CategoryGroup | undefined {
+  return SUBCATEGORY_TO_GROUP.get(subcategory);
+}
+
+/**
+ * Lista todas as sub-categorias mapeadas em algum grupo.
+ */
+export function listMappedSubcategories(): readonly string[] {
+  return [...SUBCATEGORY_TO_GROUP.keys()];
+}

--- a/packages/core/src/category-groups.ts
+++ b/packages/core/src/category-groups.ts
@@ -23,14 +23,14 @@ export type CategoryGroup =
   | 'composicao-envelhecimento';
 
 export interface CategoryGroupInfo {
-  /** Sub-categorias da fonte agrupadas neste bucket */
-  subcategories: readonly string[];
-  /** Slug (kebab-case, sem acento) */
-  slug: CategoryGroup;
-  /** Rótulo em português */
-  pt: string;
   /** Rótulo em inglês */
   en: string;
+  /** Rótulo em português */
+  pt: string;
+  /** Slug (kebab-case, sem acento) */
+  slug: CategoryGroup;
+  /** Sub-categorias da fonte agrupadas neste bucket */
+  subcategories: readonly string[];
 }
 
 export const CATEGORY_GROUPS: Record<CategoryGroup, CategoryGroupInfo> = {
@@ -40,23 +40,11 @@ export const CATEGORY_GROUPS: Record<CategoryGroup, CategoryGroupInfo> = {
     slug: 'cardiovascular',
     subcategories: ['coracao'],
   },
-  'metabolico-endocrino': {
-    en: 'Metabolic & Endocrine',
-    pt: 'Metabólico e Endócrino',
-    slug: 'metabolico-endocrino',
-    subcategories: ['metabolico', 'pancreas', 'hormonios', 'tireoide'],
-  },
-  'renal-eletrolitico': {
-    en: 'Renal & Electrolytes',
-    pt: 'Renal e Eletrolítico',
-    slug: 'renal-eletrolitico',
-    subcategories: ['rins', 'urina', 'eletrolitos'],
-  },
-  'hepatico-biliar': {
-    en: 'Hepatic & Biliary',
-    pt: 'Hepático e Biliar',
-    slug: 'hepatico-biliar',
-    subcategories: ['figado'],
+  'composicao-envelhecimento': {
+    en: 'Body Composition & Aging',
+    pt: 'Composição Corporal e Envelhecimento',
+    slug: 'composicao-envelhecimento',
+    subcategories: ['composicao-corporal', 'densidade-ossea', 'estresse-envelhecimento'],
   },
   hematologico: {
     en: 'Hematology',
@@ -64,17 +52,23 @@ export const CATEGORY_GROUPS: Record<CategoryGroup, CategoryGroupInfo> = {
     slug: 'hematologico',
     subcategories: ['sangue'],
   },
+  'hepatico-biliar': {
+    en: 'Hepatic & Biliary',
+    pt: 'Hepático e Biliar',
+    slug: 'hepatico-biliar',
+    subcategories: ['figado'],
+  },
   imunologico: {
     en: 'Immunology',
     pt: 'Imunológico',
     slug: 'imunologico',
     subcategories: ['autoimunidade', 'regulacao-imunologica'],
   },
-  oncologico: {
-    en: 'Oncology',
-    pt: 'Oncológico',
-    slug: 'oncologico',
-    subcategories: ['marcadores-tumorais'],
+  'metabolico-endocrino': {
+    en: 'Metabolic & Endocrine',
+    pt: 'Metabólico e Endócrino',
+    slug: 'metabolico-endocrino',
+    subcategories: ['metabolico', 'pancreas', 'hormonios', 'tireoide'],
   },
   'nutricional-ambiental': {
     en: 'Nutrition & Environmental Exposure',
@@ -82,17 +76,23 @@ export const CATEGORY_GROUPS: Record<CategoryGroup, CategoryGroupInfo> = {
     slug: 'nutricional-ambiental',
     subcategories: ['nutrientes', 'toxinas-ambientais'],
   },
+  oncologico: {
+    en: 'Oncology',
+    pt: 'Oncológico',
+    slug: 'oncologico',
+    subcategories: ['marcadores-tumorais'],
+  },
+  'renal-eletrolitico': {
+    en: 'Renal & Electrolytes',
+    pt: 'Renal e Eletrolítico',
+    slug: 'renal-eletrolitico',
+    subcategories: ['rins', 'urina', 'eletrolitos'],
+  },
   'saude-reprodutiva': {
     en: 'Reproductive Health',
     pt: 'Saúde Reprodutiva',
     slug: 'saude-reprodutiva',
     subcategories: ['saude-feminina', 'saude-masculina'],
-  },
-  'composicao-envelhecimento': {
-    en: 'Body Composition & Aging',
-    pt: 'Composição Corporal e Envelhecimento',
-    slug: 'composicao-envelhecimento',
-    subcategories: ['composicao-corporal', 'densidade-ossea', 'estresse-envelhecimento'],
   },
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,9 @@ export type {
 // Export biomarker definitions (single source of truth)
 export * from './biomarkers';
 
+// Export 10-group taxonomy over the 20 biomarker subcategories
+export * from './category-groups';
+
 // Export unit mappings and configurations
 export * from './units';
 

--- a/packages/rnds-sandbox/Dockerfile
+++ b/packages/rnds-sandbox/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22-alpine
+
+RUN apk add --no-cache tini \
+  && npm install -g @precisa-saude/fhir-rnds-sandbox
+
+EXPOSE 8080
+ENTRYPOINT ["/sbin/tini", "--", "rnds-sandbox"]
+CMD ["start", "--host", "0.0.0.0"]

--- a/packages/rnds-sandbox/README.md
+++ b/packages/rnds-sandbox/README.md
@@ -1,0 +1,324 @@
+# @precisa-saude/fhir-rnds-sandbox
+
+> Mock local da RNDS (Rede Nacional de Dados em Saúde) — endpoints FHIR R4
+> com cenários sintéticos para desenvolvimento, ensino e demos.
+
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+Sem certificado ICP-Brasil. Sem credenciamento DATASUS. Roda em segundos.
+
+## Por que existe
+
+Testar uma integração com a RNDS em produção exige certificado ICP-Brasil
+(SERPRO/AC) e homologação no DATASUS — meses de papelada. Esse atrito trava
+hackathons, aulas, PoCs e a adoção de qualquer cliente RNDS, inclusive o
+nosso (`@precisa-saude/fhir-rnds`).
+
+`rnds-sandbox` é um servidor HTTP leve que implementa o subset de endpoints
+FHIR R4 que clientes RNDS usam de fato — busca de paciente por CPF/CNS,
+consulta de organização (CNES) e profissional (CNS), e submissão de Bundle.
+Os dados são sintéticos, claramente falsos e versionados em cenários
+nomeados.
+
+## Instalação
+
+```bash
+npx @precisa-saude/fhir-rnds-sandbox start
+```
+
+Ou como dependência:
+
+```bash
+pnpm add -D @precisa-saude/fhir-rnds-sandbox
+```
+
+## Uso — CLI
+
+```bash
+# sobe na porta padrão 8080 com cenário "paciente-com-exames"
+rnds-sandbox start
+
+# escolhe cenário e porta
+rnds-sandbox start --port 9000 --scenario internacao
+
+# habilita mTLS (cliente precisa apresentar certificado)
+rnds-sandbox start --mtls --pfx ./dev-cert.pfx --pfx-password senha
+
+# lista cenários disponíveis
+rnds-sandbox scenarios
+```
+
+## Uso — programático
+
+```ts
+import { createSandboxServer } from '@precisa-saude/fhir-rnds-sandbox';
+
+const sandbox = createSandboxServer({
+  scenario: 'paciente-com-exames',
+  port: 0, // porta efêmera — útil em testes
+});
+
+const { host, port } = await sandbox.start();
+console.log(`sandbox em http://${host}:${port}`);
+
+// ... rode seus testes ...
+
+await sandbox.stop();
+```
+
+## Cenários
+
+| Nome | Descrição |
+| ---- | --------- |
+| `paciente-com-exames` | Joana da Silva, 42 anos, com lipidograma + glicemia codificados em LOINC. (padrão) |
+| `internacao` | Carlos Souza, 67, internado por insuficiência cardíaca (CID I50.0), com NT-proBNP e troponina. |
+| `vacina` | Pedro Almeida, 8 anos, com calendário vacinal aplicado (BCG, hepatite B, tríplice viral). |
+| `vazio` | Estado limpo. Útil para testar fluxos do zero. |
+
+Identificadores sintéticos usados nos cenários:
+
+| CPF | CNS | Cenário |
+| --- | --- | ------- |
+| `12345678901` | `700000000000001` | paciente-com-exames |
+| `98765432100` | `700000000000020` | internacao |
+| _(sem CPF)_ | `700000000000040` | vacina |
+
+CNES dos estabelecimentos: `2345678` (lab), `3456789` (hospital), `4567890` (UBS).
+
+### Exemplos por cenário
+
+Todos os exemplos assumem o sandbox rodando em `http://127.0.0.1:8080`. Os
+campos `submittedBundles` listados em cada cenário ficam disponíveis via
+`sandbox.store.getSubmittedBundles()` na API programática (ou seja, são
+"histórico" do paciente — o cliente os consome via outras consultas, não
+por um endpoint dedicado).
+
+#### `paciente-com-exames` (padrão)
+
+```bash
+rnds-sandbox start
+```
+
+Buscar paciente por CPF:
+
+```bash
+$ curl -s "http://127.0.0.1:8080/api/fhir/r4/Patient?identifier=$(printf 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|12345678901' | jq -sRr @uri)"
+```
+
+```json
+{
+  "resourceType": "Patient",
+  "id": "700000000000001",
+  "identifier": [
+    { "system": "http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf", "value": "12345678901" },
+    { "system": "http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns", "value": "700000000000001" }
+  ],
+  "name": [{ "family": "Silva", "given": ["Joana", "Maria", "da"] }],
+  "gender": "female",
+  "birthDate": "1983-08-12"
+}
+```
+
+Histórico pré-carregado (Bundle de lipidograma + glicemia, todas as
+Observations codificadas em LOINC):
+
+| LOINC | Biomarcador | Valor |
+| ----- | ----------- | ----- |
+| `2093-3` | Colesterol total | 198 mg/dL |
+| `2089-1` | LDL-Colesterol | 124 mg/dL |
+| `2085-9` | HDL-Colesterol | 56 mg/dL |
+| `2345-7` | Glicose | 96 mg/dL |
+
+Submeter um novo Bundle (resposta abaixo):
+
+```bash
+$ curl -s -X POST http://127.0.0.1:8080/api/fhir/r4/Bundle \
+    -H "Content-Type: application/fhir+json" \
+    -d '{"resourceType":"Bundle","type":"transaction","entry":[{"request":{"method":"POST","url":"Observation"},"resource":{"resourceType":"Observation","status":"final","code":{"coding":[{"system":"http://loinc.org","code":"2345-7","display":"Glicose"}]},"valueQuantity":{"value":102,"unit":"mg/dL","system":"http://unitsofmeasure.org","code":"mg/dL"}}}]}'
+```
+
+```json
+{
+  "resourceType": "Bundle",
+  "type": "transaction-response",
+  "entry": [{ "response": { "status": "201 Created", "location": "Resource/sandbox-1" } }]
+}
+```
+
+#### `internacao`
+
+```bash
+rnds-sandbox start --scenario internacao
+```
+
+Buscar paciente por CNS:
+
+```bash
+$ curl -s http://127.0.0.1:8080/api/fhir/r4/Patient/700000000000020
+```
+
+```json
+{
+  "resourceType": "Patient",
+  "id": "700000000000020",
+  "identifier": [
+    { "system": "http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf", "value": "98765432100" },
+    { "system": "http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns", "value": "700000000000020" }
+  ],
+  "name": [{ "family": "Souza", "given": ["Carlos", "Henrique"] }],
+  "gender": "male",
+  "birthDate": "1958-02-28"
+}
+```
+
+Buscar o hospital (Organization) pelo CNES:
+
+```bash
+$ curl -s http://127.0.0.1:8080/api/fhir/r4/Organization/3456789
+```
+
+```json
+{
+  "resourceType": "Organization",
+  "id": "3456789",
+  "active": true,
+  "identifier": [
+    { "system": "http://rnds.saude.gov.br/fhir/r4/NamingSystem/cnes", "value": "3456789" }
+  ],
+  "name": "Hospital Sintético do Coração (sandbox)"
+}
+```
+
+Histórico pré-carregado:
+
+| Recurso | Detalhe |
+| ------- | ------- |
+| `Encounter` | classe `IMP` (inpatient), iniciado em 2026-04-15 |
+| `Condition` | CID-10 `I50.0` (Insuficiência cardíaca congestiva) |
+| `Observation` LOINC `33762-6` | NT-proBNP — 4820 pg/mL |
+| `Observation` LOINC `49563-0` | Troponina I — 0.08 ng/mL |
+
+#### `vacina`
+
+```bash
+rnds-sandbox start --scenario vacina
+```
+
+Buscar o paciente pediátrico:
+
+```bash
+$ curl -s http://127.0.0.1:8080/api/fhir/r4/Patient/700000000000040
+```
+
+```json
+{
+  "resourceType": "Patient",
+  "id": "700000000000040",
+  "identifier": [
+    { "system": "http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns", "value": "700000000000040" }
+  ],
+  "name": [{ "family": "Almeida", "given": ["Pedro", "Lima"] }],
+  "gender": "male",
+  "birthDate": "2017-11-04"
+}
+```
+
+Histórico pré-carregado (3 `Immunization`, sistema PNI/CVP
+`urn:oid:2.16.840.1.113883.6.59`):
+
+| Vacina | Código | Data |
+| ------ | ------ | ---- |
+| BCG | `BCG` | 2017-11-05 |
+| Hepatite B (RN) | `HBV` | 2017-11-05 |
+| Tríplice viral (SCR) | `MMR` | 2018-12-12 |
+
+#### `vazio`
+
+```bash
+rnds-sandbox start --scenario vazio
+```
+
+Toda consulta de leitura retorna `404 OperationOutcome`. Útil para
+exercitar o caminho de erro do cliente:
+
+```bash
+$ curl -s -i http://127.0.0.1:8080/api/fhir/r4/Patient/700000000000001 | head -1
+HTTP/1.1 404 Not Found
+```
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "not-found",
+      "diagnostics": "Paciente CNS 700000000000001 não encontrado"
+    }
+  ]
+}
+```
+
+## Endpoints
+
+Compatível com o subset usado por `@precisa-saude/fhir-rnds`:
+
+| Método | Path | Descrição |
+| ------ | ---- | --------- |
+| `POST` | `/api/token` | Emite token JWT (sem assinatura criptográfica real). |
+| `GET` | `/api/fhir/r4/Patient?identifier={system}\|{value}` | Busca por CPF (`.../cpf`) ou CNS (`.../cns`). |
+| `GET` | `/api/fhir/r4/Patient/{cns}` | Lê paciente por CNS. |
+| `GET` | `/api/fhir/r4/Organization/{cnes}` | Lê estabelecimento por CNES. |
+| `GET` | `/api/fhir/r4/Practitioner/{cns}` | Lê profissional por CNS. |
+| `POST` | `/api/fhir/r4/Bundle` | Aceita Bundle transaction/batch e retorna transaction-response. |
+
+Recursos não encontrados retornam `404` com `OperationOutcome`.
+
+## mTLS opcional
+
+Por padrão o sandbox usa HTTP sem certificado — basta cURL/fetch. Para
+exercitar o handshake mTLS que a RNDS exige em produção (incluindo o
+caminho de autenticação), suba com `--mtls`. Você precisa de um PFX para o
+servidor (qualquer cert auto-assinado serve para dev).
+
+```bash
+# gera cert auto-assinado para teste local (uma vez)
+openssl req -newkey rsa:2048 -nodes -keyout dev.key -x509 \
+  -days 365 -out dev.crt -subj "/CN=rnds-sandbox.local"
+openssl pkcs12 -export -out dev.pfx -inkey dev.key -in dev.crt -password pass:dev
+
+rnds-sandbox start --mtls --pfx ./dev.pfx --pfx-password dev
+```
+
+O sandbox aceita certificados não confiáveis (`rejectUnauthorized: false`)
+para que clientes possam testar o fluxo sem PKI completa.
+
+## Docker
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/precisa-saude/fhir-rnds-sandbox:latest
+```
+
+Escolha cenário e porta:
+
+```bash
+docker run --rm -p 9000:9000 ghcr.io/precisa-saude/fhir-rnds-sandbox:latest \
+  start --port 9000 --scenario internacao
+```
+
+## Aviso de produção
+
+Este pacote é estritamente para **desenvolvimento, testes e ensino**.
+Tokens emitidos não têm assinatura criptográfica válida. Dados são
+sintéticos. Não submeta dados de pacientes reais a este servidor — ele
+apenas armazena em memória e perde o estado quando reinicia.
+
+## Aviso médico
+
+Os recursos FHIR retornados pelo sandbox **não constituem** registros de
+saúde reais. Cenários são fictícios e ilustrativos. Não use para tomar
+decisões clínicas.
+
+## Licença
+
+Apache-2.0 © Precisa Saúde

--- a/packages/rnds-sandbox/README.md
+++ b/packages/rnds-sandbox/README.md
@@ -263,35 +263,112 @@ HTTP/1.1 404 Not Found
 
 Compatível com o subset usado por `@precisa-saude/fhir-rnds`:
 
-| Método | Path | Descrição |
-| ------ | ---- | --------- |
-| `POST` | `/api/token` | Emite token JWT (sem assinatura criptográfica real). |
-| `GET` | `/api/fhir/r4/Patient?identifier={system}\|{value}` | Busca por CPF (`.../cpf`) ou CNS (`.../cns`). |
-| `GET` | `/api/fhir/r4/Patient/{cns}` | Lê paciente por CNS. |
-| `GET` | `/api/fhir/r4/Organization/{cnes}` | Lê estabelecimento por CNES. |
-| `GET` | `/api/fhir/r4/Practitioner/{cns}` | Lê profissional por CNS. |
-| `POST` | `/api/fhir/r4/Bundle` | Aceita Bundle transaction/batch e retorna transaction-response. |
+| Método | Path | Auth (modo strict) | Descrição |
+| ------ | ---- | ------------------ | --------- |
+| `POST` | `/api/token` | mTLS (cert do cliente) | Emite token JWT assinado em RS256. |
+| `GET`  | `/.well-known/jwks.json` | público | Chave pública (JWK) usada para verificar a assinatura do token. |
+| `GET`  | `/api/fhir/r4/Patient?identifier={system}\|{value}` | bearer + CNS | Busca por CPF (`.../cpf`) ou CNS (`.../cns`). |
+| `GET`  | `/api/fhir/r4/Patient/{cns}` | bearer + CNS | Lê paciente por CNS. |
+| `GET`  | `/api/fhir/r4/Organization/{cnes}` | bearer + CNS | Lê estabelecimento por CNES. |
+| `GET`  | `/api/fhir/r4/Practitioner/{cns}` | bearer + CNS | Lê profissional por CNS. |
+| `POST` | `/api/fhir/r4/Bundle` | bearer + CNS | Aceita Bundle transaction/batch e retorna transaction-response. |
 
-Recursos não encontrados retornam `404` com `OperationOutcome`.
+Em modo **permissivo** (padrão sem flags) nenhum auth é exigido — qualquer
+curl entra. Recursos não encontrados retornam `404` com `OperationOutcome`.
+Endpoints FHIR exigem dois headers em modo strict (igual à API real):
 
-## mTLS opcional
+- `X-Authorization-Server: Bearer <jwt>` — token RS256 emitido pelo sandbox
+- `Authorization: <CNS>` — CNS de 15 dígitos do profissional requisitante
 
-Por padrão o sandbox usa HTTP sem certificado — basta cURL/fetch. Para
-exercitar o handshake mTLS que a RNDS exige em produção (incluindo o
-caminho de autenticação), suba com `--mtls`. Você precisa de um PFX para o
-servidor (qualquer cert auto-assinado serve para dev).
+## Modos de fidelidade
+
+O sandbox tem três modos. Escolha o que combina com o que você quer
+demonstrar/testar:
+
+| Modo | Como ativar | Comportamento |
+| ---- | ----------- | ------------- |
+| **Permissivo** | (sem flags) | HTTP puro, qualquer chamada aceita. Útil para curl, aulas e iteração rápida. |
+| **Strict** | `--strict` | HTTP, mas /api/fhir/r4/* exige bearer + CNS, e /api/token exige cert mTLS apresentado (rejeita sem). Útil para validar a lógica de auth do cliente sem precisar configurar TLS. |
+| **mTLS** | `--mtls` (implica strict) | HTTPS com handshake mTLS opcional do cliente. Réplica fiel da RNDS: cert exigido em /api/token; FHIR API exige bearer. |
+
+### JWT — RS256 com JWKS
+
+O token é um JWT RS256 real, assinado com uma chave RSA-2048. Por padrão
+a chave é gerada **efêmera** no boot — bom para devs que rodam o sandbox
+em sessões curtas. Em CI/demos onde você quer reusar o mesmo token entre
+restarts, passe `--jwt-private-key`:
 
 ```bash
-# gera cert auto-assinado para teste local (uma vez)
-openssl req -newkey rsa:2048 -nodes -keyout dev.key -x509 \
-  -days 365 -out dev.crt -subj "/CN=rnds-sandbox.local"
-openssl pkcs12 -export -out dev.pfx -inkey dev.key -in dev.crt -password pass:dev
+# gere uma chave estável (uma vez)
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt.pem
 
-rnds-sandbox start --mtls --pfx ./dev.pfx --pfx-password dev
+rnds-sandbox start --strict --jwt-private-key ./jwt.pem
 ```
 
-O sandbox aceita certificados não confiáveis (`rejectUnauthorized: false`)
-para que clientes possam testar o fluxo sem PKI completa.
+A chave pública é exposta via `/.well-known/jwks.json`. Bibliotecas de JWT
+(`jose`, `jsonwebtoken`, `jwt.io` com a URL do JWKS) podem verificar a
+assinatura sem configuração fora-de-banda:
+
+```bash
+$ curl -s http://127.0.0.1:8080/.well-known/jwks.json | jq
+{
+  "keys": [
+    {
+      "alg": "RS256",
+      "e": "AQAB",
+      "kid": "rnds-sandbox-1",
+      "kty": "RSA",
+      "n": "qdg8rAyVCT0s7UA4YM_j6fjjLt_-0huK7sQyLT...",
+      "use": "sig"
+    }
+  ]
+}
+```
+
+### mTLS na prática
+
+Você precisa de um cert para o **servidor**. Qualquer cert auto-assinado
+serve, ou use o que já tiver (cert ICP-Brasil de homologação, por
+exemplo). O sandbox aceita certs de cliente sem validar a CA
+(`rejectUnauthorized: false`) — propósito: dev, não produção.
+
+```bash
+# 1. Gere cert auto-assinado para o servidor (uma vez)
+openssl req -newkey rsa:2048 -nodes -keyout srv.key -x509 \
+  -days 365 -out srv.crt -subj "/CN=rnds-sandbox.local"
+
+# 2. Suba com mTLS — aceita PFX OU key+cert PEM
+rnds-sandbox start --mtls --server-key ./srv.key --server-cert ./srv.crt
+
+# (alternativa) PFX:
+openssl pkcs12 -export -out srv.pfx -inkey srv.key -in srv.crt -password pass:dev
+rnds-sandbox start --mtls --pfx ./srv.pfx --pfx-password dev
+```
+
+Para apresentar um cert de cliente no curl (e receber CN/CNES embutidos
+no token):
+
+```bash
+# Gere um cert de cliente que embute CNES "1234567" no CN
+openssl req -newkey rsa:2048 -nodes -keyout client.key -x509 \
+  -days 365 -out client.crt \
+  -subj "/CN=PRECISA SAUDE LTDA:1234567"
+
+# Pega token via mTLS — note --cacert + --cert
+TOKEN=$(curl -sk \
+  --cert client.crt --key client.key \
+  -X POST https://127.0.0.1:8443/api/token | jq -r .access_token)
+
+# Decodifique para conferir cn/cnes nas claims (jwt.io ou jq):
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq
+# → { "iss": "...", "sub": "PRECISA SAUDE LTDA:1234567",
+#     "cnes": "1234567", "cn": "PRECISA SAUDE LTDA:1234567", ... }
+
+# Use o token + CNS do profissional na chamada FHIR:
+curl -sk https://127.0.0.1:8443/api/fhir/r4/Patient/700000000000001 \
+  -H "X-Authorization-Server: Bearer $TOKEN" \
+  -H "Authorization: 700000000000010"
+```
 
 ## Docker
 
@@ -309,9 +386,11 @@ docker run --rm -p 9000:9000 ghcr.io/precisa-saude/fhir-rnds-sandbox:latest \
 ## Aviso de produção
 
 Este pacote é estritamente para **desenvolvimento, testes e ensino**.
-Tokens emitidos não têm assinatura criptográfica válida. Dados são
-sintéticos. Não submeta dados de pacientes reais a este servidor — ele
-apenas armazena em memória e perde o estado quando reinicia.
+Tokens são RS256-assinados, mas com chave gerada localmente (não da RNDS)
+— a assinatura é cryptograficamente válida no escopo do sandbox e nada
+mais. Dados são sintéticos. Não submeta dados de pacientes reais a este
+servidor — ele apenas armazena em memória e perde o estado quando
+reinicia.
 
 ## Aviso médico
 

--- a/packages/rnds-sandbox/README.md
+++ b/packages/rnds-sandbox/README.md
@@ -68,20 +68,20 @@ await sandbox.stop();
 
 ## Cenários
 
-| Nome | Descrição |
-| ---- | --------- |
-| `paciente-com-exames` | Joana da Silva, 42 anos, com lipidograma + glicemia codificados em LOINC. (padrão) |
-| `internacao` | Carlos Souza, 67, internado por insuficiência cardíaca (CID I50.0), com NT-proBNP e troponina. |
-| `vacina` | Pedro Almeida, 8 anos, com calendário vacinal aplicado (BCG, hepatite B, tríplice viral). |
-| `vazio` | Estado limpo. Útil para testar fluxos do zero. |
+| Nome                  | Descrição                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| `paciente-com-exames` | Joana da Silva, 42 anos, com lipidograma + glicemia codificados em LOINC. (padrão)             |
+| `internacao`          | Carlos Souza, 67, internado por insuficiência cardíaca (CID I50.0), com NT-proBNP e troponina. |
+| `vacina`              | Pedro Almeida, 8 anos, com calendário vacinal aplicado (BCG, hepatite B, tríplice viral).      |
+| `vazio`               | Estado limpo. Útil para testar fluxos do zero.                                                 |
 
 Identificadores sintéticos usados nos cenários:
 
-| CPF | CNS | Cenário |
-| --- | --- | ------- |
+| CPF           | CNS               | Cenário             |
+| ------------- | ----------------- | ------------------- |
 | `12345678901` | `700000000000001` | paciente-com-exames |
-| `98765432100` | `700000000000020` | internacao |
-| _(sem CPF)_ | `700000000000040` | vacina |
+| `98765432100` | `700000000000020` | internacao          |
+| _(sem CPF)_   | `700000000000040` | vacina              |
 
 CNES dos estabelecimentos: `2345678` (lab), `3456789` (hospital), `4567890` (UBS).
 
@@ -122,12 +122,12 @@ $ curl -s "http://127.0.0.1:8080/api/fhir/r4/Patient?identifier=$(printf 'http:/
 Histórico pré-carregado (Bundle de lipidograma + glicemia, todas as
 Observations codificadas em LOINC):
 
-| LOINC | Biomarcador | Valor |
-| ----- | ----------- | ----- |
+| LOINC    | Biomarcador      | Valor     |
+| -------- | ---------------- | --------- |
 | `2093-3` | Colesterol total | 198 mg/dL |
-| `2089-1` | LDL-Colesterol | 124 mg/dL |
-| `2085-9` | HDL-Colesterol | 56 mg/dL |
-| `2345-7` | Glicose | 96 mg/dL |
+| `2089-1` | LDL-Colesterol   | 124 mg/dL |
+| `2085-9` | HDL-Colesterol   | 56 mg/dL  |
+| `2345-7` | Glicose          | 96 mg/dL  |
 
 Submeter um novo Bundle (resposta abaixo):
 
@@ -191,12 +191,12 @@ $ curl -s http://127.0.0.1:8080/api/fhir/r4/Organization/3456789
 
 Histórico pré-carregado:
 
-| Recurso | Detalhe |
-| ------- | ------- |
-| `Encounter` | classe `IMP` (inpatient), iniciado em 2026-04-15 |
-| `Condition` | CID-10 `I50.0` (Insuficiência cardíaca congestiva) |
-| `Observation` LOINC `33762-6` | NT-proBNP — 4820 pg/mL |
-| `Observation` LOINC `49563-0` | Troponina I — 0.08 ng/mL |
+| Recurso                       | Detalhe                                            |
+| ----------------------------- | -------------------------------------------------- |
+| `Encounter`                   | classe `IMP` (inpatient), iniciado em 2026-04-15   |
+| `Condition`                   | CID-10 `I50.0` (Insuficiência cardíaca congestiva) |
+| `Observation` LOINC `33762-6` | NT-proBNP — 4820 pg/mL                             |
+| `Observation` LOINC `49563-0` | Troponina I — 0.08 ng/mL                           |
 
 #### `vacina`
 
@@ -226,11 +226,11 @@ $ curl -s http://127.0.0.1:8080/api/fhir/r4/Patient/700000000000040
 Histórico pré-carregado (3 `Immunization`, sistema PNI/CVP
 `urn:oid:2.16.840.1.113883.6.59`):
 
-| Vacina | Código | Data |
-| ------ | ------ | ---- |
-| BCG | `BCG` | 2017-11-05 |
-| Hepatite B (RN) | `HBV` | 2017-11-05 |
-| Tríplice viral (SCR) | `MMR` | 2018-12-12 |
+| Vacina               | Código | Data       |
+| -------------------- | ------ | ---------- |
+| BCG                  | `BCG`  | 2017-11-05 |
+| Hepatite B (RN)      | `HBV`  | 2017-11-05 |
+| Tríplice viral (SCR) | `MMR`  | 2018-12-12 |
 
 #### `vazio`
 
@@ -263,15 +263,16 @@ HTTP/1.1 404 Not Found
 
 Compatível com o subset usado por `@precisa-saude/fhir-rnds`:
 
-| Método | Path | Auth (modo strict) | Descrição |
-| ------ | ---- | ------------------ | --------- |
-| `POST` | `/api/token` | mTLS (cert do cliente) | Emite token JWT assinado em RS256. |
-| `GET`  | `/.well-known/jwks.json` | público | Chave pública (JWK) usada para verificar a assinatura do token. |
-| `GET`  | `/api/fhir/r4/Patient?identifier={system}\|{value}` | bearer + CNS | Busca por CPF (`.../cpf`) ou CNS (`.../cns`). |
-| `GET`  | `/api/fhir/r4/Patient/{cns}` | bearer + CNS | Lê paciente por CNS. |
-| `GET`  | `/api/fhir/r4/Organization/{cnes}` | bearer + CNS | Lê estabelecimento por CNES. |
-| `GET`  | `/api/fhir/r4/Practitioner/{cns}` | bearer + CNS | Lê profissional por CNS. |
-| `POST` | `/api/fhir/r4/Bundle` | bearer + CNS | Aceita Bundle transaction/batch e retorna transaction-response. |
+| Método | Path                                                                                                     | Auth (modo strict)     | Descrição                                                                                                                |
+| ------ | -------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `POST` | `/api/token`                                                                                             | mTLS (cert do cliente) | Emite token JWT assinado em RS256.                                                                                       |
+| `GET`  | `/.well-known/jwks.json`                                                                                 | público                | Chave pública (JWK) usada para verificar a assinatura do token.                                                          |
+| `GET`  | `/api/fhir/r4/Patient?identifier={system}\|{value}`                                                      | bearer + CNS           | Busca por CPF (`.../cpf`) ou CNS (`.../cns`).                                                                            |
+| `GET`  | `/api/fhir/r4/Patient/{cns}`                                                                             | bearer + CNS           | Lê paciente por CNS.                                                                                                     |
+| `GET`  | `/api/fhir/r4/Organization/{cnes}`                                                                       | bearer + CNS           | Lê estabelecimento por CNES.                                                                                             |
+| `GET`  | `/api/fhir/r4/Practitioner/{cns}`                                                                        | bearer + CNS           | Lê profissional por CNS.                                                                                                 |
+| `POST` | `/api/fhir/r4/Bundle`                                                                                    | bearer + CNS           | Aceita Bundle transaction/batch e retorna transaction-response.                                                          |
+| `GET`  | `/api/fhir/r4/{Observation\|DiagnosticReport\|Immunization\|Condition\|Encounter}?subject=Patient/{cns}` | bearer + CNS           | Retorna searchset Bundle com recursos pré-carregados + submetidos. Aceita também `?patient=...` ou só o CNS sem prefixo. |
 
 Em modo **permissivo** (padrão sem flags) nenhum auth é exigido — qualquer
 curl entra. Recursos não encontrados retornam `404` com `OperationOutcome`.
@@ -285,11 +286,11 @@ Endpoints FHIR exigem dois headers em modo strict (igual à API real):
 O sandbox tem três modos. Escolha o que combina com o que você quer
 demonstrar/testar:
 
-| Modo | Como ativar | Comportamento |
-| ---- | ----------- | ------------- |
-| **Permissivo** | (sem flags) | HTTP puro, qualquer chamada aceita. Útil para curl, aulas e iteração rápida. |
-| **Strict** | `--strict` | HTTP, mas /api/fhir/r4/* exige bearer + CNS, e /api/token exige cert mTLS apresentado (rejeita sem). Útil para validar a lógica de auth do cliente sem precisar configurar TLS. |
-| **mTLS** | `--mtls` (implica strict) | HTTPS com handshake mTLS opcional do cliente. Réplica fiel da RNDS: cert exigido em /api/token; FHIR API exige bearer. |
+| Modo           | Como ativar               | Comportamento                                                                                                                                                                    |
+| -------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Permissivo** | (sem flags)               | HTTP puro, qualquer chamada aceita. Útil para curl, aulas e iteração rápida.                                                                                                     |
+| **Strict**     | `--strict`                | HTTP, mas /api/fhir/r4/\* exige bearer + CNS, e /api/token exige cert mTLS apresentado (rejeita sem). Útil para validar a lógica de auth do cliente sem precisar configurar TLS. |
+| **mTLS**       | `--mtls` (implica strict) | HTTPS com handshake mTLS opcional do cliente. Réplica fiel da RNDS: cert exigido em /api/token; FHIR API exige bearer.                                                           |
 
 ### JWT — RS256 com JWKS
 

--- a/packages/rnds-sandbox/package.json
+++ b/packages/rnds-sandbox/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@precisa-saude/fhir-rnds-sandbox",
+  "version": "0.1.0",
+  "description": "Mock local da RNDS (Rede Nacional de Dados em Saúde) — endpoints FHIR R4 com cenários sintéticos para desenvolvimento e ensino",
+  "keywords": [
+    "fhir",
+    "rnds",
+    "datasus",
+    "sus",
+    "saude",
+    "brasil",
+    "mock",
+    "sandbox",
+    "fhir-r4"
+  ],
+  "homepage": "https://github.com/Precisa-Saude/fhir-brasil/tree/main/packages/rnds-sandbox#readme",
+  "bugs": "https://github.com/Precisa-Saude/fhir-brasil/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Precisa-Saude/fhir-brasil.git",
+    "directory": "packages/rnds-sandbox"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "rnds-sandbox": "./dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist .turbo",
+    "lint": "eslint src/ --max-warnings 0",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@precisa-saude/fhir": "workspace:^"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "~5.7.3",
+    "vitest": "^2.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/rnds-sandbox/src/__tests__/auth.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/auth.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { issueToken, verifyToken } from '../auth';
+import { resolveSigningKeys } from '../keys';
+
+const KEYS = resolveSigningKeys({ keyId: 'test-key' });
+
+describe('auth — issueToken / verifyToken (RS256)', () => {
+  it('assina com a chave privada e a verificação passa com a pública', () => {
+    const { access_token } = issueToken(KEYS);
+    const result = verifyToken(access_token, KEYS);
+    expect(result.valid).toBe(true);
+  });
+
+  it('inclui kid no header e claims básicas no payload', () => {
+    const { access_token } = issueToken(KEYS);
+    const [headerB64, payloadB64] = access_token.split('.');
+    const header = JSON.parse(Buffer.from(headerB64!, 'base64url').toString()) as {
+      alg: string;
+      kid: string;
+      typ: string;
+    };
+    const payload = JSON.parse(Buffer.from(payloadB64!, 'base64url').toString()) as {
+      aud: string;
+      exp: number;
+      iat: number;
+      iss: string;
+      sub: string;
+    };
+    expect(header).toMatchObject({ alg: 'RS256', kid: 'test-key', typ: 'JWT' });
+    expect(payload.aud).toBe('rnds-sandbox');
+    expect(payload.iss).toBe('https://rnds-sandbox.local');
+    expect(payload.exp).toBeGreaterThan(payload.iat);
+  });
+
+  it('embute identidade do mTLS (cn/cnes) quando fornecida', () => {
+    const { access_token } = issueToken(KEYS, {
+      identity: { cn: 'PRECISA SAUDE LTDA:1234567', cnes: '1234567' },
+    });
+    const [, payloadB64] = access_token.split('.');
+    const payload = JSON.parse(Buffer.from(payloadB64!, 'base64url').toString()) as {
+      cn: string;
+      cnes: string;
+      sub: string;
+    };
+    expect(payload.cn).toBe('PRECISA SAUDE LTDA:1234567');
+    expect(payload.cnes).toBe('1234567');
+    expect(payload.sub).toBe('PRECISA SAUDE LTDA:1234567');
+  });
+
+  it('detecta token expirado', () => {
+    const past = Date.now() - 60 * 60 * 1000;
+    const { access_token } = issueToken(KEYS, { now: past });
+    const result = verifyToken(access_token, KEYS);
+    expect(result).toEqual({ reason: 'expired', valid: false });
+  });
+
+  it('detecta assinatura corrompida', () => {
+    const { access_token } = issueToken(KEYS);
+    const [h, p] = access_token.split('.');
+    const tampered = `${h}.${p}.dGFtcGVyZWQ`;
+    const result = verifyToken(tampered, KEYS);
+    expect(result).toEqual({ reason: 'bad-signature', valid: false });
+  });
+
+  it('rejeita JWTs malformados', () => {
+    expect(verifyToken('foo', KEYS)).toEqual({ reason: 'malformed', valid: false });
+    expect(verifyToken('a.b', KEYS)).toEqual({ reason: 'malformed', valid: false });
+  });
+
+  it('detecta kid de chave diferente', () => {
+    const otherKeys = resolveSigningKeys({ keyId: 'outra-chave' });
+    const { access_token } = issueToken(otherKeys);
+    const result = verifyToken(access_token, KEYS);
+    expect(result).toEqual({ reason: 'wrong-key', valid: false });
+  });
+});

--- a/packages/rnds-sandbox/src/__tests__/auth.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/auth.test.ts
@@ -80,4 +80,16 @@ describe('auth — issueToken / verifyToken (RS256)', () => {
     const result = verifyToken(access_token, KEYS);
     expect(result).toEqual({ reason: 'wrong-key', valid: false });
   });
+
+  it('rejeita audience diferente da esperada', () => {
+    const { access_token } = issueToken(KEYS, { audience: 'outro-publico' });
+    const result = verifyToken(access_token, KEYS);
+    expect(result).toEqual({ reason: 'wrong-audience', valid: false });
+  });
+
+  it('aceita audience customizada via VerifyOptions', () => {
+    const { access_token } = issueToken(KEYS, { audience: 'meu-app' });
+    const result = verifyToken(access_token, KEYS, { audience: 'meu-app' });
+    expect(result.valid).toBe(true);
+  });
 });

--- a/packages/rnds-sandbox/src/__tests__/auth.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/auth.test.ts
@@ -12,6 +12,12 @@ describe('auth — issueToken / verifyToken (RS256)', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('expressa expires_in em segundos (OAuth2 spec), não em milissegundos', () => {
+    const { expires_in } = issueToken(KEYS);
+    expect(expires_in).toBe(1800); // 30 min em segundos
+    expect(expires_in).toBeLessThan(3600); // sanity: < 1h
+  });
+
   it('inclui kid no header e claims básicas no payload', () => {
     const { access_token } = issueToken(KEYS);
     const [headerB64, payloadB64] = access_token.split('.');

--- a/packages/rnds-sandbox/src/__tests__/cli.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/cli.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseArgs } from '../cli';
+
+describe('cli — parseArgs', () => {
+  it('reconhece subcomando start', () => {
+    const r = parseArgs(['start']);
+    expect(r.command).toBe('start');
+    expect(r.errors).toEqual([]);
+  });
+
+  it('reconhece scenarios e help', () => {
+    expect(parseArgs(['scenarios']).command).toBe('scenarios');
+    expect(parseArgs(['help']).command).toBe('help');
+    expect(parseArgs(['--help']).command).toBe('help');
+    expect(parseArgs(['-h']).command).toBe('help');
+  });
+
+  it('parseia --port numérico', () => {
+    const r = parseArgs(['start', '--port', '9000']);
+    expect(r.options.port).toBe(9000);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('rejeita --port não-numérico', () => {
+    const r = parseArgs(['start', '--port', 'abc']);
+    expect(r.errors[0]).toContain('--port');
+  });
+
+  it('parseia --scenario válido', () => {
+    const r = parseArgs(['start', '--scenario', 'internacao']);
+    expect(r.options.scenario).toBe('internacao');
+  });
+
+  it('rejeita --scenario inválido com lista de opções', () => {
+    const r = parseArgs(['start', '--scenario', 'inexistente']);
+    expect(r.errors[0]).toContain('paciente-com-exames');
+    expect(r.errors[0]).toContain('inexistente');
+  });
+
+  it('parseia flags booleanas --mtls e --strict', () => {
+    const r = parseArgs(['start', '--mtls', '--strict']);
+    expect(r.options.mtls).toBe(true);
+    expect(r.options.strict).toBe(true);
+  });
+
+  it('parseia argumentos string (PFX, PEM, JWT keys)', () => {
+    const r = parseArgs([
+      'start',
+      '--pfx',
+      'cert.pfx',
+      '--pfx-password',
+      's3cret',
+      '--server-key',
+      's.key',
+      '--server-cert',
+      's.crt',
+      '--jwt-private-key',
+      'jwt.pem',
+      '--jwt-public-key',
+      'jwt.pub',
+      '--jwt-key-id',
+      'k1',
+    ]);
+    expect(r.errors).toEqual([]);
+    expect(r.options.serverPfx).toBe('cert.pfx');
+    expect(r.options.serverPfxPassword).toBe('s3cret');
+    expect(r.options.serverKey).toBe('s.key');
+    expect(r.options.serverCert).toBe('s.crt');
+    expect(r.options.jwtPrivateKey).toBe('jwt.pem');
+    expect(r.options.jwtPublicKey).toBe('jwt.pub');
+    expect(r.options.jwtKeyId).toBe('k1');
+  });
+
+  it('rejeita argumentos string sem valor', () => {
+    const r = parseArgs(['start', '--pfx']);
+    expect(r.errors[0]).toContain('--pfx');
+  });
+
+  it('rejeita flag desconhecida', () => {
+    const r = parseArgs(['start', '--xyz']);
+    expect(r.errors[0]).toContain('--xyz');
+  });
+});

--- a/packages/rnds-sandbox/src/__tests__/router.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/router.test.ts
@@ -128,7 +128,9 @@ describe('dispatch — modo permissivo', () => {
   });
 
   it('rejeita método não suportado em endpoint FHIR', () => {
-    const res = dispatch(makeCtx({ method: 'DELETE', path: '/api/fhir/r4/Patient/700000000000001' }));
+    const res = dispatch(
+      makeCtx({ method: 'DELETE', path: '/api/fhir/r4/Patient/700000000000001' }),
+    );
     expect(res.status).toBe(405);
   });
 
@@ -138,11 +140,121 @@ describe('dispatch — modo permissivo', () => {
   });
 });
 
+describe('dispatch — busca por paciente', () => {
+  it('retorna searchset Bundle com Observations pré-carregadas', () => {
+    const res = dispatch(
+      makeCtx({
+        path: '/api/fhir/r4/Observation',
+        query: new URLSearchParams({ subject: 'Patient/700000000000001' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const bundle = res.body as {
+      entry: { resource: { code: { coding: { code: string }[] } } }[];
+      total: number;
+      type: string;
+    };
+    expect(bundle.type).toBe('searchset');
+    expect(bundle.total).toBe(4);
+    expect(bundle.entry).toHaveLength(4);
+    const codes = bundle.entry.map((e) => e.resource.code.coding[0]?.code);
+    expect(codes).toEqual(expect.arrayContaining(['2093-3', '2089-1', '2085-9', '2345-7']));
+  });
+
+  it('inclui Observations submetidas após o load', () => {
+    const store = makeStore();
+    store.recordBundle({
+      entry: [
+        {
+          request: { method: 'POST', url: 'Observation' },
+          resource: {
+            code: { coding: [{ code: '2160-0', system: 'http://loinc.org' }] },
+            resourceType: 'Observation',
+            subject: { reference: 'Patient/700000000000001' },
+          },
+        },
+      ],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    });
+    const res = dispatch(
+      makeCtx({
+        path: '/api/fhir/r4/Observation',
+        query: new URLSearchParams({ subject: 'Patient/700000000000001' }),
+        store,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { total: number }).total).toBe(5);
+  });
+
+  it('aceita CNS sem prefixo Patient/', () => {
+    const res = dispatch(
+      makeCtx({
+        path: '/api/fhir/r4/Observation',
+        query: new URLSearchParams({ subject: '700000000000001' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { total: number }).total).toBe(4);
+  });
+
+  it('retorna searchset vazio quando paciente não tem recursos', () => {
+    const res = dispatch(
+      makeCtx({
+        path: '/api/fhir/r4/Observation',
+        query: new URLSearchParams({ subject: 'Patient/000000000000000' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { entry: unknown[]; total: number };
+    expect(body.total).toBe(0);
+    expect(body.entry).toEqual([]);
+  });
+
+  it('exige parâmetro subject ou patient', () => {
+    const res = dispatch(
+      makeCtx({ path: '/api/fhir/r4/Observation', query: new URLSearchParams() }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('busca Immunization usando ?patient=', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vacina'));
+    const res = dispatch(
+      makeCtx({
+        path: '/api/fhir/r4/Immunization',
+        query: new URLSearchParams({ patient: 'Patient/700000000000040' }),
+        store,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { total: number }).total).toBe(3);
+  });
+
+  it('busca Condition do cenário internação', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('internacao'));
+    const res = dispatch(
+      makeCtx({
+        path: '/api/fhir/r4/Condition',
+        query: new URLSearchParams({ subject: 'Patient/700000000000020' }),
+        store,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((res.body as { total: number }).total).toBe(1);
+  });
+});
+
 describe('dispatch — JWKS', () => {
   it('serve /.well-known/jwks.json com a chave RSA', () => {
     const res = dispatch(makeCtx({ path: '/.well-known/jwks.json' }));
     expect(res.status).toBe(200);
-    const jwks = res.body as { keys: { alg: string; kty: string; kid: string; n: string; e: string }[] };
+    const jwks = res.body as {
+      keys: { alg: string; kty: string; kid: string; n: string; e: string }[];
+    };
     expect(jwks.keys).toHaveLength(1);
     expect(jwks.keys[0]).toMatchObject({
       alg: 'RS256',
@@ -160,9 +272,7 @@ describe('dispatch — modo strict', () => {
   const VALID_CNS = '700000000000001';
 
   it('rejeita FHIR sem header X-Authorization-Server', () => {
-    const res = dispatch(
-      makeCtx({ path: '/api/fhir/r4/Patient/700000000000001', strict: true }),
-    );
+    const res = dispatch(makeCtx({ path: '/api/fhir/r4/Patient/700000000000001', strict: true }));
     expect(res.status).toBe(401);
   });
 
@@ -178,7 +288,7 @@ describe('dispatch — modo strict', () => {
   });
 
   it('rejeita token com assinatura inválida', () => {
-    const tampered = validToken.split('.').slice(0, 2).join('.') + '.invalidsig';
+    const tampered = `${validToken.split('.').slice(0, 2).join('.')}.invalidsig`;
     const res = dispatch(
       makeCtx({
         headers: {

--- a/packages/rnds-sandbox/src/__tests__/router.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/router.test.ts
@@ -1,0 +1,159 @@
+import type { FHIRBundle } from '@precisa-saude/fhir';
+import { describe, expect, it } from 'vitest';
+
+import { dispatch } from '../router';
+import { resolveScenario } from '../scenarios';
+import { SandboxStore } from '../store';
+
+function makeStore() {
+  const store = new SandboxStore();
+  store.load(resolveScenario('paciente-com-exames'));
+  return store;
+}
+
+describe('dispatch', () => {
+  it('emite token JWT estruturado em POST /api/token', () => {
+    const res = dispatch({
+      method: 'POST',
+      path: '/api/token',
+      query: new URLSearchParams(),
+      store: new SandboxStore(),
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { access_token: string; expires_in: number };
+    expect(body.access_token.split('.')).toHaveLength(3);
+    expect(body.expires_in).toBeGreaterThan(0);
+  });
+
+  it('busca paciente por CPF com identifier system|value', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/api/fhir/r4/Patient',
+      query: new URLSearchParams({
+        identifier: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|12345678901',
+      }),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(200);
+    const patient = res.body as { resourceType: string; name: { family: string }[] };
+    expect(patient.resourceType).toBe('Patient');
+    expect(patient.name[0]?.family).toBe('Silva');
+  });
+
+  it('aceita CPF formatado no identifier (123.456.789-01)', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/api/fhir/r4/Patient',
+      query: new URLSearchParams({
+        identifier: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|123.456.789-01',
+      }),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('lê paciente por CNS via /Patient/{cns}', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/api/fhir/r4/Patient/700000000000001',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { resourceType: string }).resourceType).toBe('Patient');
+  });
+
+  it('retorna 404 com OperationOutcome quando paciente não existe', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/api/fhir/r4/Patient/000000000000000',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(404);
+    expect((res.body as { resourceType: string }).resourceType).toBe('OperationOutcome');
+  });
+
+  it('lê organização por CNES', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/api/fhir/r4/Organization/2345678',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { resourceType: string }).resourceType).toBe('Organization');
+  });
+
+  it('lê profissional por CNS', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/api/fhir/r4/Practitioner/700000000000010',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { resourceType: string }).resourceType).toBe('Practitioner');
+  });
+
+  it('aceita Bundle em POST e retorna transaction-response', () => {
+    const store = makeStore();
+    const bundle: FHIRBundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          request: { method: 'POST', url: 'Observation' },
+          resource: {
+            code: { coding: [{ code: '2345-7', system: 'http://loinc.org' }] },
+            resourceType: 'Observation',
+            status: 'final',
+          },
+        },
+      ],
+    };
+    const res = dispatch({
+      body: bundle,
+      method: 'POST',
+      path: '/api/fhir/r4/Bundle',
+      query: new URLSearchParams(),
+      store,
+    });
+    expect(res.status).toBe(200);
+    const responseBundle = res.body as FHIRBundle;
+    expect(responseBundle.type).toBe('transaction-response');
+    expect(responseBundle.entry?.[0]?.response?.status).toContain('201');
+    expect(store.getSubmittedBundles()).toHaveLength(2); // 1 pré-carregado + 1 novo
+  });
+
+  it('rejeita Bundle com tipo inválido', () => {
+    const res = dispatch({
+      body: { resourceType: 'Bundle', type: 'document' } as FHIRBundle,
+      method: 'POST',
+      path: '/api/fhir/r4/Bundle',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejeita método não suportado em endpoint FHIR', () => {
+    const res = dispatch({
+      method: 'DELETE',
+      path: '/api/fhir/r4/Patient/700000000000001',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it('retorna 404 para paths fora do prefixo FHIR', () => {
+    const res = dispatch({
+      method: 'GET',
+      path: '/random',
+      query: new URLSearchParams(),
+      store: makeStore(),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/rnds-sandbox/src/__tests__/router.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/router.test.ts
@@ -1,9 +1,13 @@
-import type { FHIRBundle } from '@precisa-saude/fhir';
 import { describe, expect, it } from 'vitest';
 
-import { dispatch } from '../router';
+import { issueToken } from '../auth';
+import { resolveSigningKeys, type SigningKeys } from '../keys';
+import { dispatch, type RouteContext } from '../router';
 import { resolveScenario } from '../scenarios';
 import { SandboxStore } from '../store';
+import type { SandboxBundle } from '../types';
+
+const KEYS: SigningKeys = resolveSigningKeys();
 
 function makeStore() {
   const store = new SandboxStore();
@@ -11,14 +15,22 @@ function makeStore() {
   return store;
 }
 
-describe('dispatch', () => {
+function makeCtx(overrides: Partial<RouteContext> = {}): RouteContext {
+  return {
+    headers: {},
+    keys: KEYS,
+    method: 'GET',
+    path: '/',
+    query: new URLSearchParams(),
+    store: makeStore(),
+    strict: false,
+    ...overrides,
+  };
+}
+
+describe('dispatch — modo permissivo', () => {
   it('emite token JWT estruturado em POST /api/token', () => {
-    const res = dispatch({
-      method: 'POST',
-      path: '/api/token',
-      query: new URLSearchParams(),
-      store: new SandboxStore(),
-    });
+    const res = dispatch(makeCtx({ method: 'POST', path: '/api/token' }));
     expect(res.status).toBe(200);
     const body = res.body as { access_token: string; expires_in: number };
     expect(body.access_token.split('.')).toHaveLength(3);
@@ -26,14 +38,15 @@ describe('dispatch', () => {
   });
 
   it('busca paciente por CPF com identifier system|value', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/api/fhir/r4/Patient',
-      query: new URLSearchParams({
-        identifier: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|12345678901',
+    const res = dispatch(
+      makeCtx({
+        method: 'GET',
+        path: '/api/fhir/r4/Patient',
+        query: new URLSearchParams({
+          identifier: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|12345678901',
+        }),
       }),
-      store: makeStore(),
-    });
+    );
     expect(res.status).toBe(200);
     const patient = res.body as { resourceType: string; name: { family: string }[] };
     expect(patient.resourceType).toBe('Patient');
@@ -41,66 +54,45 @@ describe('dispatch', () => {
   });
 
   it('aceita CPF formatado no identifier (123.456.789-01)', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/api/fhir/r4/Patient',
-      query: new URLSearchParams({
-        identifier: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|123.456.789-01',
+    const res = dispatch(
+      makeCtx({
+        method: 'GET',
+        path: '/api/fhir/r4/Patient',
+        query: new URLSearchParams({
+          identifier: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|123.456.789-01',
+        }),
       }),
-      store: makeStore(),
-    });
+    );
     expect(res.status).toBe(200);
   });
 
   it('lê paciente por CNS via /Patient/{cns}', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/api/fhir/r4/Patient/700000000000001',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(makeCtx({ path: '/api/fhir/r4/Patient/700000000000001' }));
     expect(res.status).toBe(200);
     expect((res.body as { resourceType: string }).resourceType).toBe('Patient');
   });
 
   it('retorna 404 com OperationOutcome quando paciente não existe', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/api/fhir/r4/Patient/000000000000000',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(makeCtx({ path: '/api/fhir/r4/Patient/000000000000000' }));
     expect(res.status).toBe(404);
     expect((res.body as { resourceType: string }).resourceType).toBe('OperationOutcome');
   });
 
   it('lê organização por CNES', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/api/fhir/r4/Organization/2345678',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(makeCtx({ path: '/api/fhir/r4/Organization/2345678' }));
     expect(res.status).toBe(200);
     expect((res.body as { resourceType: string }).resourceType).toBe('Organization');
   });
 
   it('lê profissional por CNS', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/api/fhir/r4/Practitioner/700000000000010',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(makeCtx({ path: '/api/fhir/r4/Practitioner/700000000000010' }));
     expect(res.status).toBe(200);
     expect((res.body as { resourceType: string }).resourceType).toBe('Practitioner');
   });
 
   it('aceita Bundle em POST e retorna transaction-response', () => {
     const store = makeStore();
-    const bundle: FHIRBundle = {
-      resourceType: 'Bundle',
-      type: 'transaction',
+    const bundle: SandboxBundle = {
       entry: [
         {
           request: { method: 'POST', url: 'Observation' },
@@ -111,49 +103,157 @@ describe('dispatch', () => {
           },
         },
       ],
+      resourceType: 'Bundle',
+      type: 'transaction',
     };
-    const res = dispatch({
-      body: bundle,
-      method: 'POST',
-      path: '/api/fhir/r4/Bundle',
-      query: new URLSearchParams(),
-      store,
-    });
+    const res = dispatch(
+      makeCtx({ body: bundle, method: 'POST', path: '/api/fhir/r4/Bundle', store }),
+    );
     expect(res.status).toBe(200);
-    const responseBundle = res.body as FHIRBundle;
+    const responseBundle = res.body as SandboxBundle;
     expect(responseBundle.type).toBe('transaction-response');
     expect(responseBundle.entry?.[0]?.response?.status).toContain('201');
-    expect(store.getSubmittedBundles()).toHaveLength(2); // 1 pré-carregado + 1 novo
+    expect(store.getSubmittedBundles()).toHaveLength(2);
   });
 
   it('rejeita Bundle com tipo inválido', () => {
-    const res = dispatch({
-      body: { resourceType: 'Bundle', type: 'document' } as FHIRBundle,
-      method: 'POST',
-      path: '/api/fhir/r4/Bundle',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(
+      makeCtx({
+        body: { resourceType: 'Bundle', type: 'document' } as unknown as SandboxBundle,
+        method: 'POST',
+        path: '/api/fhir/r4/Bundle',
+      }),
+    );
     expect(res.status).toBe(400);
   });
 
   it('rejeita método não suportado em endpoint FHIR', () => {
-    const res = dispatch({
-      method: 'DELETE',
-      path: '/api/fhir/r4/Patient/700000000000001',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(makeCtx({ method: 'DELETE', path: '/api/fhir/r4/Patient/700000000000001' }));
     expect(res.status).toBe(405);
   });
 
   it('retorna 404 para paths fora do prefixo FHIR', () => {
-    const res = dispatch({
-      method: 'GET',
-      path: '/random',
-      query: new URLSearchParams(),
-      store: makeStore(),
-    });
+    const res = dispatch(makeCtx({ path: '/random' }));
     expect(res.status).toBe(404);
+  });
+});
+
+describe('dispatch — JWKS', () => {
+  it('serve /.well-known/jwks.json com a chave RSA', () => {
+    const res = dispatch(makeCtx({ path: '/.well-known/jwks.json' }));
+    expect(res.status).toBe(200);
+    const jwks = res.body as { keys: { alg: string; kty: string; kid: string; n: string; e: string }[] };
+    expect(jwks.keys).toHaveLength(1);
+    expect(jwks.keys[0]).toMatchObject({
+      alg: 'RS256',
+      kid: KEYS.keyId,
+      kty: 'RSA',
+      use: 'sig',
+    });
+    expect(jwks.keys[0]?.n).toBeTruthy();
+    expect(jwks.keys[0]?.e).toBeTruthy();
+  });
+});
+
+describe('dispatch — modo strict', () => {
+  const validToken = issueToken(KEYS).access_token;
+  const VALID_CNS = '700000000000001';
+
+  it('rejeita FHIR sem header X-Authorization-Server', () => {
+    const res = dispatch(
+      makeCtx({ path: '/api/fhir/r4/Patient/700000000000001', strict: true }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejeita bearer sem o esquema "Bearer"', () => {
+    const res = dispatch(
+      makeCtx({
+        headers: { 'x-authorization-server': validToken, authorization: VALID_CNS },
+        path: '/api/fhir/r4/Patient/700000000000001',
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejeita token com assinatura inválida', () => {
+    const tampered = validToken.split('.').slice(0, 2).join('.') + '.invalidsig';
+    const res = dispatch(
+      makeCtx({
+        headers: {
+          authorization: VALID_CNS,
+          'x-authorization-server': `Bearer ${tampered}`,
+        },
+        path: '/api/fhir/r4/Patient/700000000000001',
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect((res.body as { issue: { diagnostics: string }[] }).issue[0]?.diagnostics).toContain(
+      'bad-signature',
+    );
+  });
+
+  it('rejeita FHIR com bearer válido mas sem header Authorization (CNS)', () => {
+    const res = dispatch(
+      makeCtx({
+        headers: { 'x-authorization-server': `Bearer ${validToken}` },
+        path: '/api/fhir/r4/Patient/700000000000001',
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejeita CNS com formato inválido', () => {
+    const res = dispatch(
+      makeCtx({
+        headers: {
+          authorization: '12345',
+          'x-authorization-server': `Bearer ${validToken}`,
+        },
+        path: '/api/fhir/r4/Patient/700000000000001',
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('aceita FHIR com bearer válido + CNS bem formado', () => {
+    const res = dispatch(
+      makeCtx({
+        headers: {
+          authorization: VALID_CNS,
+          'x-authorization-server': `Bearer ${validToken}`,
+        },
+        path: '/api/fhir/r4/Patient/700000000000001',
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejeita /api/token sem cert apresentado quando strict', () => {
+    const res = dispatch(
+      makeCtx({
+        method: 'POST',
+        path: '/api/token',
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('aceita /api/token com cert apresentado quando strict', () => {
+    const res = dispatch(
+      makeCtx({
+        method: 'POST',
+        path: '/api/token',
+        peerCert: { cn: 'PRECISA SAUDE LTDA:1234567', cnes: '1234567', presented: true },
+        strict: true,
+      }),
+    );
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/rnds-sandbox/src/__tests__/scenarios.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/scenarios.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveScenario, SCENARIOS } from '../scenarios';
+import { SandboxStore } from '../store';
+
+describe('cenários', () => {
+  it('cobre os três cenários nomeados + vazio', () => {
+    expect(Object.keys(SCENARIOS).sort()).toEqual([
+      'internacao',
+      'paciente-com-exames',
+      'vacina',
+      'vazio',
+    ]);
+  });
+
+  it('paciente-com-exames carrega Bundle de lipidograma + glicemia (4 observations)', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('paciente-com-exames'));
+    const submitted = store.getSubmittedBundles();
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]?.entry).toHaveLength(4);
+  });
+
+  it('internacao inclui Encounter + Condition + 2 Observations', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('internacao'));
+    const types = store.getSubmittedBundles()[0]?.entry?.map((e) => e.resource?.resourceType);
+    expect(types).toEqual(['Encounter', 'Condition', 'Observation', 'Observation']);
+  });
+
+  it('vacina inclui 3 Immunizations', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vacina'));
+    const types = store.getSubmittedBundles()[0]?.entry?.map((e) => e.resource?.resourceType);
+    expect(types).toEqual(['Immunization', 'Immunization', 'Immunization']);
+  });
+
+  it('vazio carrega zero recursos', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vazio'));
+    expect(store.getSubmittedBundles()).toHaveLength(0);
+    expect(store.findPatientByCns('700000000000001')).toBeUndefined();
+  });
+});

--- a/packages/rnds-sandbox/src/__tests__/server.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/server.test.ts
@@ -76,6 +76,37 @@ describe('createSandboxServer (HTTP)', () => {
     expect(jwks.keys[0]?.kty).toBe('RSA');
     expect(jwks.keys[0]?.kid).toBe(sandbox.signingKeys.keyId);
   });
+
+  it('locations do transaction-response são únicas entre POSTs (regression)', async () => {
+    const bundlePayload = JSON.stringify({
+      entry: [
+        {
+          request: { method: 'POST', url: 'Observation' },
+          resource: {
+            code: { coding: [{ code: '2345-7' }] },
+            resourceType: 'Observation',
+            status: 'final',
+          },
+        },
+      ],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    });
+    const headers = { 'Content-Type': 'application/fhir+json' };
+    const r1 = await fetch(`${baseUrl}/api/fhir/r4/Bundle`, {
+      body: bundlePayload,
+      headers,
+      method: 'POST',
+    });
+    const r2 = await fetch(`${baseUrl}/api/fhir/r4/Bundle`, {
+      body: bundlePayload,
+      headers,
+      method: 'POST',
+    });
+    const b1 = (await r1.json()) as { entry: { response: { location: string } }[] };
+    const b2 = (await r2.json()) as { entry: { response: { location: string } }[] };
+    expect(b1.entry[0]?.response.location).not.toBe(b2.entry[0]?.response.location);
+  });
 });
 
 describe('createSandboxServer (HTTP, --strict)', () => {

--- a/packages/rnds-sandbox/src/__tests__/server.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/server.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createSandboxServer, type SandboxServer } from '../server';
+
+describe('createSandboxServer (HTTP)', () => {
+  let sandbox: SandboxServer;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    sandbox = createSandboxServer({ log: () => {}, port: 0, scenario: 'paciente-com-exames' });
+    const { host, port } = await sandbox.start();
+    baseUrl = `http://${host}:${port}`;
+  });
+
+  afterEach(async () => {
+    await sandbox.stop();
+  });
+
+  it('emite token via POST /api/token', async () => {
+    const res = await fetch(`${baseUrl}/api/token`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { access_token: string };
+    expect(body.access_token).toBeTruthy();
+  });
+
+  it('responde Patient por CNS', async () => {
+    const res = await fetch(`${baseUrl}/api/fhir/r4/Patient/700000000000001`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resourceType: string };
+    expect(body.resourceType).toBe('Patient');
+  });
+
+  it('responde Patient por CPF (search)', async () => {
+    const url = `${baseUrl}/api/fhir/r4/Patient?identifier=${encodeURIComponent(
+      'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf|12345678901',
+    )}`;
+    const res = await fetch(url);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resourceType: string };
+    expect(body.resourceType).toBe('Patient');
+  });
+
+  it('aceita Bundle e retorna transaction-response', async () => {
+    const res = await fetch(`${baseUrl}/api/fhir/r4/Bundle`, {
+      body: JSON.stringify({
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: { coding: [{ code: '2345-7', system: 'http://loinc.org' }] },
+              resourceType: 'Observation',
+              status: 'final',
+            },
+          },
+        ],
+      }),
+      headers: { 'Content-Type': 'application/fhir+json' },
+      method: 'POST',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { type: string };
+    expect(body.type).toBe('transaction-response');
+  });
+
+  it('expõe content-type FHIR JSON', async () => {
+    const res = await fetch(`${baseUrl}/api/fhir/r4/Patient/700000000000001`);
+    expect(res.headers.get('content-type')).toContain('application/fhir+json');
+  });
+});

--- a/packages/rnds-sandbox/src/__tests__/server.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/server.test.ts
@@ -68,4 +68,48 @@ describe('createSandboxServer (HTTP)', () => {
     const res = await fetch(`${baseUrl}/api/fhir/r4/Patient/700000000000001`);
     expect(res.headers.get('content-type')).toContain('application/fhir+json');
   });
+
+  it('expõe JWKS em /.well-known/jwks.json', async () => {
+    const res = await fetch(`${baseUrl}/.well-known/jwks.json`);
+    expect(res.status).toBe(200);
+    const jwks = (await res.json()) as { keys: { kty: string; kid: string }[] };
+    expect(jwks.keys[0]?.kty).toBe('RSA');
+    expect(jwks.keys[0]?.kid).toBe(sandbox.signingKeys.keyId);
+  });
+});
+
+describe('createSandboxServer (HTTP, --strict)', () => {
+  let sandbox: SandboxServer;
+  let baseUrl: string;
+  const VALID_CNS = '700000000000001';
+
+  beforeEach(async () => {
+    sandbox = createSandboxServer({ log: () => {}, port: 0, strict: true });
+    const { host, port } = await sandbox.start();
+    baseUrl = `http://${host}:${port}`;
+  });
+
+  afterEach(async () => {
+    await sandbox.stop();
+  });
+
+  it('rejeita FHIR sem auth (401)', async () => {
+    const res = await fetch(`${baseUrl}/api/fhir/r4/Patient/${VALID_CNS}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('aceita FHIR com bearer + CNS', async () => {
+    const tokenRes = await fetch(`${baseUrl}/api/token`, { method: 'POST' });
+    // strict sem mTLS: /api/token rejeita pois não há cert
+    expect(tokenRes.status).toBe(401);
+  });
+
+  it('emite token quando peer cert vem via mTLS (simulado: sandbox não-mtls aqui rejeita)', async () => {
+    // Em modo strict sem mTLS o /api/token sempre rejeita; este teste documenta isso.
+    // O fluxo end-to-end completo está coberto por router.test.ts (peerCert presented).
+    const tokenRes = await fetch(`${baseUrl}/api/token`, { method: 'POST' });
+    expect(tokenRes.status).toBe(401);
+    const oo = (await tokenRes.json()) as { issue: { diagnostics: string }[] };
+    expect(oo.issue[0]?.diagnostics).toContain('Certificado mTLS');
+  });
 });

--- a/packages/rnds-sandbox/src/__tests__/store.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/store.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveScenario } from '../scenarios';
+import { SandboxStore } from '../store';
+
+function loadedStore() {
+  const store = new SandboxStore();
+  store.load(resolveScenario('paciente-com-exames'));
+  return store;
+}
+
+describe('SandboxStore.searchResourcesByPatient — match estrito por path-segment', () => {
+  it('encontra Observations por CNS exato', () => {
+    const store = loadedStore();
+    const obs = store.searchResourcesByPatient('Observation', '700000000000001');
+    expect(obs).toHaveLength(4);
+  });
+
+  it('NÃO false-matcha por sufixo do CNS (regression: Patient/1700... vs 700...)', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vazio'));
+    store.recordBundle({
+      entry: [
+        {
+          request: { method: 'POST', url: 'Observation' },
+          resource: {
+            code: { coding: [{ code: '2345-7' }] },
+            resourceType: 'Observation',
+            // Reference termina em "...700000000000001" mas não é Patient/700000000000001
+            subject: { reference: 'Patient/1700000000000001' },
+          },
+        },
+      ],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    });
+    const matches = store.searchResourcesByPatient('Observation', '700000000000001');
+    expect(matches).toEqual([]);
+  });
+
+  it('aceita reference apenas com o CNS (sem prefixo Patient/)', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vazio'));
+    store.recordBundle({
+      entry: [
+        {
+          request: { method: 'POST', url: 'Observation' },
+          resource: {
+            code: { coding: [{ code: '2345-7' }] },
+            resourceType: 'Observation',
+            subject: { reference: '700000000000001' },
+          },
+        },
+      ],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    });
+    const matches = store.searchResourcesByPatient('Observation', '700000000000001');
+    expect(matches).toHaveLength(1);
+  });
+});
+
+describe('SandboxStore.nextResourceId — sequência global', () => {
+  it('incrementa a cada chamada e não reseta entre bundles', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vazio'));
+    expect(store.nextResourceId()).toBe(1);
+    expect(store.nextResourceId()).toBe(2);
+    expect(store.nextResourceId()).toBe(3);
+  });
+
+  it('reseta apenas no `load` (novo cenário)', () => {
+    const store = new SandboxStore();
+    store.load(resolveScenario('vazio'));
+    store.nextResourceId();
+    store.nextResourceId();
+    store.load(resolveScenario('paciente-com-exames'));
+    expect(store.nextResourceId()).toBe(1);
+  });
+});

--- a/packages/rnds-sandbox/src/auth.ts
+++ b/packages/rnds-sandbox/src/auth.ts
@@ -27,10 +27,10 @@ export interface TokenPayload {
 export interface JwtClaims {
   /** Audience — identifica quem deve consumir o token */
   aud: string;
-  /** CNES extraído do certificado mTLS apresentado, se houver */
-  cnes?: string;
   /** Common Name do certificado mTLS, se houver */
   cn?: string;
+  /** CNES extraído do certificado mTLS apresentado, se houver */
+  cnes?: string;
   /** Expiração (epoch seconds) */
   exp: number;
   /** Issued at (epoch seconds) */
@@ -42,10 +42,10 @@ export interface JwtClaims {
 }
 
 export interface IssueTokenOptions {
-  /** Identidade extraída do certificado mTLS, se aplicável */
-  identity?: { cn?: string; cnes?: string };
   /** Audience — padrão 'rnds-sandbox' */
   audience?: string;
+  /** Identidade extraída do certificado mTLS, se aplicável */
+  identity?: { cn?: string; cnes?: string };
   /** Issuer — padrão 'https://rnds-sandbox.local' */
   issuer?: string;
   /** Override de tempo (testes) */

--- a/packages/rnds-sandbox/src/auth.ts
+++ b/packages/rnds-sandbox/src/auth.ts
@@ -1,0 +1,40 @@
+/**
+ * Emissor simples de token JWT para o sandbox.
+ *
+ * Não há chave privada nem assinatura criptográfica real — o token é
+ * estruturalmente um JWT (header.payload.signature) mas a "assinatura"
+ * é um placeholder. O cliente RNDS apenas valida estrutura e expiry.
+ */
+
+const SIGNATURE_PLACEHOLDER = 'sandbox-signature-not-cryptographically-valid';
+const TOKEN_TTL_MS = 30 * 60 * 1000;
+
+export interface TokenPayload {
+  access_token: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+}
+
+export function issueToken(now: number = Date.now()): TokenPayload {
+  const header = base64UrlJson({ alg: 'RS256', typ: 'JWT' });
+  const payload = base64UrlJson({
+    aud: 'rnds-sandbox',
+    exp: Math.floor((now + TOKEN_TTL_MS) / 1000),
+    iat: Math.floor(now / 1000),
+    iss: 'https://rnds-sandbox.local',
+    sub: 'sandbox',
+  });
+  const signature = Buffer.from(SIGNATURE_PLACEHOLDER).toString('base64url');
+
+  return {
+    access_token: `${header}.${payload}.${signature}`,
+    expires_in: TOKEN_TTL_MS,
+    scope: 'rnds:read rnds:write',
+    token_type: 'Bearer',
+  };
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}

--- a/packages/rnds-sandbox/src/auth.ts
+++ b/packages/rnds-sandbox/src/auth.ts
@@ -71,7 +71,7 @@ export function issueToken(keys: SigningKeys, options: IssueTokenOptions = {}): 
 
   return {
     access_token: accessToken,
-    expires_in: TOKEN_TTL_MS,
+    expires_in: Math.floor(TOKEN_TTL_MS / 1000),
     scope: 'rnds:read rnds:write',
     token_type: 'Bearer',
   };

--- a/packages/rnds-sandbox/src/auth.ts
+++ b/packages/rnds-sandbox/src/auth.ts
@@ -79,13 +79,25 @@ export function issueToken(keys: SigningKeys, options: IssueTokenOptions = {}): 
 
 export type VerifyResult =
   | { valid: true; claims: JwtClaims }
-  | { valid: false; reason: 'malformed' | 'bad-signature' | 'expired' | 'wrong-key' };
+  | {
+      valid: false;
+      reason: 'malformed' | 'bad-signature' | 'expired' | 'wrong-key' | 'wrong-audience';
+    };
+
+export interface VerifyOptions {
+  /** Audience esperada — falha quando claim `aud` não casa. Padrão: 'rnds-sandbox' */
+  audience?: string;
+  /** Override de tempo para testes */
+  now?: number;
+}
 
 export function verifyToken(
   token: string,
   keys: SigningKeys,
-  now: number = Date.now(),
+  options: VerifyOptions = {},
 ): VerifyResult {
+  const now = options.now ?? Date.now();
+  const expectedAudience = options.audience ?? 'rnds-sandbox';
   const parts = token.split('.');
   if (parts.length !== 3) {
     return { reason: 'malformed', valid: false };
@@ -117,6 +129,10 @@ export function verifyToken(
 
   if (payload.exp * 1000 < now) {
     return { reason: 'expired', valid: false };
+  }
+
+  if (payload.aud !== expectedAudience) {
+    return { reason: 'wrong-audience', valid: false };
   }
 
   return { claims: payload, valid: true };

--- a/packages/rnds-sandbox/src/auth.ts
+++ b/packages/rnds-sandbox/src/auth.ts
@@ -1,12 +1,20 @@
 /**
- * Emissor simples de token JWT para o sandbox.
+ * Emissor e verificador de tokens JWT (RS256) para o sandbox.
  *
- * Não há chave privada nem assinatura criptográfica real — o token é
- * estruturalmente um JWT (header.payload.signature) mas a "assinatura"
- * é um placeholder. O cliente RNDS apenas valida estrutura e expiry.
+ * A RNDS real assina seus tokens com RS256 e expõe a chave pública
+ * para validação. O sandbox faz o mesmo: gera (ou carrega) um par
+ * RSA-2048, assina com a privada e expõe a pública via JWKS em
+ * `/.well-known/jwks.json`.
+ *
+ * Claims seguem o formato observado em respostas da RNDS:
+ * `iss`, `sub`, `aud`, `iat`, `exp`, e — quando o cliente apresenta
+ * certificado mTLS — `cn`/`cnes` extraídos do certificado.
  */
 
-const SIGNATURE_PLACEHOLDER = 'sandbox-signature-not-cryptographically-valid';
+import { createSign, createVerify } from 'node:crypto';
+
+import type { SigningKeys } from './keys';
+
 const TOKEN_TTL_MS = 30 * 60 * 1000;
 
 export interface TokenPayload {
@@ -16,23 +24,112 @@ export interface TokenPayload {
   token_type: string;
 }
 
-export function issueToken(now: number = Date.now()): TokenPayload {
-  const header = base64UrlJson({ alg: 'RS256', typ: 'JWT' });
-  const payload = base64UrlJson({
-    aud: 'rnds-sandbox',
+export interface JwtClaims {
+  /** Audience — identifica quem deve consumir o token */
+  aud: string;
+  /** CNES extraído do certificado mTLS apresentado, se houver */
+  cnes?: string;
+  /** Common Name do certificado mTLS, se houver */
+  cn?: string;
+  /** Expiração (epoch seconds) */
+  exp: number;
+  /** Issued at (epoch seconds) */
+  iat: number;
+  /** Issuer */
+  iss: string;
+  /** Subject — identidade do cliente (CN ou 'sandbox') */
+  sub: string;
+}
+
+export interface IssueTokenOptions {
+  /** Identidade extraída do certificado mTLS, se aplicável */
+  identity?: { cn?: string; cnes?: string };
+  /** Audience — padrão 'rnds-sandbox' */
+  audience?: string;
+  /** Issuer — padrão 'https://rnds-sandbox.local' */
+  issuer?: string;
+  /** Override de tempo (testes) */
+  now?: number;
+}
+
+export function issueToken(keys: SigningKeys, options: IssueTokenOptions = {}): TokenPayload {
+  const now = options.now ?? Date.now();
+  const audience = options.audience ?? 'rnds-sandbox';
+  const issuer = options.issuer ?? 'https://rnds-sandbox.local';
+
+  const claims: JwtClaims = {
+    aud: audience,
     exp: Math.floor((now + TOKEN_TTL_MS) / 1000),
     iat: Math.floor(now / 1000),
-    iss: 'https://rnds-sandbox.local',
-    sub: 'sandbox',
-  });
-  const signature = Buffer.from(SIGNATURE_PLACEHOLDER).toString('base64url');
+    iss: issuer,
+    sub: options.identity?.cn ?? 'sandbox',
+    ...(options.identity?.cn ? { cn: options.identity.cn } : {}),
+    ...(options.identity?.cnes ? { cnes: options.identity.cnes } : {}),
+  };
+
+  const accessToken = signJwt(claims, keys);
 
   return {
-    access_token: `${header}.${payload}.${signature}`,
+    access_token: accessToken,
     expires_in: TOKEN_TTL_MS,
     scope: 'rnds:read rnds:write',
     token_type: 'Bearer',
   };
+}
+
+export type VerifyResult =
+  | { valid: true; claims: JwtClaims }
+  | { valid: false; reason: 'malformed' | 'bad-signature' | 'expired' | 'wrong-key' };
+
+export function verifyToken(
+  token: string,
+  keys: SigningKeys,
+  now: number = Date.now(),
+): VerifyResult {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return { reason: 'malformed', valid: false };
+  }
+  const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
+
+  let header: { alg?: string; kid?: string; typ?: string };
+  let payload: JwtClaims;
+  try {
+    header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf-8')) as typeof header;
+    payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8')) as JwtClaims;
+  } catch {
+    return { reason: 'malformed', valid: false };
+  }
+
+  if (header.alg !== 'RS256') {
+    return { reason: 'malformed', valid: false };
+  }
+  if (header.kid && header.kid !== keys.keyId) {
+    return { reason: 'wrong-key', valid: false };
+  }
+
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const verifier = createVerify('RSA-SHA256').update(signingInput);
+  const signatureValid = verifier.verify(keys.publicKey, Buffer.from(signatureB64, 'base64url'));
+  if (!signatureValid) {
+    return { reason: 'bad-signature', valid: false };
+  }
+
+  if (payload.exp * 1000 < now) {
+    return { reason: 'expired', valid: false };
+  }
+
+  return { claims: payload, valid: true };
+}
+
+function signJwt(claims: JwtClaims, keys: SigningKeys): string {
+  const header = { alg: 'RS256', kid: keys.keyId, typ: 'JWT' };
+  const headerB64 = base64UrlJson(header);
+  const payloadB64 = base64UrlJson(claims);
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signer = createSign('RSA-SHA256').update(signingInput);
+  const signature = signer.sign(keys.privateKey).toString('base64url');
+  return `${signingInput}.${signature}`;
 }
 
 function base64UrlJson(value: unknown): string {

--- a/packages/rnds-sandbox/src/cli.ts
+++ b/packages/rnds-sandbox/src/cli.ts
@@ -23,18 +23,61 @@ Uso:
   rnds-sandbox --help
 
 Opções de start:
-  --port <n>            Porta (padrão: 8080, ou 8443 se --mtls)
-  --host <h>            Host (padrão: 127.0.0.1)
-  --scenario <nome>     paciente-com-exames | internacao | vacina | vazio
-  --mtls                Habilita mTLS no handshake (requer --pfx, --pfx-password)
-  --pfx <caminho>       Caminho do PFX do servidor
-  --pfx-password <s>    Senha do PFX
+  --port <n>              Porta (padrão: 8080, ou 8443 se --mtls)
+  --host <h>              Host (padrão: 127.0.0.1)
+  --scenario <nome>       paciente-com-exames | internacao | vacina | vazio
+
+Modos de fidelidade RNDS:
+  --strict                Exige bearer token + header Authorization: <CNS> em /api/fhir/r4/*
+                          (implícito quando --mtls está ativo)
+  --mtls                  HTTPS + handshake mTLS (cliente apresenta cert).
+                          /api/token exige cert; FHIR API exige bearer.
+
+Cert do servidor (use uma forma OU outra):
+  --pfx <caminho>         PFX do servidor
+  --pfx-password <s>      Senha do PFX
+  --server-key <caminho>  PEM da chave privada do servidor
+  --server-cert <caminho> PEM do certificado do servidor
+
+Chaves de assinatura JWT (RS256):
+  --jwt-private-key <p>   PEM da chave privada (padrão: gera uma RSA-2048 efêmera)
+  --jwt-public-key <p>    PEM da chave pública (opcional — derivada da privada)
+  --jwt-key-id <s>        kid no JWT/JWKS (padrão: rnds-sandbox-1)
 
 Exemplos:
   rnds-sandbox start
+  rnds-sandbox start --strict --jwt-private-key ./jwt.pem
   rnds-sandbox start --port 9000 --scenario internacao
   rnds-sandbox start --mtls --pfx ./cert.pfx --pfx-password senha
+  rnds-sandbox start --mtls --server-key ./srv.key --server-cert ./srv.crt
 `;
+
+const STRING_ARGS: Record<string, (options: SandboxOptions, value: string) => void> = {
+  '--host': (o, v) => {
+    o.host = v;
+  },
+  '--pfx': (o, v) => {
+    o.serverPfx = v;
+  },
+  '--pfx-password': (o, v) => {
+    o.serverPfxPassword = v;
+  },
+  '--server-key': (o, v) => {
+    o.serverKey = v;
+  },
+  '--server-cert': (o, v) => {
+    o.serverCert = v;
+  },
+  '--jwt-private-key': (o, v) => {
+    o.jwtPrivateKey = v;
+  },
+  '--jwt-public-key': (o, v) => {
+    o.jwtPublicKey = v;
+  },
+  '--jwt-key-id': (o, v) => {
+    o.jwtKeyId = v;
+  },
+};
 
 function parseArgs(argv: string[]): ParsedArgs {
   const errors: string[] = [];
@@ -62,15 +105,6 @@ function parseArgs(argv: string[]): ParsedArgs {
       }
       continue;
     }
-    if (token === '--host') {
-      const value = args.shift();
-      if (!value) {
-        errors.push('--host requer valor');
-      } else {
-        options.host = value;
-      }
-      continue;
-    }
     if (token === '--scenario') {
       const value = args.shift();
       if (!value || !(value in SCENARIOS)) {
@@ -86,21 +120,17 @@ function parseArgs(argv: string[]): ParsedArgs {
       options.mtls = true;
       continue;
     }
-    if (token === '--pfx') {
-      const value = args.shift();
-      if (!value) {
-        errors.push('--pfx requer caminho');
-      } else {
-        options.serverPfx = value;
-      }
+    if (token === '--strict') {
+      options.strict = true;
       continue;
     }
-    if (token === '--pfx-password') {
+    const stringSetter = STRING_ARGS[token];
+    if (stringSetter) {
       const value = args.shift();
       if (!value) {
-        errors.push('--pfx-password requer valor');
+        errors.push(`${token} requer valor`);
       } else {
-        options.serverPfxPassword = value;
+        stringSetter(options, value);
       }
       continue;
     }
@@ -134,9 +164,15 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     return 0;
   }
 
-  if (parsed.options.mtls && !parsed.options.serverPfx) {
-    process.stderr.write('erro: --mtls requer --pfx <caminho> e --pfx-password <senha>\n');
-    return 1;
+  if (parsed.options.mtls) {
+    const hasPfx = parsed.options.serverPfx;
+    const hasKeyAndCert = parsed.options.serverKey && parsed.options.serverCert;
+    if (!hasPfx && !hasKeyAndCert) {
+      process.stderr.write(
+        'erro: --mtls requer --pfx + --pfx-password OU --server-key + --server-cert\n',
+      );
+      return 1;
+    }
   }
 
   const sandbox = createSandboxServer(parsed.options);

--- a/packages/rnds-sandbox/src/cli.ts
+++ b/packages/rnds-sandbox/src/cli.ts
@@ -5,6 +5,7 @@
  * Sobe um mock local da RNDS para desenvolvimento.
  */
 
+import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { SCENARIOS } from './scenarios';
@@ -191,13 +192,25 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   return 0;
 }
 
-// Só executa quando este arquivo é o entry-point (via `node dist/cli.js` ou
-// via shebang). Permite importar `parseArgs`/`main` em testes sem efeito
-// colateral.
-const isEntryPoint =
-  typeof process.argv[1] === 'string' && fileURLToPath(import.meta.url) === process.argv[1];
+// Só executa quando este arquivo é o entry-point. Comparamos via realpath
+// (ambos os lados) porque `process.argv[1]` pode ser um symlink criado pelo
+// npm em `node_modules/.bin/` enquanto `import.meta.url` resolve para o
+// arquivo bundled real. Sem realpath, importar este módulo em teste acaba
+// disparando `main()` em alguns ambientes / o oposto: o bin não roda quando
+// invocado via npx.
+function isCliEntryPoint(): boolean {
+  const argv1 = process.argv[1];
+  if (typeof argv1 !== 'string' || argv1.length === 0) return false;
+  try {
+    const here = fs.realpathSync(fileURLToPath(import.meta.url));
+    const invoked = fs.realpathSync(argv1);
+    return here === invoked;
+  } catch {
+    return false;
+  }
+}
 
-if (isEntryPoint) {
+if (isCliEntryPoint()) {
   main().catch((err: unknown) => {
     process.stderr.write(`erro fatal: ${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);

--- a/packages/rnds-sandbox/src/cli.ts
+++ b/packages/rnds-sandbox/src/cli.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * CLI: rnds-sandbox start [opções]
+ *
+ * Sobe um mock local da RNDS para desenvolvimento.
+ */
+
+import { createSandboxServer } from './server';
+import { SCENARIOS } from './scenarios';
+import type { ScenarioName, SandboxOptions } from './types';
+
+interface ParsedArgs {
+  command?: 'start' | 'help' | 'scenarios';
+  options: SandboxOptions;
+  errors: string[];
+}
+
+const HELP = `rnds-sandbox — mock local da RNDS
+
+Uso:
+  rnds-sandbox start [opções]
+  rnds-sandbox scenarios
+  rnds-sandbox --help
+
+Opções de start:
+  --port <n>            Porta (padrão: 8080, ou 8443 se --mtls)
+  --host <h>            Host (padrão: 127.0.0.1)
+  --scenario <nome>     paciente-com-exames | internacao | vacina | vazio
+  --mtls                Habilita mTLS no handshake (requer --pfx, --pfx-password)
+  --pfx <caminho>       Caminho do PFX do servidor
+  --pfx-password <s>    Senha do PFX
+
+Exemplos:
+  rnds-sandbox start
+  rnds-sandbox start --port 9000 --scenario internacao
+  rnds-sandbox start --mtls --pfx ./cert.pfx --pfx-password senha
+`;
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const errors: string[] = [];
+  const options: SandboxOptions = {};
+  let command: ParsedArgs['command'];
+
+  const args = [...argv];
+  while (args.length > 0) {
+    const token = args.shift()!;
+    if (token === '--help' || token === '-h') {
+      command = 'help';
+      continue;
+    }
+    if (!command && (token === 'start' || token === 'scenarios' || token === 'help')) {
+      command = token;
+      continue;
+    }
+    if (token === '--port') {
+      const value = args.shift();
+      const port = Number(value);
+      if (!value || Number.isNaN(port)) {
+        errors.push(`--port requer valor numérico, recebido: ${String(value)}`);
+      } else {
+        options.port = port;
+      }
+      continue;
+    }
+    if (token === '--host') {
+      const value = args.shift();
+      if (!value) {
+        errors.push('--host requer valor');
+      } else {
+        options.host = value;
+      }
+      continue;
+    }
+    if (token === '--scenario') {
+      const value = args.shift();
+      if (!value || !(value in SCENARIOS)) {
+        errors.push(
+          `--scenario inválido. Disponíveis: ${Object.keys(SCENARIOS).join(', ')}. Recebido: ${String(value)}`,
+        );
+      } else {
+        options.scenario = value as ScenarioName;
+      }
+      continue;
+    }
+    if (token === '--mtls') {
+      options.mtls = true;
+      continue;
+    }
+    if (token === '--pfx') {
+      const value = args.shift();
+      if (!value) {
+        errors.push('--pfx requer caminho');
+      } else {
+        options.serverPfx = value;
+      }
+      continue;
+    }
+    if (token === '--pfx-password') {
+      const value = args.shift();
+      if (!value) {
+        errors.push('--pfx-password requer valor');
+      } else {
+        options.serverPfxPassword = value;
+      }
+      continue;
+    }
+    errors.push(`argumento desconhecido: ${token}`);
+  }
+
+  return { command, errors, options };
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const parsed = parseArgs(argv);
+
+  if (parsed.errors.length > 0) {
+    for (const err of parsed.errors) {
+      process.stderr.write(`erro: ${err}\n`);
+    }
+    process.stderr.write('\n' + HELP);
+    return 1;
+  }
+
+  if (!parsed.command || parsed.command === 'help') {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  if (parsed.command === 'scenarios') {
+    process.stdout.write('Cenários disponíveis:\n\n');
+    for (const scenario of Object.values(SCENARIOS)) {
+      process.stdout.write(`  ${scenario.name}\n    ${scenario.description}\n\n`);
+    }
+    return 0;
+  }
+
+  if (parsed.options.mtls && !parsed.options.serverPfx) {
+    process.stderr.write('erro: --mtls requer --pfx <caminho> e --pfx-password <senha>\n');
+    return 1;
+  }
+
+  const sandbox = createSandboxServer(parsed.options);
+  await sandbox.start();
+
+  const shutdown = async (signal: string) => {
+    process.stdout.write(`\n[rnds-sandbox] recebido ${signal}, encerrando...\n`);
+    await sandbox.stop();
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+  return 0;
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`erro fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/rnds-sandbox/src/cli.ts
+++ b/packages/rnds-sandbox/src/cli.ts
@@ -5,11 +5,13 @@
  * Sobe um mock local da RNDS para desenvolvimento.
  */
 
+import { fileURLToPath } from 'node:url';
+
 import { SCENARIOS } from './scenarios';
 import { createSandboxServer } from './server';
 import type { SandboxOptions, ScenarioName } from './types';
 
-interface ParsedArgs {
+export interface ParsedArgs {
   command?: 'start' | 'help' | 'scenarios';
   errors: string[];
   options: SandboxOptions;
@@ -79,7 +81,7 @@ const STRING_ARGS: Record<string, (options: SandboxOptions, value: string) => vo
   },
 };
 
-function parseArgs(argv: string[]): ParsedArgs {
+export function parseArgs(argv: string[]): ParsedArgs {
   const errors: string[] = [];
   const options: SandboxOptions = {};
   let command: ParsedArgs['command'];
@@ -189,7 +191,15 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   return 0;
 }
 
-main().catch((err: unknown) => {
-  process.stderr.write(`erro fatal: ${err instanceof Error ? err.message : String(err)}\n`);
-  process.exit(1);
-});
+// Só executa quando este arquivo é o entry-point (via `node dist/cli.js` ou
+// via shebang). Permite importar `parseArgs`/`main` em testes sem efeito
+// colateral.
+const isEntryPoint =
+  typeof process.argv[1] === 'string' && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isEntryPoint) {
+  main().catch((err: unknown) => {
+    process.stderr.write(`erro fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/rnds-sandbox/src/cli.ts
+++ b/packages/rnds-sandbox/src/cli.ts
@@ -5,14 +5,14 @@
  * Sobe um mock local da RNDS para desenvolvimento.
  */
 
-import { createSandboxServer } from './server';
 import { SCENARIOS } from './scenarios';
-import type { ScenarioName, SandboxOptions } from './types';
+import { createSandboxServer } from './server';
+import type { SandboxOptions, ScenarioName } from './types';
 
 interface ParsedArgs {
   command?: 'start' | 'help' | 'scenarios';
-  options: SandboxOptions;
   errors: string[];
+  options: SandboxOptions;
 }
 
 const HELP = `rnds-sandbox — mock local da RNDS
@@ -56,17 +56,8 @@ const STRING_ARGS: Record<string, (options: SandboxOptions, value: string) => vo
   '--host': (o, v) => {
     o.host = v;
   },
-  '--pfx': (o, v) => {
-    o.serverPfx = v;
-  },
-  '--pfx-password': (o, v) => {
-    o.serverPfxPassword = v;
-  },
-  '--server-key': (o, v) => {
-    o.serverKey = v;
-  },
-  '--server-cert': (o, v) => {
-    o.serverCert = v;
+  '--jwt-key-id': (o, v) => {
+    o.jwtKeyId = v;
   },
   '--jwt-private-key': (o, v) => {
     o.jwtPrivateKey = v;
@@ -74,8 +65,17 @@ const STRING_ARGS: Record<string, (options: SandboxOptions, value: string) => vo
   '--jwt-public-key': (o, v) => {
     o.jwtPublicKey = v;
   },
-  '--jwt-key-id': (o, v) => {
-    o.jwtKeyId = v;
+  '--pfx': (o, v) => {
+    o.serverPfx = v;
+  },
+  '--pfx-password': (o, v) => {
+    o.serverPfxPassword = v;
+  },
+  '--server-cert': (o, v) => {
+    o.serverCert = v;
+  },
+  '--server-key': (o, v) => {
+    o.serverKey = v;
   },
 };
 
@@ -147,7 +147,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     for (const err of parsed.errors) {
       process.stderr.write(`erro: ${err}\n`);
     }
-    process.stderr.write('\n' + HELP);
+    process.stderr.write(`\n${HELP}`);
     return 1;
   }
 

--- a/packages/rnds-sandbox/src/index.ts
+++ b/packages/rnds-sandbox/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @precisa-saude/fhir-rnds-sandbox
+ *
+ * Mock local da RNDS para desenvolvimento, ensino e demos.
+ * Sem certificado ICP-Brasil. Sem credenciamento DATASUS.
+ */
+
+export { issueToken } from './auth';
+export type { TokenPayload } from './auth';
+export { dispatch } from './router';
+export type { RouteContext, RouteResponse } from './router';
+export { internacao, pacienteComExames, resolveScenario, SCENARIOS, vacina } from './scenarios';
+export { createSandboxServer } from './server';
+export type { SandboxServer } from './server';
+export { SandboxStore } from './store';
+export type {
+  SandboxOptions,
+  SandboxOrganization,
+  SandboxPractitioner,
+  Scenario,
+  ScenarioData,
+  ScenarioName,
+} from './types';

--- a/packages/rnds-sandbox/src/index.ts
+++ b/packages/rnds-sandbox/src/index.ts
@@ -5,12 +5,18 @@
  * Sem certificado ICP-Brasil. Sem credenciamento DATASUS.
  */
 
-export type { IssueTokenOptions, JwtClaims, TokenPayload, VerifyResult } from './auth';
+export type {
+  IssueTokenOptions,
+  JwtClaims,
+  TokenPayload,
+  VerifyOptions,
+  VerifyResult,
+} from './auth';
 export { issueToken, verifyToken } from './auth';
 export type { Jwk, JwksDocument } from './jwks';
 export { buildJwks } from './jwks';
 export type { KeyOptions, SigningKeys } from './keys';
-export { resolveSigningKeys } from './keys';
+export { resetSigningKeysCache, resolveSigningKeys } from './keys';
 export type { PeerCertInfo, RouteContext, RouteResponse } from './router';
 export { dispatch } from './router';
 export { internacao, pacienteComExames, resolveScenario, SCENARIOS, vacina } from './scenarios';

--- a/packages/rnds-sandbox/src/index.ts
+++ b/packages/rnds-sandbox/src/index.ts
@@ -5,17 +5,17 @@
  * Sem certificado ICP-Brasil. Sem credenciamento DATASUS.
  */
 
-export { issueToken, verifyToken } from './auth';
 export type { IssueTokenOptions, JwtClaims, TokenPayload, VerifyResult } from './auth';
-export { buildJwks } from './jwks';
+export { issueToken, verifyToken } from './auth';
 export type { Jwk, JwksDocument } from './jwks';
-export { resolveSigningKeys } from './keys';
+export { buildJwks } from './jwks';
 export type { KeyOptions, SigningKeys } from './keys';
-export { dispatch } from './router';
+export { resolveSigningKeys } from './keys';
 export type { PeerCertInfo, RouteContext, RouteResponse } from './router';
+export { dispatch } from './router';
 export { internacao, pacienteComExames, resolveScenario, SCENARIOS, vacina } from './scenarios';
-export { createSandboxServer } from './server';
 export type { SandboxServer } from './server';
+export { createSandboxServer } from './server';
 export { SandboxStore } from './store';
 export type {
   SandboxOptions,

--- a/packages/rnds-sandbox/src/index.ts
+++ b/packages/rnds-sandbox/src/index.ts
@@ -5,10 +5,14 @@
  * Sem certificado ICP-Brasil. Sem credenciamento DATASUS.
  */
 
-export { issueToken } from './auth';
-export type { TokenPayload } from './auth';
+export { issueToken, verifyToken } from './auth';
+export type { IssueTokenOptions, JwtClaims, TokenPayload, VerifyResult } from './auth';
+export { buildJwks } from './jwks';
+export type { Jwk, JwksDocument } from './jwks';
+export { resolveSigningKeys } from './keys';
+export type { KeyOptions, SigningKeys } from './keys';
 export { dispatch } from './router';
-export type { RouteContext, RouteResponse } from './router';
+export type { PeerCertInfo, RouteContext, RouteResponse } from './router';
 export { internacao, pacienteComExames, resolveScenario, SCENARIOS, vacina } from './scenarios';
 export { createSandboxServer } from './server';
 export type { SandboxServer } from './server';

--- a/packages/rnds-sandbox/src/jwks.ts
+++ b/packages/rnds-sandbox/src/jwks.ts
@@ -1,0 +1,44 @@
+/**
+ * Geração do documento JWKS (`/.well-known/jwks.json`).
+ *
+ * Permite que clientes (incluindo jwt.io) busquem a chave pública do
+ * sandbox e validem a assinatura do token sem nenhuma configuração
+ * fora-de-banda.
+ */
+
+import type { SigningKeys } from './keys';
+
+export interface Jwk {
+  alg: 'RS256';
+  e: string;
+  kid: string;
+  kty: 'RSA';
+  n: string;
+  use: 'sig';
+}
+
+export interface JwksDocument {
+  keys: Jwk[];
+}
+
+export function buildJwks(keys: SigningKeys): JwksDocument {
+  const exported = keys.publicKey.export({ format: 'jwk' });
+  if (typeof exported !== 'object' || exported === null || exported.kty !== 'RSA') {
+    throw new Error('Chave pública não é RSA — JWKS só suporta RS256 no sandbox');
+  }
+  if (typeof exported.n !== 'string' || typeof exported.e !== 'string') {
+    throw new Error('Chave pública RSA exportada está incompleta (n/e ausentes)');
+  }
+  return {
+    keys: [
+      {
+        alg: 'RS256',
+        e: exported.e,
+        kid: keys.keyId,
+        kty: 'RSA',
+        n: exported.n,
+        use: 'sig',
+      },
+    ],
+  };
+}

--- a/packages/rnds-sandbox/src/keys.ts
+++ b/packages/rnds-sandbox/src/keys.ts
@@ -7,13 +7,13 @@
  * (PEM) — útil em CI ou em demos onde o token é capturado e reutilizado.
  */
 
-import fs from 'node:fs';
 import {
   createPrivateKey,
   createPublicKey,
   generateKeyPairSync,
   type KeyObject,
 } from 'node:crypto';
+import fs from 'node:fs';
 
 export interface SigningKeys {
   /** Identificador da chave (claim `kid` no JWT, `kid` no JWKS) */
@@ -25,12 +25,12 @@ export interface SigningKeys {
 }
 
 export interface KeyOptions {
+  /** Identificador da chave. Padrão: 'rnds-sandbox-1' */
+  keyId?: string;
   /** PEM da chave privada (Buffer ou caminho). Se omitido, gera-se um par novo. */
   privateKey?: Buffer | string;
   /** PEM da chave pública (Buffer ou caminho). Opcional — derivada da privada quando omitida. */
   publicKey?: Buffer | string;
-  /** Identificador da chave. Padrão: 'rnds-sandbox-1' */
-  keyId?: string;
 }
 
 const DEFAULT_KEY_ID = 'rnds-sandbox-1';

--- a/packages/rnds-sandbox/src/keys.ts
+++ b/packages/rnds-sandbox/src/keys.ts
@@ -1,0 +1,66 @@
+/**
+ * Geração e carregamento de chaves RSA para assinatura RS256 do JWT.
+ *
+ * Em produção a RNDS usa chaves estáveis (com `kid` publicado em JWKS).
+ * No sandbox, geramos um par RSA-2048 efêmero no boot por padrão; quem
+ * precisa de tokens estáveis entre reinícios passa `--jwt-private-key`
+ * (PEM) — útil em CI ou em demos onde o token é capturado e reutilizado.
+ */
+
+import fs from 'node:fs';
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  type KeyObject,
+} from 'node:crypto';
+
+export interface SigningKeys {
+  /** Identificador da chave (claim `kid` no JWT, `kid` no JWKS) */
+  keyId: string;
+  /** Chave privada — usada para assinar */
+  privateKey: KeyObject;
+  /** Chave pública — exposta via JWKS */
+  publicKey: KeyObject;
+}
+
+export interface KeyOptions {
+  /** PEM da chave privada (Buffer ou caminho). Se omitido, gera-se um par novo. */
+  privateKey?: Buffer | string;
+  /** PEM da chave pública (Buffer ou caminho). Opcional — derivada da privada quando omitida. */
+  publicKey?: Buffer | string;
+  /** Identificador da chave. Padrão: 'rnds-sandbox-1' */
+  keyId?: string;
+}
+
+const DEFAULT_KEY_ID = 'rnds-sandbox-1';
+
+export function resolveSigningKeys(options: KeyOptions = {}): SigningKeys {
+  const keyId = options.keyId ?? DEFAULT_KEY_ID;
+
+  if (options.privateKey) {
+    const privatePem = readPem(options.privateKey);
+    const privateKey = createPrivateKey(privatePem);
+    const publicKey = options.publicKey
+      ? createPublicKey(readPem(options.publicKey))
+      : createPublicKey(privateKey);
+    return { keyId, privateKey, publicKey };
+  }
+
+  const generated = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  return {
+    keyId,
+    privateKey: generated.privateKey,
+    publicKey: generated.publicKey,
+  };
+}
+
+function readPem(value: Buffer | string): Buffer | string {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.includes('-----BEGIN')) {
+    return value;
+  }
+  return fs.readFileSync(value);
+}

--- a/packages/rnds-sandbox/src/keys.ts
+++ b/packages/rnds-sandbox/src/keys.ts
@@ -35,6 +35,13 @@ export interface KeyOptions {
 
 const DEFAULT_KEY_ID = 'rnds-sandbox-1';
 
+// Singleton lazy do par RSA gerado — caro (~50ms) e não-determinístico.
+// Cacheamos pra que múltiplos `resolveSigningKeys()` sem opções (caso
+// típico de testes que rodam à parte) compartilhem o mesmo par e o
+// `kid`. Quem precisar de chaves distintas passa `keyId` ou `privateKey`
+// diferentes.
+let cachedDefaultKeys: SigningKeys | undefined;
+
 export function resolveSigningKeys(options: KeyOptions = {}): SigningKeys {
   const keyId = options.keyId ?? DEFAULT_KEY_ID;
 
@@ -47,12 +54,27 @@ export function resolveSigningKeys(options: KeyOptions = {}): SigningKeys {
     return { keyId, privateKey, publicKey };
   }
 
+  // Cache atinge somente o caminho default (sem PEM, com keyId padrão).
+  // Qualquer override de keyId exige par novo (testes podem querer kids distintos).
+  if (keyId === DEFAULT_KEY_ID && cachedDefaultKeys) {
+    return cachedDefaultKeys;
+  }
+
   const generated = generateKeyPairSync('rsa', { modulusLength: 2048 });
-  return {
+  const result: SigningKeys = {
     keyId,
     privateKey: generated.privateKey,
     publicKey: generated.publicKey,
   };
+  if (keyId === DEFAULT_KEY_ID) {
+    cachedDefaultKeys = result;
+  }
+  return result;
+}
+
+/** Limpa o cache do par default — útil em testes que precisam reset. */
+export function resetSigningKeysCache(): void {
+  cachedDefaultKeys = undefined;
 }
 
 function readPem(value: Buffer | string): Buffer | string {

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -290,9 +290,9 @@ function handleSubmitBundle(ctx: RouteContext): RouteResponse {
 
   ctx.store.recordBundle(bundle);
 
-  const responseEntries: SandboxBundleEntry[] = (bundle.entry ?? []).map((_, index) => ({
+  const responseEntries: SandboxBundleEntry[] = (bundle.entry ?? []).map(() => ({
     response: {
-      location: `Resource/sandbox-${index + 1}`,
+      location: `Resource/sandbox-${ctx.store.nextResourceId()}`,
       status: '201 Created',
     },
   }));

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -290,6 +290,10 @@ function handleSubmitBundle(ctx: RouteContext): RouteResponse {
 
   ctx.store.recordBundle(bundle);
 
+  // As `location`s retornadas são puramente sintéticas — servem só para
+  // imitar o formato de transaction-response da RNDS. O sandbox não
+  // resolve esses IDs de volta; os recursos submetidos são consultados
+  // via `GET /{ResourceType}?subject=Patient/{cns}` (ou similar).
   const responseEntries: SandboxBundleEntry[] = (bundle.entry ?? []).map(() => ({
     response: {
       location: `Resource/sandbox-${ctx.store.nextResourceId()}`,

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -2,27 +2,54 @@
  * Roteador HTTP do sandbox.
  *
  * Mapeia o subset de endpoints da RNDS consumidos por
- * @precisa-saude/fhir-rnds. Não cobre o protocolo FHIR completo.
+ * @precisa-saude/fhir-rnds. Aplica autenticação por rota:
+ *
+ *  - /api/token: exige certificado mTLS quando o sandbox roda em modo
+ *    `--mtls` (RNDS de fato exige nesse endpoint).
+ *  - /api/fhir/r4/*: em modo `strict`, exige bearer token assinado +
+ *    header `Authorization: <CNS>` (igual à API real). Em modo
+ *    permissivo (padrão sem flags), aceita sem auth — útil para
+ *    curl / aulas sem fricção.
+ *  - /.well-known/jwks.json: público sempre.
  */
 
-import { issueToken } from './auth';
+import { issueToken, verifyToken } from './auth';
+import { buildJwks } from './jwks';
+import type { SigningKeys } from './keys';
 import type { SandboxStore } from './store';
 import type { SandboxBundle, SandboxBundleEntry } from './types';
 
 const FHIR_PREFIX = '/api/fhir/r4';
 const TOKEN_PATH = '/api/token';
+const JWKS_PATH = '/.well-known/jwks.json';
 
 const NS = {
   cns: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
   cpf: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf',
 } as const;
 
+export interface PeerCertInfo {
+  /** Common Name (subject.CN) do cert apresentado, se houver */
+  cn?: string;
+  /** CNES de 7 dígitos extraído do CN (heurística), se encontrado */
+  cnes?: string;
+  /** True quando o cliente apresentou um certificado válido (qualquer CA) */
+  presented: boolean;
+}
+
 export interface RouteContext {
   body?: unknown;
+  /** Cabeçalhos HTTP recebidos (chaves em lowercase) */
+  headers: Record<string, string | undefined>;
+  keys: SigningKeys;
   method: string;
   path: string;
+  /** Informação extraída do certificado mTLS, quando o servidor está em modo mtls */
+  peerCert?: PeerCertInfo;
   query: URLSearchParams;
   store: SandboxStore;
+  /** Quando true, /api/token requer cert apresentado e FHIR exige bearer + CNS */
+  strict: boolean;
 }
 
 export interface RouteResponse {
@@ -31,12 +58,23 @@ export interface RouteResponse {
 }
 
 export function dispatch(ctx: RouteContext): RouteResponse {
+  if (ctx.method === 'GET' && ctx.path === JWKS_PATH) {
+    return { body: buildJwks(ctx.keys), status: 200 };
+  }
+
   if (ctx.method === 'POST' && ctx.path === TOKEN_PATH) {
-    return { body: issueToken(), status: 200 };
+    return handleToken(ctx);
   }
 
   if (!ctx.path.startsWith(FHIR_PREFIX)) {
     return notFound(`Recurso não encontrado: ${ctx.path}`);
+  }
+
+  if (ctx.strict) {
+    const authError = enforceFhirAuth(ctx);
+    if (authError) {
+      return authError;
+    }
   }
 
   const fhirPath = ctx.path.slice(FHIR_PREFIX.length);
@@ -52,6 +90,78 @@ export function dispatch(ctx: RouteContext): RouteResponse {
     body: operationOutcome('error', 'not-supported', `${ctx.method} ${ctx.path} não suportado`),
     status: 405,
   };
+}
+
+function handleToken(ctx: RouteContext): RouteResponse {
+  if (ctx.strict && !ctx.peerCert?.presented) {
+    return {
+      body: operationOutcome(
+        'error',
+        'security',
+        'Certificado mTLS é obrigatório em /api/token quando o sandbox está em modo --mtls',
+      ),
+      status: 401,
+    };
+  }
+  const tokenPayload = issueToken(ctx.keys, {
+    identity: ctx.peerCert?.presented
+      ? { cn: ctx.peerCert.cn, cnes: ctx.peerCert.cnes }
+      : undefined,
+  });
+  return { body: tokenPayload, status: 200 };
+}
+
+function enforceFhirAuth(ctx: RouteContext): RouteResponse | null {
+  const bearerHeader = ctx.headers['x-authorization-server'];
+  if (!bearerHeader) {
+    return {
+      body: operationOutcome(
+        'error',
+        'security',
+        'header X-Authorization-Server: Bearer <token> é obrigatório',
+      ),
+      status: 401,
+    };
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(bearerHeader);
+  if (!match) {
+    return {
+      body: operationOutcome(
+        'error',
+        'security',
+        'X-Authorization-Server deve usar o esquema "Bearer <token>"',
+      ),
+      status: 401,
+    };
+  }
+  const token = match[1]!.trim();
+  const verification = verifyToken(token, ctx.keys);
+  if (!verification.valid) {
+    return {
+      body: operationOutcome('error', 'security', `Token inválido (${verification.reason})`),
+      status: 401,
+    };
+  }
+
+  const cnsHeader = ctx.headers['authorization'];
+  if (!cnsHeader) {
+    return {
+      body: operationOutcome(
+        'error',
+        'required',
+        'header Authorization: <CNS-do-profissional> é obrigatório',
+      ),
+      status: 400,
+    };
+  }
+  if (!/^\d{15}$/.test(cnsHeader.trim())) {
+    return {
+      body: operationOutcome('error', 'invalid', 'Authorization deve conter um CNS de 15 dígitos'),
+      status: 400,
+    };
+  }
+
+  return null;
 }
 
 function handleFhirGet(fhirPath: string, ctx: RouteContext): RouteResponse {
@@ -114,8 +224,6 @@ function handlePatientSearch(ctx: RouteContext): RouteResponse {
     return notFound(`NamingSystem não suportado: ${system}`);
   }
 
-  // RNDS retorna o Patient direto (não searchset) quando há match único.
-  // Se não houver, retorna 404 — o cliente trata como null.
   return patient
     ? { body: patient, status: 200 }
     : notFound(`Paciente ${system}|${value} não encontrado`);

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -1,0 +1,175 @@
+/**
+ * Roteador HTTP do sandbox.
+ *
+ * Mapeia o subset de endpoints da RNDS consumidos por
+ * @precisa-saude/fhir-rnds. Não cobre o protocolo FHIR completo.
+ */
+
+import { issueToken } from './auth';
+import type { SandboxStore } from './store';
+import type { SandboxBundle, SandboxBundleEntry } from './types';
+
+const FHIR_PREFIX = '/api/fhir/r4';
+const TOKEN_PATH = '/api/token';
+
+const NS = {
+  cns: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
+  cpf: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf',
+} as const;
+
+export interface RouteContext {
+  body?: unknown;
+  method: string;
+  path: string;
+  query: URLSearchParams;
+  store: SandboxStore;
+}
+
+export interface RouteResponse {
+  body: unknown;
+  status: number;
+}
+
+export function dispatch(ctx: RouteContext): RouteResponse {
+  if (ctx.method === 'POST' && ctx.path === TOKEN_PATH) {
+    return { body: issueToken(), status: 200 };
+  }
+
+  if (!ctx.path.startsWith(FHIR_PREFIX)) {
+    return notFound(`Recurso não encontrado: ${ctx.path}`);
+  }
+
+  const fhirPath = ctx.path.slice(FHIR_PREFIX.length);
+
+  if (ctx.method === 'GET') {
+    return handleFhirGet(fhirPath, ctx);
+  }
+  if (ctx.method === 'POST' && fhirPath === '/Bundle') {
+    return handleSubmitBundle(ctx);
+  }
+
+  return {
+    body: operationOutcome('error', 'not-supported', `${ctx.method} ${ctx.path} não suportado`),
+    status: 405,
+  };
+}
+
+function handleFhirGet(fhirPath: string, ctx: RouteContext): RouteResponse {
+  if (fhirPath === '/Patient') {
+    return handlePatientSearch(ctx);
+  }
+  const patientMatch = /^\/Patient\/([^/]+)$/.exec(fhirPath);
+  if (patientMatch) {
+    const cns = decodeURIComponent(patientMatch[1]!);
+    const patient = ctx.store.findPatientByCns(cns);
+    return patient
+      ? { body: patient, status: 200 }
+      : notFound(`Paciente CNS ${cns} não encontrado`);
+  }
+  const orgMatch = /^\/Organization\/([^/]+)$/.exec(fhirPath);
+  if (orgMatch) {
+    const cnes = decodeURIComponent(orgMatch[1]!);
+    const org = ctx.store.findOrganizationByCnes(cnes);
+    return org
+      ? { body: org, status: 200 }
+      : notFound(`Organização CNES ${cnes} não encontrada`);
+  }
+  const practMatch = /^\/Practitioner\/([^/]+)$/.exec(fhirPath);
+  if (practMatch) {
+    const cns = decodeURIComponent(practMatch[1]!);
+    const pract = ctx.store.findPractitionerByCns(cns);
+    return pract
+      ? { body: pract, status: 200 }
+      : notFound(`Profissional CNS ${cns} não encontrado`);
+  }
+  return notFound(`Recurso FHIR não suportado: ${fhirPath}`);
+}
+
+function handlePatientSearch(ctx: RouteContext): RouteResponse {
+  const identifier = ctx.query.get('identifier');
+  if (!identifier) {
+    return {
+      body: operationOutcome(
+        'error',
+        'required',
+        'parâmetro identifier é obrigatório em /Patient',
+      ),
+      status: 400,
+    };
+  }
+  const [system, value] = identifier.split('|');
+  if (!system || !value) {
+    return {
+      body: operationOutcome('error', 'invalid', 'identifier deve ser no formato system|value'),
+      status: 400,
+    };
+  }
+
+  let patient = undefined;
+  if (system === NS.cpf) {
+    patient = ctx.store.findPatientByCpf(value);
+  } else if (system === NS.cns) {
+    patient = ctx.store.findPatientByCns(value);
+  } else {
+    return notFound(`NamingSystem não suportado: ${system}`);
+  }
+
+  // RNDS retorna o Patient direto (não searchset) quando há match único.
+  // Se não houver, retorna 404 — o cliente trata como null.
+  return patient
+    ? { body: patient, status: 200 }
+    : notFound(`Paciente ${system}|${value} não encontrado`);
+}
+
+function handleSubmitBundle(ctx: RouteContext): RouteResponse {
+  const bundle = ctx.body as SandboxBundle | undefined;
+  if (!bundle || bundle.resourceType !== 'Bundle') {
+    return {
+      body: operationOutcome('error', 'structure', 'corpo da requisição não é um Bundle FHIR'),
+      status: 400,
+    };
+  }
+  if (bundle.type !== 'transaction' && bundle.type !== 'batch') {
+    return {
+      body: operationOutcome(
+        'error',
+        'invalid',
+        `Bundle.type "${String(bundle.type)}" não suportado — use transaction ou batch`,
+      ),
+      status: 400,
+    };
+  }
+
+  ctx.store.recordBundle(bundle);
+
+  const responseEntries: SandboxBundleEntry[] = (bundle.entry ?? []).map((_, index) => ({
+    response: {
+      location: `Resource/sandbox-${index + 1}`,
+      status: '201 Created',
+    },
+  }));
+  const response: SandboxBundle = {
+    entry: responseEntries,
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+  };
+  return { body: response, status: 200 };
+}
+
+function notFound(diagnostics: string): RouteResponse {
+  return {
+    body: operationOutcome('error', 'not-found', diagnostics),
+    status: 404,
+  };
+}
+
+function operationOutcome(
+  severity: 'fatal' | 'error' | 'warning' | 'information',
+  code: string,
+  diagnostics: string,
+): unknown {
+  return {
+    issue: [{ code, diagnostics, severity }],
+    resourceType: 'OperationOutcome',
+  };
+}

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -164,6 +164,19 @@ function enforceFhirAuth(ctx: RouteContext): RouteResponse | null {
   return null;
 }
 
+/**
+ * Tipos cuja busca por paciente o sandbox suporta. Cada um aceita
+ * `?subject=Patient/{cns}` ou `?patient=Patient/{cns}` (também tolera
+ * só o CNS sem prefixo).
+ */
+const SEARCHABLE_BY_PATIENT = new Set([
+  'Observation',
+  'DiagnosticReport',
+  'Immunization',
+  'Condition',
+  'Encounter',
+]);
+
 function handleFhirGet(fhirPath: string, ctx: RouteContext): RouteResponse {
   if (fhirPath === '/Patient') {
     return handlePatientSearch(ctx);
@@ -180,9 +193,7 @@ function handleFhirGet(fhirPath: string, ctx: RouteContext): RouteResponse {
   if (orgMatch) {
     const cnes = decodeURIComponent(orgMatch[1]!);
     const org = ctx.store.findOrganizationByCnes(cnes);
-    return org
-      ? { body: org, status: 200 }
-      : notFound(`Organização CNES ${cnes} não encontrada`);
+    return org ? { body: org, status: 200 } : notFound(`Organização CNES ${cnes} não encontrada`);
   }
   const practMatch = /^\/Practitioner\/([^/]+)$/.exec(fhirPath);
   if (practMatch) {
@@ -192,18 +203,47 @@ function handleFhirGet(fhirPath: string, ctx: RouteContext): RouteResponse {
       ? { body: pract, status: 200 }
       : notFound(`Profissional CNS ${cns} não encontrado`);
   }
+  const searchMatch = /^\/([A-Z][A-Za-z]+)$/.exec(fhirPath);
+  if (searchMatch) {
+    const resourceType = searchMatch[1]!;
+    if (SEARCHABLE_BY_PATIENT.has(resourceType)) {
+      return handleResourceSearch(resourceType, ctx);
+    }
+  }
   return notFound(`Recurso FHIR não suportado: ${fhirPath}`);
+}
+
+function handleResourceSearch(resourceType: string, ctx: RouteContext): RouteResponse {
+  const ref = ctx.query.get('subject') ?? ctx.query.get('patient');
+  if (!ref) {
+    return {
+      body: operationOutcome(
+        'error',
+        'required',
+        `${resourceType} search exige ?subject=Patient/{cns} ou ?patient=Patient/{cns}`,
+      ),
+      status: 400,
+    };
+  }
+  const cns = ref.startsWith('Patient/') ? ref.slice('Patient/'.length) : ref;
+  const matches = ctx.store.searchResourcesByPatient(resourceType, cns);
+  const entry: SandboxBundleEntry[] = matches.map((resource) => ({ resource }));
+  return {
+    body: {
+      entry,
+      resourceType: 'Bundle',
+      total: matches.length,
+      type: 'searchset',
+    },
+    status: 200,
+  };
 }
 
 function handlePatientSearch(ctx: RouteContext): RouteResponse {
   const identifier = ctx.query.get('identifier');
   if (!identifier) {
     return {
-      body: operationOutcome(
-        'error',
-        'required',
-        'parâmetro identifier é obrigatório em /Patient',
-      ),
+      body: operationOutcome('error', 'required', 'parâmetro identifier é obrigatório em /Patient'),
       status: 400,
     };
   }

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -270,8 +270,15 @@ function handlePatientSearch(ctx: RouteContext): RouteResponse {
 }
 
 function handleSubmitBundle(ctx: RouteContext): RouteResponse {
+  if (typeof ctx.body === 'symbol') {
+    // sentinela INVALID_BODY de readBody — JSON malformado
+    return {
+      body: operationOutcome('error', 'structure', 'corpo da requisição não é JSON válido'),
+      status: 400,
+    };
+  }
   const bundle = ctx.body as SandboxBundle | undefined;
-  if (!bundle || bundle.resourceType !== 'Bundle') {
+  if (!bundle || typeof bundle !== 'object' || bundle.resourceType !== 'Bundle') {
     return {
       body: operationOutcome('error', 'structure', 'corpo da requisição não é um Bundle FHIR'),
       status: 400,

--- a/packages/rnds-sandbox/src/scenarios/index.ts
+++ b/packages/rnds-sandbox/src/scenarios/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Registro de cenários disponíveis no sandbox.
+ */
+
+import type { Scenario, ScenarioName } from '../types';
+
+import { internacao } from './internacao';
+import { pacienteComExames } from './paciente-com-exames';
+import { vacina } from './vacina';
+
+export const SCENARIOS: Record<ScenarioName, Scenario> = {
+  'paciente-com-exames': pacienteComExames,
+  internacao,
+  vacina,
+  vazio: {
+    description: 'Estado limpo. Útil para testar fluxos do zero.',
+    name: 'vazio',
+    data: { organizations: [], patients: [], practitioners: [] },
+  },
+};
+
+export function resolveScenario(name: ScenarioName | undefined): Scenario {
+  return SCENARIOS[name ?? 'paciente-com-exames'];
+}
+
+export { internacao, pacienteComExames, vacina };

--- a/packages/rnds-sandbox/src/scenarios/index.ts
+++ b/packages/rnds-sandbox/src/scenarios/index.ts
@@ -3,19 +3,18 @@
  */
 
 import type { Scenario, ScenarioName } from '../types';
-
 import { internacao } from './internacao';
 import { pacienteComExames } from './paciente-com-exames';
 import { vacina } from './vacina';
 
 export const SCENARIOS: Record<ScenarioName, Scenario> = {
-  'paciente-com-exames': pacienteComExames,
   internacao,
+  'paciente-com-exames': pacienteComExames,
   vacina,
   vazio: {
+    data: { organizations: [], patients: [], practitioners: [] },
     description: 'Estado limpo. Útil para testar fluxos do zero.',
     name: 'vazio',
-    data: { organizations: [], patients: [], practitioners: [] },
   },
 };
 

--- a/packages/rnds-sandbox/src/scenarios/internacao.ts
+++ b/packages/rnds-sandbox/src/scenarios/internacao.ts
@@ -14,9 +14,6 @@ const CNES_HOSPITAL = '3456789';
 const CNS_PROFISSIONAL = '700000000000030';
 
 export const internacao: Scenario = {
-  description:
-    'Carlos Henrique Souza (CPF 987.654.321-00, CNS 700 0000 0000 0020), 67 anos, internado por insuficiência cardíaca descompensada (CID I50.0). Hospital CNES 3456789.',
-  name: 'internacao',
   data: {
     organizations: [
       {
@@ -58,8 +55,6 @@ export const internacao: Scenario = {
     ],
     submittedBundles: [
       {
-        resourceType: 'Bundle',
-        type: 'transaction',
         entry: [
           {
             request: { method: 'POST', url: 'Encounter' },
@@ -111,9 +106,7 @@ export const internacao: Scenario = {
             request: { method: 'POST', url: 'Observation' },
             resource: {
               code: {
-                coding: [
-                  { code: '49563-0', display: 'Troponina I', system: 'http://loinc.org' },
-                ],
+                coding: [{ code: '49563-0', display: 'Troponina I', system: 'http://loinc.org' }],
               },
               effectiveDateTime: '2026-04-15T11:15:00-03:00',
               resourceType: 'Observation',
@@ -128,7 +121,12 @@ export const internacao: Scenario = {
             },
           },
         ],
+        resourceType: 'Bundle',
+        type: 'transaction',
       },
     ],
   },
+  description:
+    'Carlos Henrique Souza (CPF 987.654.321-00, CNS 700 0000 0000 0020), 67 anos, internado por insuficiência cardíaca descompensada (CID I50.0). Hospital CNES 3456789.',
+  name: 'internacao',
 };

--- a/packages/rnds-sandbox/src/scenarios/internacao.ts
+++ b/packages/rnds-sandbox/src/scenarios/internacao.ts
@@ -1,0 +1,134 @@
+/**
+ * Cenário: paciente com episódio de internação recente.
+ *
+ * Carlos Henrique Souza, 67 anos, internado por descompensação de
+ * insuficiência cardíaca. Bundle pré-submetido contém Encounter
+ * (admissão) + Observations (BNP, troponina) + Condition (CID I50.0).
+ */
+
+import type { Scenario } from '../types';
+
+const CPF = '98765432100';
+const CNS = '700000000000020';
+const CNES_HOSPITAL = '3456789';
+const CNS_PROFISSIONAL = '700000000000030';
+
+export const internacao: Scenario = {
+  description:
+    'Carlos Henrique Souza (CPF 987.654.321-00, CNS 700 0000 0000 0020), 67 anos, internado por insuficiência cardíaca descompensada (CID I50.0). Hospital CNES 3456789.',
+  name: 'internacao',
+  data: {
+    organizations: [
+      {
+        active: true,
+        id: CNES_HOSPITAL,
+        identifier: [
+          { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cnes', value: CNES_HOSPITAL },
+        ],
+        name: 'Hospital Sintético do Coração (sandbox)',
+        resourceType: 'Organization',
+      },
+    ],
+    patients: [
+      {
+        birthDate: '1958-02-28',
+        gender: 'male',
+        id: CNS,
+        identifier: [
+          { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf', value: CPF },
+          { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns', value: CNS },
+        ],
+        name: [{ family: 'Souza', given: ['Carlos', 'Henrique'] }],
+        resourceType: 'Patient',
+      },
+    ],
+    practitioners: [
+      {
+        active: true,
+        id: CNS_PROFISSIONAL,
+        identifier: [
+          {
+            system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
+            value: CNS_PROFISSIONAL,
+          },
+        ],
+        name: [{ family: 'Mendes', given: ['Roberto'] }],
+        resourceType: 'Practitioner',
+      },
+    ],
+    submittedBundles: [
+      {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            request: { method: 'POST', url: 'Encounter' },
+            resource: {
+              class: { code: 'IMP', display: 'inpatient encounter' },
+              period: { start: '2026-04-15T10:30:00-03:00' },
+              resourceType: 'Encounter',
+              serviceProvider: { reference: `Organization/${CNES_HOSPITAL}` },
+              status: 'in-progress',
+              subject: { reference: `Patient/${CNS}` },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Condition' },
+            resource: {
+              code: {
+                coding: [
+                  {
+                    code: 'I50.0',
+                    display: 'Insuficiência cardíaca congestiva',
+                    system: 'http://hl7.org/fhir/sid/icd-10',
+                  },
+                ],
+              },
+              recordedDate: '2026-04-15',
+              resourceType: 'Condition',
+              subject: { reference: `Patient/${CNS}` },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: {
+                coding: [{ code: '33762-6', display: 'NT-proBNP', system: 'http://loinc.org' }],
+              },
+              effectiveDateTime: '2026-04-15T11:15:00-03:00',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: `Patient/${CNS}` },
+              valueQuantity: {
+                code: 'pg/mL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'pg/mL',
+                value: 4820,
+              },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: {
+                coding: [
+                  { code: '49563-0', display: 'Troponina I', system: 'http://loinc.org' },
+                ],
+              },
+              effectiveDateTime: '2026-04-15T11:15:00-03:00',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: `Patient/${CNS}` },
+              valueQuantity: {
+                code: 'ng/mL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'ng/mL',
+                value: 0.08,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/packages/rnds-sandbox/src/scenarios/paciente-com-exames.ts
+++ b/packages/rnds-sandbox/src/scenarios/paciente-com-exames.ts
@@ -16,9 +16,6 @@ const CNES_LAB = '2345678';
 const CNS_PROFISSIONAL = '700000000000010';
 
 export const pacienteComExames: Scenario = {
-  description:
-    'Joana Maria da Silva (CPF 123.456.789-01, CNS 700 0000 0000 0001), 42 anos, com histórico de lipidograma e glicemia. Laboratório CNES 2345678. Profissional Dr(a). Pereira (CNS 700 0000 0000 0010).',
-  name: 'paciente-com-exames',
   data: {
     organizations: [
       {
@@ -63,8 +60,6 @@ export const pacienteComExames: Scenario = {
     ],
     submittedBundles: [
       {
-        resourceType: 'Bundle',
-        type: 'transaction',
         entry: [
           {
             request: { method: 'POST', url: 'Observation' },
@@ -94,9 +89,7 @@ export const pacienteComExames: Scenario = {
             request: { method: 'POST', url: 'Observation' },
             resource: {
               code: {
-                coding: [
-                  { code: '2089-1', display: 'LDL-Colesterol', system: 'http://loinc.org' },
-                ],
+                coding: [{ code: '2089-1', display: 'LDL-Colesterol', system: 'http://loinc.org' }],
               },
               effectiveDateTime: '2025-09-10',
               resourceType: 'Observation',
@@ -114,9 +107,7 @@ export const pacienteComExames: Scenario = {
             request: { method: 'POST', url: 'Observation' },
             resource: {
               code: {
-                coding: [
-                  { code: '2085-9', display: 'HDL-Colesterol', system: 'http://loinc.org' },
-                ],
+                coding: [{ code: '2085-9', display: 'HDL-Colesterol', system: 'http://loinc.org' }],
               },
               effectiveDateTime: '2025-09-10',
               resourceType: 'Observation',
@@ -149,7 +140,12 @@ export const pacienteComExames: Scenario = {
             },
           },
         ],
+        resourceType: 'Bundle',
+        type: 'transaction',
       },
     ],
   },
+  description:
+    'Joana Maria da Silva (CPF 123.456.789-01, CNS 700 0000 0000 0001), 42 anos, com histórico de lipidograma e glicemia. Laboratório CNES 2345678. Profissional Dr(a). Pereira (CNS 700 0000 0000 0010).',
+  name: 'paciente-com-exames',
 };

--- a/packages/rnds-sandbox/src/scenarios/paciente-com-exames.ts
+++ b/packages/rnds-sandbox/src/scenarios/paciente-com-exames.ts
@@ -1,0 +1,155 @@
+/**
+ * Cenário: paciente com histórico de exames laboratoriais.
+ *
+ * Joana Maria da Silva, 42 anos, com Bundle pré-submetido de
+ * lipidograma, glicemia e hemograma. Útil para demonstrar
+ * o fluxo "buscar paciente → consultar exames anteriores → submeter novos".
+ *
+ * IDs sintéticos — não correspondem a CPF/CNS reais.
+ */
+
+import type { Scenario } from '../types';
+
+const CPF = '12345678901';
+const CNS = '700000000000001';
+const CNES_LAB = '2345678';
+const CNS_PROFISSIONAL = '700000000000010';
+
+export const pacienteComExames: Scenario = {
+  description:
+    'Joana Maria da Silva (CPF 123.456.789-01, CNS 700 0000 0000 0001), 42 anos, com histórico de lipidograma e glicemia. Laboratório CNES 2345678. Profissional Dr(a). Pereira (CNS 700 0000 0000 0010).',
+  name: 'paciente-com-exames',
+  data: {
+    organizations: [
+      {
+        active: true,
+        id: CNES_LAB,
+        identifier: [
+          {
+            system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cnes',
+            value: CNES_LAB,
+          },
+        ],
+        name: 'Laboratório Sintético São Paulo (sandbox)',
+        resourceType: 'Organization',
+      },
+    ],
+    patients: [
+      {
+        birthDate: '1983-08-12',
+        gender: 'female',
+        id: CNS,
+        identifier: [
+          { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf', value: CPF },
+          { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns', value: CNS },
+        ],
+        name: [{ family: 'Silva', given: ['Joana', 'Maria', 'da'] }],
+        resourceType: 'Patient',
+      },
+    ],
+    practitioners: [
+      {
+        active: true,
+        id: CNS_PROFISSIONAL,
+        identifier: [
+          {
+            system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
+            value: CNS_PROFISSIONAL,
+          },
+        ],
+        name: [{ family: 'Pereira', given: ['Ana', 'Carolina'] }],
+        resourceType: 'Practitioner',
+      },
+    ],
+    submittedBundles: [
+      {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: {
+                coding: [
+                  {
+                    code: '2093-3',
+                    display: 'Colesterol total',
+                    system: 'http://loinc.org',
+                  },
+                ],
+              },
+              effectiveDateTime: '2025-09-10',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: `Patient/${CNS}` },
+              valueQuantity: {
+                code: 'mg/dL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'mg/dL',
+                value: 198,
+              },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: {
+                coding: [
+                  { code: '2089-1', display: 'LDL-Colesterol', system: 'http://loinc.org' },
+                ],
+              },
+              effectiveDateTime: '2025-09-10',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: `Patient/${CNS}` },
+              valueQuantity: {
+                code: 'mg/dL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'mg/dL',
+                value: 124,
+              },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: {
+                coding: [
+                  { code: '2085-9', display: 'HDL-Colesterol', system: 'http://loinc.org' },
+                ],
+              },
+              effectiveDateTime: '2025-09-10',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: `Patient/${CNS}` },
+              valueQuantity: {
+                code: 'mg/dL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'mg/dL',
+                value: 56,
+              },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              code: {
+                coding: [{ code: '2345-7', display: 'Glicose', system: 'http://loinc.org' }],
+              },
+              effectiveDateTime: '2025-09-10',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: `Patient/${CNS}` },
+              valueQuantity: {
+                code: 'mg/dL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'mg/dL',
+                value: 96,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/packages/rnds-sandbox/src/scenarios/vacina.ts
+++ b/packages/rnds-sandbox/src/scenarios/vacina.ts
@@ -1,0 +1,113 @@
+/**
+ * Cenário: paciente com calendário vacinal aplicado.
+ *
+ * Pedro Lima Almeida, 8 anos, com Bundle pré-submetido contendo
+ * Immunization (BCG, hepatite B, pentavalente, tríplice viral).
+ */
+
+import type { Scenario } from '../types';
+
+const CNS = '700000000000040';
+const CNES_UBS = '4567890';
+const CNS_PROFISSIONAL = '700000000000050';
+
+export const vacina: Scenario = {
+  description:
+    'Pedro Lima Almeida (CNS 700 0000 0000 0040), 8 anos, com calendário vacinal aplicado em UBS CNES 4567890.',
+  name: 'vacina',
+  data: {
+    organizations: [
+      {
+        active: true,
+        id: CNES_UBS,
+        identifier: [
+          { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cnes', value: CNES_UBS },
+        ],
+        name: 'UBS Sintética Vila Saúde (sandbox)',
+        resourceType: 'Organization',
+      },
+    ],
+    patients: [
+      {
+        birthDate: '2017-11-04',
+        gender: 'male',
+        id: CNS,
+        identifier: [{ system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns', value: CNS }],
+        name: [{ family: 'Almeida', given: ['Pedro', 'Lima'] }],
+        resourceType: 'Patient',
+      },
+    ],
+    practitioners: [
+      {
+        active: true,
+        id: CNS_PROFISSIONAL,
+        identifier: [
+          {
+            system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
+            value: CNS_PROFISSIONAL,
+          },
+        ],
+        name: [{ family: 'Costa', given: ['Fernanda'] }],
+        resourceType: 'Practitioner',
+      },
+    ],
+    submittedBundles: [
+      {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            request: { method: 'POST', url: 'Immunization' },
+            resource: {
+              occurrenceDateTime: '2017-11-05',
+              patient: { reference: `Patient/${CNS}` },
+              resourceType: 'Immunization',
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  { code: 'BCG', display: 'BCG', system: 'urn:oid:2.16.840.1.113883.6.59' },
+                ],
+              },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Immunization' },
+            resource: {
+              occurrenceDateTime: '2017-11-05',
+              patient: { reference: `Patient/${CNS}` },
+              resourceType: 'Immunization',
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  {
+                    code: 'HBV',
+                    display: 'Hepatite B (RN)',
+                    system: 'urn:oid:2.16.840.1.113883.6.59',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            request: { method: 'POST', url: 'Immunization' },
+            resource: {
+              occurrenceDateTime: '2018-12-12',
+              patient: { reference: `Patient/${CNS}` },
+              resourceType: 'Immunization',
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  {
+                    code: 'MMR',
+                    display: 'Tríplice viral (SCR)',
+                    system: 'urn:oid:2.16.840.1.113883.6.59',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/packages/rnds-sandbox/src/scenarios/vacina.ts
+++ b/packages/rnds-sandbox/src/scenarios/vacina.ts
@@ -12,9 +12,6 @@ const CNES_UBS = '4567890';
 const CNS_PROFISSIONAL = '700000000000050';
 
 export const vacina: Scenario = {
-  description:
-    'Pedro Lima Almeida (CNS 700 0000 0000 0040), 8 anos, com calendário vacinal aplicado em UBS CNES 4567890.',
-  name: 'vacina',
   data: {
     organizations: [
       {
@@ -53,8 +50,6 @@ export const vacina: Scenario = {
     ],
     submittedBundles: [
       {
-        resourceType: 'Bundle',
-        type: 'transaction',
         entry: [
           {
             request: { method: 'POST', url: 'Immunization' },
@@ -64,9 +59,7 @@ export const vacina: Scenario = {
               resourceType: 'Immunization',
               status: 'completed',
               vaccineCode: {
-                coding: [
-                  { code: 'BCG', display: 'BCG', system: 'urn:oid:2.16.840.1.113883.6.59' },
-                ],
+                coding: [{ code: 'BCG', display: 'BCG', system: 'urn:oid:2.16.840.1.113883.6.59' }],
               },
             },
           },
@@ -107,7 +100,12 @@ export const vacina: Scenario = {
             },
           },
         ],
+        resourceType: 'Bundle',
+        type: 'transaction',
       },
     ],
   },
+  description:
+    'Pedro Lima Almeida (CNS 700 0000 0000 0040), 8 anos, com calendário vacinal aplicado em UBS CNES 4567890.',
+  name: 'vacina',
 };

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -8,8 +8,8 @@
  */
 
 import fs from 'node:fs';
-import http from 'node:http';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import http from 'node:http';
 import https from 'node:https';
 import type { TLSSocket } from 'node:tls';
 
@@ -24,15 +24,16 @@ export interface SandboxServer {
   server: http.Server | https.Server;
   /** Chaves RSA usadas para assinar/validar tokens. */
   signingKeys: SigningKeys;
-  /** Store em memória — útil para inspeção em testes. */
-  store: SandboxStore;
   /** Inicia o servidor. Retorna quando estiver escutando. */
   start: () => Promise<{ host: string; port: number }>;
   /** Encerra o servidor. */
   stop: () => Promise<void>;
+  /** Store em memória — útil para inspeção em testes. */
+  store: SandboxStore;
 }
 
 export function createSandboxServer(options: SandboxOptions = {}): SandboxServer {
+  // eslint-disable-next-line no-console
   const log = options.log ?? ((msg: string) => console.log(`[rnds-sandbox] ${msg}`));
   const useMtls = options.mtls === true;
   const strict = options.strict ?? useMtls;
@@ -72,7 +73,6 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
   return {
     server,
     signingKeys,
-    store,
     start: () =>
       new Promise<{ host: string; port: number }>((resolve, reject) => {
         const onError = (err: Error) => {
@@ -95,6 +95,7 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
       new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
       }),
+    store,
   };
 }
 
@@ -194,9 +195,7 @@ function extractCnesFromCn(cn: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
-function lowercaseHeaders(
-  headers: http.IncomingHttpHeaders,
-): Record<string, string | undefined> {
+function lowercaseHeaders(headers: http.IncomingHttpHeaders): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {};
   for (const [key, value] of Object.entries(headers)) {
     if (Array.isArray(value)) {
@@ -222,9 +221,7 @@ function buildTlsOptions(options: SandboxOptions): https.ServerOptions {
     tlsOptions.key = resolveBuffer(options.serverKey);
     tlsOptions.cert = resolveBuffer(options.serverCert);
   } else {
-    throw new Error(
-      'mTLS requer --pfx + --pfx-password OU --server-key + --server-cert (PEM)',
-    );
+    throw new Error('mTLS requer --pfx + --pfx-password OU --server-key + --server-cert (PEM)');
   }
   return tlsOptions;
 }

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -1,0 +1,148 @@
+/**
+ * Servidor HTTP(S) do sandbox.
+ *
+ * Cria um http.Server (ou https.Server com mTLS) que despacha
+ * requisições para o roteador.
+ */
+
+import fs from 'node:fs';
+import http from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import https from 'node:https';
+
+import { dispatch, type RouteContext } from './router';
+import { resolveScenario } from './scenarios';
+import { SandboxStore } from './store';
+import type { SandboxOptions } from './types';
+
+export interface SandboxServer {
+  /** Servidor HTTP(S) subjacente. */
+  server: http.Server | https.Server;
+  /** Store em memória — útil para inspeção em testes. */
+  store: SandboxStore;
+  /** Inicia o servidor. Retorna quando estiver escutando. */
+  start: () => Promise<{ host: string; port: number }>;
+  /** Encerra o servidor. */
+  stop: () => Promise<void>;
+}
+
+export function createSandboxServer(options: SandboxOptions = {}): SandboxServer {
+  const log = options.log ?? ((msg: string) => console.log(`[rnds-sandbox] ${msg}`));
+  const useMtls = options.mtls === true;
+  const port = options.port ?? (useMtls ? 8443 : 8080);
+  const host = options.host ?? '127.0.0.1';
+
+  const store = new SandboxStore();
+  store.load(resolveScenario(options.scenario));
+
+  const handler = (req: IncomingMessage, res: ServerResponse) => {
+    handleRequest(req, res, store, log).catch((err: unknown) => {
+      log(`erro inesperado: ${err instanceof Error ? err.message : String(err)}`);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
+            resourceType: 'OperationOutcome',
+          }),
+        );
+      }
+    });
+  };
+
+  const server: http.Server | https.Server = useMtls
+    ? https.createServer(
+        {
+          pfx: resolvePfx(options.serverPfx),
+          passphrase: options.serverPfxPassword,
+          requestCert: true,
+          rejectUnauthorized: false,
+        },
+        handler,
+      )
+    : http.createServer(handler);
+
+  return {
+    server,
+    store,
+    start: () =>
+      new Promise<{ host: string; port: number }>((resolve, reject) => {
+        const onError = (err: Error) => {
+          server.off('error', onError);
+          reject(err);
+        };
+        server.once('error', onError);
+        server.listen(port, host, () => {
+          server.off('error', onError);
+          const address = server.address();
+          const actualPort = typeof address === 'object' && address ? address.port : port;
+          log(
+            `${useMtls ? 'HTTPS+mTLS' : 'HTTP'} ouvindo em ${host}:${actualPort} ` +
+              `(cenário: ${options.scenario ?? 'paciente-com-exames'})`,
+          );
+          resolve({ host, port: actualPort });
+        });
+      }),
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  store: SandboxStore,
+  log: (msg: string) => void,
+): Promise<void> {
+  const url = new URL(req.url ?? '/', 'http://sandbox.local');
+  const body = await readBody(req);
+  const ctx: RouteContext = {
+    body,
+    method: req.method ?? 'GET',
+    path: url.pathname,
+    query: url.searchParams,
+    store,
+  };
+
+  const response = dispatch(ctx);
+  log(`${ctx.method} ${ctx.path} → ${response.status}`);
+
+  res.writeHead(response.status, {
+    'Content-Type': 'application/fhir+json; charset=utf-8',
+  });
+  res.end(JSON.stringify(response.body));
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  if (req.method !== 'POST' && req.method !== 'PUT') {
+    return undefined;
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  if (chunks.length === 0) {
+    return undefined;
+  }
+  const text = Buffer.concat(chunks).toString('utf-8');
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function resolvePfx(pfx: Buffer | string | undefined): Buffer | undefined {
+  if (!pfx) {
+    return undefined;
+  }
+  if (typeof pfx === 'string') {
+    return fs.readFileSync(pfx);
+  }
+  return pfx;
+}

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -53,15 +53,19 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
     handleRequest(req, res, { keys: signingKeys, log, store, strict, useMtls }).catch(
       (err: unknown) => {
         log(`erro inesperado: ${err instanceof Error ? err.message : String(err)}`);
-        if (!res.headersSent) {
-          res.writeHead(500, { 'Content-Type': 'application/json' });
-          res.end(
-            JSON.stringify({
-              issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
-              resourceType: 'OperationOutcome',
-            }),
-          );
+        if (res.headersSent) {
+          // Headers já foram para o socket — só garante que o response feche
+          // para o cliente não pendurar. Sem body novo.
+          if (!res.writableEnded) res.end();
+          return;
         }
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
+            resourceType: 'OperationOutcome',
+          }),
+        );
       },
     );
   };

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -93,6 +93,9 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
       }),
     stop: () =>
       new Promise<void>((resolve, reject) => {
+        // server.close() para de aceitar novas conexões mas não derruba
+        // keep-alive existentes — em testes isso pode prender o vitest.
+        server.closeAllConnections?.();
         server.close((err) => (err ? reject(err) : resolve()));
       }),
     store,

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -59,7 +59,7 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
           if (!res.writableEnded) res.end();
           return;
         }
-        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.writeHead(500, { 'Content-Type': 'application/fhir+json; charset=utf-8' });
         res.end(
           JSON.stringify({
             issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
@@ -145,6 +145,9 @@ async function handleRequest(
   res.end(JSON.stringify(response.body));
 }
 
+/** Sentinela retornada quando o corpo da requisição não é JSON válido. */
+const INVALID_BODY = Symbol.for('rnds-sandbox.invalidBody');
+
 async function readBody(req: IncomingMessage): Promise<unknown> {
   if (req.method !== 'POST' && req.method !== 'PUT') {
     return undefined;
@@ -163,8 +166,16 @@ async function readBody(req: IncomingMessage): Promise<unknown> {
   try {
     return JSON.parse(text);
   } catch {
-    return text;
+    // JSON malformado — retorna sentinela. Handler de POST detecta e
+    // devolve OperationOutcome com `code: 'structure'` em vez de tentar
+    // tratar a string como Bundle.
+    return INVALID_BODY;
   }
+}
+
+/** True quando o body é a sentinela INVALID_BODY (JSON malformado). */
+export function isInvalidBody(body: unknown): boolean {
+  return body === INVALID_BODY;
 }
 
 function extractPeerCert(req: IncomingMessage): PeerCertInfo {

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -1,16 +1,20 @@
 /**
  * Servidor HTTP(S) do sandbox.
  *
- * Cria um http.Server (ou https.Server com mTLS) que despacha
- * requisições para o roteador.
+ * Cria um http.Server (sem mTLS) ou https.Server (com mTLS opcional)
+ * que despacha requisições para o roteador. Em modo mTLS, o cert do
+ * cliente apresentado no handshake é repassado ao roteador para que
+ * /api/token possa exigir + extrair identidade dele.
  */
 
 import fs from 'node:fs';
 import http from 'node:http';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import https from 'node:https';
+import type { TLSSocket } from 'node:tls';
 
-import { dispatch, type RouteContext } from './router';
+import { resolveSigningKeys, type SigningKeys } from './keys';
+import { dispatch, type PeerCertInfo, type RouteContext } from './router';
 import { resolveScenario } from './scenarios';
 import { SandboxStore } from './store';
 import type { SandboxOptions } from './types';
@@ -18,6 +22,8 @@ import type { SandboxOptions } from './types';
 export interface SandboxServer {
   /** Servidor HTTP(S) subjacente. */
   server: http.Server | https.Server;
+  /** Chaves RSA usadas para assinar/validar tokens. */
+  signingKeys: SigningKeys;
   /** Store em memória — útil para inspeção em testes. */
   store: SandboxStore;
   /** Inicia o servidor. Retorna quando estiver escutando. */
@@ -29,41 +35,43 @@ export interface SandboxServer {
 export function createSandboxServer(options: SandboxOptions = {}): SandboxServer {
   const log = options.log ?? ((msg: string) => console.log(`[rnds-sandbox] ${msg}`));
   const useMtls = options.mtls === true;
+  const strict = options.strict ?? useMtls;
   const port = options.port ?? (useMtls ? 8443 : 8080);
   const host = options.host ?? '127.0.0.1';
 
   const store = new SandboxStore();
   store.load(resolveScenario(options.scenario));
 
+  const signingKeys = resolveSigningKeys({
+    keyId: options.jwtKeyId,
+    privateKey: options.jwtPrivateKey,
+    publicKey: options.jwtPublicKey,
+  });
+
   const handler = (req: IncomingMessage, res: ServerResponse) => {
-    handleRequest(req, res, store, log).catch((err: unknown) => {
-      log(`erro inesperado: ${err instanceof Error ? err.message : String(err)}`);
-      if (!res.headersSent) {
-        res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
-            resourceType: 'OperationOutcome',
-          }),
-        );
-      }
-    });
+    handleRequest(req, res, { keys: signingKeys, log, store, strict, useMtls }).catch(
+      (err: unknown) => {
+        log(`erro inesperado: ${err instanceof Error ? err.message : String(err)}`);
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
+              resourceType: 'OperationOutcome',
+            }),
+          );
+        }
+      },
+    );
   };
 
   const server: http.Server | https.Server = useMtls
-    ? https.createServer(
-        {
-          pfx: resolvePfx(options.serverPfx),
-          passphrase: options.serverPfxPassword,
-          requestCert: true,
-          rejectUnauthorized: false,
-        },
-        handler,
-      )
+    ? https.createServer(buildTlsOptions(options), handler)
     : http.createServer(handler);
 
   return {
     server,
+    signingKeys,
     store,
     start: () =>
       new Promise<{ host: string; port: number }>((resolve, reject) => {
@@ -78,7 +86,7 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
           const actualPort = typeof address === 'object' && address ? address.port : port;
           log(
             `${useMtls ? 'HTTPS+mTLS' : 'HTTP'} ouvindo em ${host}:${actualPort} ` +
-              `(cenário: ${options.scenario ?? 'paciente-com-exames'})`,
+              `(cenário: ${options.scenario ?? 'paciente-com-exames'}, strict=${strict}, kid=${signingKeys.keyId})`,
           );
           resolve({ host, port: actualPort });
         });
@@ -90,24 +98,38 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
   };
 }
 
+interface HandlerContext {
+  keys: SigningKeys;
+  log: (msg: string) => void;
+  store: SandboxStore;
+  strict: boolean;
+  useMtls: boolean;
+}
+
 async function handleRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  store: SandboxStore,
-  log: (msg: string) => void,
+  ctx: HandlerContext,
 ): Promise<void> {
   const url = new URL(req.url ?? '/', 'http://sandbox.local');
   const body = await readBody(req);
-  const ctx: RouteContext = {
+  const peerCert = ctx.useMtls ? extractPeerCert(req) : undefined;
+  const headers = lowercaseHeaders(req.headers);
+
+  const routeCtx: RouteContext = {
     body,
+    headers,
+    keys: ctx.keys,
     method: req.method ?? 'GET',
     path: url.pathname,
+    peerCert,
     query: url.searchParams,
-    store,
+    store: ctx.store,
+    strict: ctx.strict,
   };
 
-  const response = dispatch(ctx);
-  log(`${ctx.method} ${ctx.path} → ${response.status}`);
+  const response = dispatch(routeCtx);
+  ctx.log(`${routeCtx.method} ${routeCtx.path} → ${response.status}`);
 
   res.writeHead(response.status, {
     'Content-Type': 'application/fhir+json; charset=utf-8',
@@ -137,12 +159,82 @@ async function readBody(req: IncomingMessage): Promise<unknown> {
   }
 }
 
-function resolvePfx(pfx: Buffer | string | undefined): Buffer | undefined {
-  if (!pfx) {
+function extractPeerCert(req: IncomingMessage): PeerCertInfo {
+  const socket = req.socket as TLSSocket;
+  if (typeof socket.getPeerCertificate !== 'function') {
+    return { presented: false };
+  }
+  const cert = socket.getPeerCertificate();
+  if (!cert || Object.keys(cert).length === 0) {
+    return { presented: false };
+  }
+  const cn = readCommonName(cert.subject);
+  return {
+    cn,
+    cnes: cn ? extractCnesFromCn(cn) : undefined,
+    presented: true,
+  };
+}
+
+function readCommonName(subject: unknown): string | undefined {
+  if (!subject || typeof subject !== 'object') {
     return undefined;
   }
-  if (typeof pfx === 'string') {
-    return fs.readFileSync(pfx);
+  const cnValue = (subject as Record<string, unknown>).CN;
+  if (typeof cnValue === 'string') {
+    return cnValue;
   }
-  return pfx;
+  return undefined;
+}
+
+function extractCnesFromCn(cn: string): string | undefined {
+  // Heurística: CN de cert ICP-Brasil PJ frequentemente embute CNES como
+  // sequência de 7 dígitos; se não for o caso, simplesmente não retorna nada.
+  const match = /\b(\d{7})\b/.exec(cn);
+  return match ? match[1] : undefined;
+}
+
+function lowercaseHeaders(
+  headers: http.IncomingHttpHeaders,
+): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      out[key.toLowerCase()] = value.join(', ');
+    } else {
+      out[key.toLowerCase()] = value;
+    }
+  }
+  return out;
+}
+
+function buildTlsOptions(options: SandboxOptions): https.ServerOptions {
+  const tlsOptions: https.ServerOptions = {
+    rejectUnauthorized: false,
+    requestCert: true,
+  };
+  if (options.serverPfx) {
+    tlsOptions.pfx = resolveBuffer(options.serverPfx);
+    if (options.serverPfxPassword) {
+      tlsOptions.passphrase = options.serverPfxPassword;
+    }
+  } else if (options.serverKey && options.serverCert) {
+    tlsOptions.key = resolveBuffer(options.serverKey);
+    tlsOptions.cert = resolveBuffer(options.serverCert);
+  } else {
+    throw new Error(
+      'mTLS requer --pfx + --pfx-password OU --server-key + --server-cert (PEM)',
+    );
+  }
+  return tlsOptions;
+}
+
+function resolveBuffer(value: Buffer | string): Buffer {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.includes('-----BEGIN')) {
+    return Buffer.from(value);
+  }
+  return fs.readFileSync(value);
 }

--- a/packages/rnds-sandbox/src/store.ts
+++ b/packages/rnds-sandbox/src/store.ts
@@ -108,13 +108,12 @@ export class SandboxStore {
    */
   searchResourcesByPatient(resourceType: string, patientCns: string): SandboxResource[] {
     const cns = stripFormatting(patientCns);
-    const candidates = [`Patient/${cns}`, cns];
     return this.listResourcesByType(resourceType).filter((resource) => {
       const subjectRef = resource.subject?.reference;
       const patientRef = resource.patient?.reference;
       return (
-        (subjectRef && referenceMatches(subjectRef, candidates)) ||
-        (patientRef && referenceMatches(patientRef, candidates))
+        (subjectRef && referenceMatchesCns(subjectRef, cns)) ||
+        (patientRef && referenceMatchesCns(patientRef, cns))
       );
     });
   }
@@ -156,14 +155,16 @@ function stripFormatting(value: string): string {
   return value.replace(/[^0-9A-Za-z]/g, '');
 }
 
-function referenceMatches(ref: string, candidates: readonly string[]): boolean {
-  // Compara o último segmento do path para evitar false-match por sufixo
-  // (ex.: "Patient/1700000000000001" não deve casar com candidato
-  // "700000000000001"). Aceita o reference inteiro ou só o CNS.
+/**
+ * Casa um reference FHIR contra um CNS. Aceita:
+ *  - `"700000000000001"` (CNS puro)
+ *  - `"Patient/700000000000001"` (relative reference)
+ *  - `"http://example.com/Patient/700000000000001"` (absolute URL)
+ *
+ * Compara o último segmento estritamente para evitar false-match por sufixo
+ * (ex.: `Patient/1700000000000001` não deve casar com `700000000000001`).
+ */
+function referenceMatchesCns(ref: string, cns: string): boolean {
   const lastSegment = ref.includes('/') ? ref.slice(ref.lastIndexOf('/') + 1) : ref;
-  for (const candidate of candidates) {
-    if (ref === candidate) return true;
-    if (lastSegment === candidate) return true;
-  }
-  return false;
+  return lastSegment === cns;
 }

--- a/packages/rnds-sandbox/src/store.ts
+++ b/packages/rnds-sandbox/src/store.ts
@@ -1,0 +1,113 @@
+/**
+ * Store em memória dos cenários carregados no sandbox.
+ *
+ * Indexa pacientes por CPF e CNS, organizações por CNES e
+ * profissionais por CNS. Bundles submetidos via POST /Bundle
+ * são acumulados em memória (acessíveis via getSubmittedBundles).
+ */
+
+import type {
+  Scenario,
+  SandboxBundle,
+  SandboxOrganization,
+  SandboxPatient,
+  SandboxPractitioner,
+} from './types';
+
+const NS = {
+  cns: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
+  cnes: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cnes',
+  cpf: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf',
+} as const;
+
+export class SandboxStore {
+  private patientsByCpf = new Map<string, SandboxPatient>();
+  private patientsByCns = new Map<string, SandboxPatient>();
+  private organizationsByCnes = new Map<string, SandboxOrganization>();
+  private practitionersByCns = new Map<string, SandboxPractitioner>();
+  private submittedBundles: SandboxBundle[] = [];
+
+  load(scenario: Scenario): void {
+    this.reset();
+    for (const patient of scenario.data.patients) {
+      this.indexPatient(patient);
+    }
+    for (const org of scenario.data.organizations) {
+      this.indexOrganization(org);
+    }
+    for (const pract of scenario.data.practitioners) {
+      this.indexPractitioner(pract);
+    }
+    for (const bundle of scenario.data.submittedBundles ?? []) {
+      this.submittedBundles.push(bundle);
+    }
+  }
+
+  reset(): void {
+    this.patientsByCpf.clear();
+    this.patientsByCns.clear();
+    this.organizationsByCnes.clear();
+    this.practitionersByCns.clear();
+    this.submittedBundles = [];
+  }
+
+  findPatientByCpf(cpf: string): SandboxPatient | undefined {
+    return this.patientsByCpf.get(stripFormatting(cpf));
+  }
+
+  findPatientByCns(cns: string): SandboxPatient | undefined {
+    return this.patientsByCns.get(stripFormatting(cns));
+  }
+
+  findOrganizationByCnes(cnes: string): SandboxOrganization | undefined {
+    return this.organizationsByCnes.get(stripFormatting(cnes));
+  }
+
+  findPractitionerByCns(cns: string): SandboxPractitioner | undefined {
+    return this.practitionersByCns.get(stripFormatting(cns));
+  }
+
+  recordBundle(bundle: SandboxBundle): void {
+    this.submittedBundles.push(bundle);
+  }
+
+  getSubmittedBundles(): readonly SandboxBundle[] {
+    return this.submittedBundles;
+  }
+
+  private indexPatient(patient: SandboxPatient): void {
+    const cns = patient.id ?? findIdentifier(patient.identifier, NS.cns);
+    if (cns) {
+      this.patientsByCns.set(stripFormatting(cns), patient);
+    }
+    const cpf = findIdentifier(patient.identifier, NS.cpf);
+    if (cpf) {
+      this.patientsByCpf.set(stripFormatting(cpf), patient);
+    }
+  }
+
+  private indexOrganization(org: SandboxOrganization): void {
+    const cnes = org.id ?? findIdentifier(org.identifier, NS.cnes);
+    if (cnes) {
+      this.organizationsByCnes.set(stripFormatting(cnes), org);
+    }
+  }
+
+  private indexPractitioner(pract: SandboxPractitioner): void {
+    const cns = pract.id ?? findIdentifier(pract.identifier, NS.cns);
+    if (cns) {
+      this.practitionersByCns.set(stripFormatting(cns), pract);
+    }
+  }
+}
+
+function findIdentifier(
+  ids: { system?: string; value?: string }[] | undefined,
+  system: string,
+): string | undefined {
+  return ids?.find((id) => id.system === system)?.value;
+}
+
+function stripFormatting(value: string): string {
+  return value.replace(/[^0-9A-Za-z]/g, '');
+}

--- a/packages/rnds-sandbox/src/store.ts
+++ b/packages/rnds-sandbox/src/store.ts
@@ -7,16 +7,17 @@
  */
 
 import type {
-  Scenario,
   SandboxBundle,
   SandboxOrganization,
   SandboxPatient,
   SandboxPractitioner,
+  SandboxResource,
+  Scenario,
 } from './types';
 
 const NS = {
-  cns: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
   cnes: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cnes',
+  cns: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns',
   cpf: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf',
 } as const;
 
@@ -75,6 +76,41 @@ export class SandboxStore {
     return this.submittedBundles;
   }
 
+  /**
+   * Lista todos os recursos de um tipo presentes nos bundles submetidos
+   * (incluindo os pré-carregados pelo cenário). Usado pelos endpoints
+   * de busca FHIR (`GET /Observation?subject=...`, etc.).
+   */
+  listResourcesByType(resourceType: string): SandboxResource[] {
+    const out: SandboxResource[] = [];
+    for (const bundle of this.submittedBundles) {
+      for (const entry of bundle.entry ?? []) {
+        if (entry.resource && entry.resource.resourceType === resourceType) {
+          out.push(entry.resource);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Filtra recursos cujo `subject.reference` ou `patient.reference`
+   * aponta para o paciente indicado (aceita tanto `Patient/{cns}` quanto
+   * apenas o CNS sem prefixo).
+   */
+  searchResourcesByPatient(resourceType: string, patientCns: string): SandboxResource[] {
+    const cns = stripFormatting(patientCns);
+    const candidates = [`Patient/${cns}`, cns];
+    return this.listResourcesByType(resourceType).filter((resource) => {
+      const subjectRef = readReference(resource.subject);
+      const patientRef = readReference(resource.patient);
+      return (
+        (subjectRef && referenceMatches(subjectRef, candidates)) ||
+        (patientRef && referenceMatches(patientRef, candidates))
+      );
+    });
+  }
+
   private indexPatient(patient: SandboxPatient): void {
     const cns = patient.id ?? findIdentifier(patient.identifier, NS.cns);
     if (cns) {
@@ -110,4 +146,21 @@ function findIdentifier(
 
 function stripFormatting(value: string): string {
   return value.replace(/[^0-9A-Za-z]/g, '');
+}
+
+function readReference(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  const ref = (value as { reference?: unknown }).reference;
+  return typeof ref === 'string' ? ref : undefined;
+}
+
+function referenceMatches(ref: string, candidates: readonly string[]): boolean {
+  // Aceita "Patient/{cns}" exato OU apenas o CNS no final do reference.
+  for (const candidate of candidates) {
+    if (ref === candidate) return true;
+    if (ref.endsWith(`/${candidate}`)) return true;
+  }
+  return false;
 }

--- a/packages/rnds-sandbox/src/store.ts
+++ b/packages/rnds-sandbox/src/store.ts
@@ -110,8 +110,8 @@ export class SandboxStore {
     const cns = stripFormatting(patientCns);
     const candidates = [`Patient/${cns}`, cns];
     return this.listResourcesByType(resourceType).filter((resource) => {
-      const subjectRef = readReference(resource.subject);
-      const patientRef = readReference(resource.patient);
+      const subjectRef = resource.subject?.reference;
+      const patientRef = resource.patient?.reference;
       return (
         (subjectRef && referenceMatches(subjectRef, candidates)) ||
         (patientRef && referenceMatches(patientRef, candidates))
@@ -154,14 +154,6 @@ function findIdentifier(
 
 function stripFormatting(value: string): string {
   return value.replace(/[^0-9A-Za-z]/g, '');
-}
-
-function readReference(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object') {
-    return undefined;
-  }
-  const ref = (value as { reference?: unknown }).reference;
-  return typeof ref === 'string' ? ref : undefined;
 }
 
 function referenceMatches(ref: string, candidates: readonly string[]): boolean {

--- a/packages/rnds-sandbox/src/store.ts
+++ b/packages/rnds-sandbox/src/store.ts
@@ -27,6 +27,7 @@ export class SandboxStore {
   private organizationsByCnes = new Map<string, SandboxOrganization>();
   private practitionersByCns = new Map<string, SandboxPractitioner>();
   private submittedBundles: SandboxBundle[] = [];
+  private resourceSeq = 0;
 
   load(scenario: Scenario): void {
     this.reset();
@@ -50,6 +51,13 @@ export class SandboxStore {
     this.organizationsByCnes.clear();
     this.practitionersByCns.clear();
     this.submittedBundles = [];
+    this.resourceSeq = 0;
+  }
+
+  /** Próximo número de sequência global para gerar `Resource/sandbox-N`. */
+  nextResourceId(): number {
+    this.resourceSeq += 1;
+    return this.resourceSeq;
   }
 
   findPatientByCpf(cpf: string): SandboxPatient | undefined {
@@ -157,10 +165,13 @@ function readReference(value: unknown): string | undefined {
 }
 
 function referenceMatches(ref: string, candidates: readonly string[]): boolean {
-  // Aceita "Patient/{cns}" exato OU apenas o CNS no final do reference.
+  // Compara o último segmento do path para evitar false-match por sufixo
+  // (ex.: "Patient/1700000000000001" não deve casar com candidato
+  // "700000000000001"). Aceita o reference inteiro ou só o CNS.
+  const lastSegment = ref.includes('/') ? ref.slice(ref.lastIndexOf('/') + 1) : ref;
   for (const candidate of candidates) {
     if (ref === candidate) return true;
-    if (ref.endsWith(`/${candidate}`)) return true;
+    if (lastSegment === candidate) return true;
   }
   return false;
 }

--- a/packages/rnds-sandbox/src/types.ts
+++ b/packages/rnds-sandbox/src/types.ts
@@ -7,8 +7,8 @@
  */
 
 export interface SandboxResource {
-  resourceType: string;
   [key: string]: unknown;
+  resourceType: string;
 }
 
 export interface SandboxBundleEntry {
@@ -66,27 +66,10 @@ export interface Scenario {
 }
 
 export interface SandboxOptions {
-  /**
-   * Habilita HTTPS com mTLS. Cliente é solicitado a apresentar certificado;
-   * /api/token o exige (igual à RNDS real). Padrão: false (HTTP puro).
-   */
-  mtls?: boolean;
-  /**
-   * Modo estrito — exige bearer token assinado + header `Authorization: <CNS>`
-   * em todos os endpoints `/api/fhir/r4/*`. Implícito quando `mtls = true`.
-   * Padrão: igual a `mtls`.
-   */
-  strict?: boolean;
-  /**
-   * Certificado PFX do servidor (Buffer ou caminho). Use isso OU `serverKey`+`serverCert`.
-   */
-  serverPfx?: Buffer | string;
-  /** Senha do PFX do servidor */
-  serverPfxPassword?: string;
-  /** PEM da chave privada do servidor (alternativa a `serverPfx`) */
-  serverKey?: Buffer | string;
-  /** PEM do certificado do servidor (alternativa a `serverPfx`) */
-  serverCert?: Buffer | string;
+  /** Hostname para bind. Padrão: '127.0.0.1' */
+  host?: string;
+  /** Identificador da chave (claim `kid` + `kid` no JWKS). Padrão: 'rnds-sandbox-1' */
+  jwtKeyId?: string;
   /**
    * PEM da chave privada usada para assinar JWTs (RS256). Se omitido,
    * é gerada uma chave RSA-2048 no boot.
@@ -94,16 +77,33 @@ export interface SandboxOptions {
   jwtPrivateKey?: Buffer | string;
   /** PEM da chave pública correspondente — opcional (derivada da privada) */
   jwtPublicKey?: Buffer | string;
-  /** Identificador da chave (claim `kid` + `kid` no JWKS). Padrão: 'rnds-sandbox-1' */
-  jwtKeyId?: string;
-  /** Porta para escutar. Padrão: 8443 (mtls) ou 8080 (sem mtls) */
-  port?: number;
-  /** Hostname para bind. Padrão: '127.0.0.1' */
-  host?: string;
-  /** Cenário a carregar. Padrão: 'paciente-com-exames' */
-  scenario?: ScenarioName;
   /** Logger opcional. Padrão: console.log */
   log?: (msg: string) => void;
+  /**
+   * Habilita HTTPS com mTLS. Cliente é solicitado a apresentar certificado;
+   * /api/token o exige (igual à RNDS real). Padrão: false (HTTP puro).
+   */
+  mtls?: boolean;
+  /** Porta para escutar. Padrão: 8443 (mtls) ou 8080 (sem mtls) */
+  port?: number;
+  /** Cenário a carregar. Padrão: 'paciente-com-exames' */
+  scenario?: ScenarioName;
+  /** PEM do certificado do servidor (alternativa a `serverPfx`) */
+  serverCert?: Buffer | string;
+  /** PEM da chave privada do servidor (alternativa a `serverPfx`) */
+  serverKey?: Buffer | string;
+  /**
+   * Certificado PFX do servidor (Buffer ou caminho). Use isso OU `serverKey`+`serverCert`.
+   */
+  serverPfx?: Buffer | string;
+  /** Senha do PFX do servidor */
+  serverPfxPassword?: string;
+  /**
+   * Modo estrito — exige bearer token assinado + header `Authorization: <CNS>`
+   * em todos os endpoints `/api/fhir/r4/*`. Implícito quando `mtls = true`.
+   * Padrão: igual a `mtls`.
+   */
+  strict?: boolean;
   /** Validar bundles submetidos contra perfis da IG (best-effort). Padrão: true */
   validateSubmissions?: boolean;
 }

--- a/packages/rnds-sandbox/src/types.ts
+++ b/packages/rnds-sandbox/src/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Tipos públicos do sandbox da RNDS.
+ *
+ * O sandbox usa Bundle/recursos com estrutura mais permissiva que
+ * `@precisa-saude/fhir` (que cobre apenas Patient/Observation/...) —
+ * cenários incluem Encounter, Condition, Immunization, etc.
+ */
+
+export interface SandboxResource {
+  resourceType: string;
+  [key: string]: unknown;
+}
+
+export interface SandboxBundleEntry {
+  fullUrl?: string;
+  request?: { method: string; url: string };
+  resource?: SandboxResource;
+  response?: { status: string; location?: string };
+}
+
+export interface SandboxBundle {
+  entry?: SandboxBundleEntry[];
+  resourceType: 'Bundle';
+  type: 'transaction' | 'batch' | 'transaction-response' | 'batch-response' | 'searchset';
+}
+
+export interface SandboxPatient {
+  birthDate?: string;
+  gender?: 'male' | 'female' | 'other' | 'unknown';
+  id?: string;
+  identifier?: { system?: string; value?: string }[];
+  name?: { family?: string; given?: string[] }[];
+  resourceType: 'Patient';
+}
+
+export type SandboxOrganization = {
+  active?: boolean;
+  id?: string;
+  identifier?: { system?: string; value?: string }[];
+  name?: string;
+  resourceType: 'Organization';
+};
+
+export type SandboxPractitioner = {
+  active?: boolean;
+  id?: string;
+  identifier?: { system?: string; value?: string }[];
+  name?: { family?: string; given?: string[] }[];
+  resourceType: 'Practitioner';
+};
+
+export type ScenarioName = 'paciente-com-exames' | 'internacao' | 'vacina' | 'vazio';
+
+export interface ScenarioData {
+  organizations: SandboxOrganization[];
+  patients: SandboxPatient[];
+  practitioners: SandboxPractitioner[];
+  /** Bundles previamente submetidos (e.g. cenário com histórico) */
+  submittedBundles?: SandboxBundle[];
+}
+
+export interface Scenario {
+  data: ScenarioData;
+  description: string;
+  name: ScenarioName;
+}
+
+export interface SandboxOptions {
+  /** Habilita verificação mTLS no handshake (cliente precisa apresentar cert). Padrão: false */
+  mtls?: boolean;
+  /**
+   * Se mtls = true, certificado PFX do servidor (mesmo cert que cliente apresentaria,
+   * útil para devs que já têm cert ICP-Brasil de homologação). Pode ser caminho ou Buffer.
+   */
+  serverPfx?: Buffer | string;
+  /** Senha do PFX do servidor */
+  serverPfxPassword?: string;
+  /** Porta para escutar. Padrão: 8443 (mtls) ou 8080 (sem mtls) */
+  port?: number;
+  /** Hostname para bind. Padrão: '127.0.0.1' */
+  host?: string;
+  /** Cenário a carregar. Padrão: 'paciente-com-exames' */
+  scenario?: ScenarioName;
+  /** Logger opcional. Padrão: console.log */
+  log?: (msg: string) => void;
+  /** Validar bundles submetidos contra perfis da IG (best-effort). Padrão: true */
+  validateSubmissions?: boolean;
+}

--- a/packages/rnds-sandbox/src/types.ts
+++ b/packages/rnds-sandbox/src/types.ts
@@ -66,15 +66,36 @@ export interface Scenario {
 }
 
 export interface SandboxOptions {
-  /** Habilita verificação mTLS no handshake (cliente precisa apresentar cert). Padrão: false */
+  /**
+   * Habilita HTTPS com mTLS. Cliente é solicitado a apresentar certificado;
+   * /api/token o exige (igual à RNDS real). Padrão: false (HTTP puro).
+   */
   mtls?: boolean;
   /**
-   * Se mtls = true, certificado PFX do servidor (mesmo cert que cliente apresentaria,
-   * útil para devs que já têm cert ICP-Brasil de homologação). Pode ser caminho ou Buffer.
+   * Modo estrito — exige bearer token assinado + header `Authorization: <CNS>`
+   * em todos os endpoints `/api/fhir/r4/*`. Implícito quando `mtls = true`.
+   * Padrão: igual a `mtls`.
+   */
+  strict?: boolean;
+  /**
+   * Certificado PFX do servidor (Buffer ou caminho). Use isso OU `serverKey`+`serverCert`.
    */
   serverPfx?: Buffer | string;
   /** Senha do PFX do servidor */
   serverPfxPassword?: string;
+  /** PEM da chave privada do servidor (alternativa a `serverPfx`) */
+  serverKey?: Buffer | string;
+  /** PEM do certificado do servidor (alternativa a `serverPfx`) */
+  serverCert?: Buffer | string;
+  /**
+   * PEM da chave privada usada para assinar JWTs (RS256). Se omitido,
+   * é gerada uma chave RSA-2048 no boot.
+   */
+  jwtPrivateKey?: Buffer | string;
+  /** PEM da chave pública correspondente — opcional (derivada da privada) */
+  jwtPublicKey?: Buffer | string;
+  /** Identificador da chave (claim `kid` + `kid` no JWKS). Padrão: 'rnds-sandbox-1' */
+  jwtKeyId?: string;
   /** Porta para escutar. Padrão: 8443 (mtls) ou 8080 (sem mtls) */
   port?: number;
   /** Hostname para bind. Padrão: '127.0.0.1' */

--- a/packages/rnds-sandbox/src/types.ts
+++ b/packages/rnds-sandbox/src/types.ts
@@ -6,9 +6,16 @@
  * cenários incluem Encounter, Condition, Immunization, etc.
  */
 
+/**
+ * Recurso FHIR genérico armazenado pelo sandbox. `resourceType` é
+ * obrigatório; `subject`/`patient` são tipados explicitamente porque o
+ * store usa o `.reference` deles em buscas. Demais campos ficam livres.
+ */
 export interface SandboxResource {
   [key: string]: unknown;
+  patient?: { reference?: string };
   resourceType: string;
+  subject?: { reference?: string };
 }
 
 export interface SandboxBundleEntry {

--- a/packages/rnds-sandbox/tsconfig.json
+++ b/packages/rnds-sandbox/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/rnds-sandbox/tsup.config.ts
+++ b/packages/rnds-sandbox/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: ['src/index.ts', 'src/cli.ts'],
+  format: ['esm', 'cjs'],
+  sourcemap: true,
+  splitting: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,15 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.37)(lightningcss@1.32.0)(msw@2.13.0(@types/node@20.19.37)(typescript@5.7.3))
 
+  examples/rnds-sandbox-express:
+    dependencies:
+      '@precisa-saude/fhir-rnds-sandbox':
+        specifier: workspace:^
+        version: link:../../packages/rnds-sandbox
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+
   packages/calculators:
     dependencies:
       '@precisa-saude/fhir':
@@ -123,6 +132,22 @@ importers:
         version: 2.1.9(@types/node@20.19.37)(lightningcss@1.32.0)(msw@2.13.0(@types/node@20.19.37)(typescript@5.7.3))
 
   packages/rnds:
+    dependencies:
+      '@precisa-saude/fhir':
+        specifier: workspace:^
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.7.3)(yaml@2.8.3)
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.37)(lightningcss@1.32.0)(msw@2.13.0(@types/node@20.19.37)(typescript@5.7.3))
+
+  packages/rnds-sandbox:
     dependencies:
       '@precisa-saude/fhir':
         specifier: workspace:^
@@ -1737,6 +1762,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1821,6 +1850,9 @@ packages:
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
@@ -1948,6 +1980,10 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -2191,6 +2227,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
@@ -2227,6 +2267,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -2299,6 +2342,14 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2362,6 +2413,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-indent@7.0.2:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
@@ -2679,6 +2734,10 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -2752,6 +2811,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -2812,6 +2875,10 @@ packages:
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -3063,6 +3130,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3657,6 +3728,10 @@ packages:
   mdn-data@2.23.0:
     resolution: {integrity: sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -3664,6 +3739,9 @@ packages:
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -3675,6 +3753,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -3710,6 +3792,11 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
@@ -3760,6 +3847,9 @@ packages:
   mnemonist@0.40.3:
     resolution: {integrity: sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3791,6 +3881,10 @@ packages:
   natural-orderby@5.0.0:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -4126,6 +4220,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -4276,6 +4373,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
@@ -4286,6 +4387,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -4445,6 +4550,9 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -4488,9 +4596,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -4983,6 +5099,10 @@ packages:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -5103,6 +5223,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   valid-url@1.0.9:
     resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
@@ -6869,6 +6993,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -6942,6 +7071,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
+
+  array-flatten@1.1.1: {}
 
   array-ify@1.0.0: {}
 
@@ -7068,6 +7199,23 @@ snapshots:
   baseline-browser-mapping@2.10.12: {}
 
   before-after-hook@4.0.0: {}
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.2:
     dependencies:
@@ -7313,6 +7461,10 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
@@ -7343,6 +7495,8 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
 
@@ -7409,6 +7563,10 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -7449,6 +7607,8 @@ snapshots:
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
+
+  destroy@1.2.0: {}
 
   detect-indent@7.0.2: {}
 
@@ -7955,6 +8115,42 @@ snapshots:
       express: 5.2.1
       ip-address: 10.1.0
 
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -8066,6 +8262,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -8132,6 +8340,8 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -8421,6 +8631,10 @@ snapshots:
   human-signals@8.0.1: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -8962,15 +9176,21 @@ snapshots:
 
   mdn-data@2.23.0: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
 
   meow@13.2.0: {}
+
+  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -9005,6 +9225,8 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mime@1.6.0: {}
 
   mime@4.1.0: {}
 
@@ -9049,6 +9271,8 @@ snapshots:
     dependencies:
       obliterator: 2.0.5
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   msw@2.13.0(@types/node@20.19.37)(typescript@5.7.3):
@@ -9089,6 +9313,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -9367,6 +9593,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-to-regexp@0.1.13: {}
+
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
@@ -9480,6 +9708,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
@@ -9487,6 +9719,13 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -9707,6 +9946,8 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -9770,6 +10011,24 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -9783,6 +10042,15 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10382,6 +10650,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -10503,6 +10776,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
 
   valid-url@1.0.9: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
   - 'site'
+  - 'examples/*'

--- a/site/src/components/Ecosystem.tsx
+++ b/site/src/components/Ecosystem.tsx
@@ -27,7 +27,7 @@ const ACTORS: Actor[] = [
     icon: <FlaskConical className="h-5 w-5" />,
     name: 'Laboratório',
     problem: 'Formatos proprietários, LOINC inconsistente',
-    role: 'Vocabulário compartilhado com 180+ biomarcadores',
+    role: 'Vocabulário compartilhado com 200+ biomarcadores',
   },
   {
     icon: <Building2 className="h-5 w-5" />,

--- a/site/src/components/Features.tsx
+++ b/site/src/components/Features.tsx
@@ -17,9 +17,9 @@ interface Feature {
 const FEATURES: Feature[] = [
   {
     icon: <HeartPulse className="h-6 w-6" />,
-    title: '180+ Biomarcadores',
+    title: '200+ Biomarcadores',
     description:
-      'Códigos LOINC, nomes em pt-BR e en-US, unidades UCUM e 20 categorias clínicas. Catalogo completo com normalização de aliases.',
+      'Códigos LOINC, nomes em pt-BR e en-US, unidades UCUM, organizados em 10 categorias clínicas (20 sub-categorias). Catálogo completo com normalização de aliases.',
     links: [
       { label: 'LOINC', href: 'https://loinc.org/' },
       { label: 'UCUM', href: 'https://ucum.org/' },


### PR DESCRIPTION
## Summary

- **Novo pacote `@precisa-saude/fhir-rnds-sandbox`** — mock local da RNDS (Rede Nacional de Dados em Saúde) com endpoints FHIR R4, JWT RS256 real + JWKS, mTLS opcional per-route, busca por paciente, e cenários sintéticos. Destrava devs de cliente RNDS sem precisar de cert ICP-Brasil + homologação DATASUS.
- **Eleva `@precisa-saude/fhir` para 200 biomarcadores** (de 183) e adiciona taxonomia de 10 categorias clínicas top-level sobre as 20 sub-categorias granulares — alinha com o que foi prometido na aplicação para o LOINC conference.
- **Exemplo Express + HTML/JS** em `examples/rnds-sandbox-express/` mostrando o fluxo ponta-a-ponta (auth → query → submit → search) sem framework no front.

Refs PRE-201

## Detalhes por commit

1. `feat(core): adicionar 17 biomarcadores e taxonomia de 10 categorias` — NT-proBNP, BNP, Troponina I/T, D-Dímero, Fibrinogênio, LDH, PTH, IgM, C3, C4, CA 19-9, CA 15-3, β-hCG, Cistatina C, Selênio, β-Hidroxibutirato (todos com LOINC verificado). Novo módulo `category-groups.ts` agrupa as 20 sub-categorias em 10 buckets (Cardiovascular, Metabólico/Endócrino, Renal/Eletrolítico, Hepático/Biliar, Hematológico, Imunológico, Oncológico, Nutricional/Ambiental, Saúde Reprodutiva, Composição/Envelhecimento). Atualiza site (Features, Ecosystem) e READMEs.

2. `feat(rnds-sandbox): adicionar mock local da RNDS` — servidor HTTP leve, CLI `rnds-sandbox start`, API programática `createSandboxServer()`, 4 cenários (paciente-com-exames, internacao, vacina, vazio), Dockerfile. Endpoints: POST `/api/token`, GET/POST para `Patient`/`Organization`/`Practitioner`/`Bundle`.

3. `feat(rnds-sandbox): fidelidade RNDS — RS256 + JWKS + bearer/CNS + per-route mTLS` — assina JWT com RSA-2048 (zero deps novas, via `node:crypto`), expõe JWKS em `/.well-known/jwks.json`, valida bearer token + header `Authorization: <CNS-15-dígitos>` em FHIR endpoints, exige cert mTLS no `/api/token` (igual à API real). Três modos: permissivo (default), `--strict`, `--mtls`. CLI ganha `--strict`, `--server-key`/`--server-cert`, `--jwt-private-key`/`--jwt-public-key`/`--jwt-key-id`.

4. `docs(rnds-sandbox): exemplo Express + frontend HTML/JS` — `examples/rnds-sandbox-express/` com backend Node/Express que boota o sandbox em-processo e expõe `/api/...` com bearer + CNS, e frontend HTML/JS sem framework que renderiza JSON cru. Adiciona `examples/*` ao `pnpm-workspace.yaml`.

5. `feat(rnds): busca de recursos por paciente no sandbox` — round-trip submit→search funcional. Novos endpoints: `GET /Observation?subject=Patient/{cns}` (e DiagnosticReport, Immunization, Condition, Encounter), retorna FHIR `searchset` Bundle agregando recursos pré-carregados + submetidos. Atualiza exemplo com botão "Buscar Observations".

6-7. `style: prettier` + `style: eslint --fix` — formatação e ordenação de chaves para passar nos hooks pré-push.

## Estatísticas

- **35 arquivos novos**, ~4.250 linhas adicionadas
- **Cobertura**: 48 testes no rnds-sandbox + 6 no category-groups; total 663 testes verdes no monorepo
- **Zero deps runtime novas** no `@precisa-saude/fhir-rnds-sandbox` (só `node:http`/`node:https`/`node:crypto`); exemplo usa `express` como devDep

## Test plan

- [ ] `pnpm install && pnpm test` (full monorepo) passa
- [ ] `pnpm --filter @precisa-saude/fhir-rnds-sandbox build` produz `dist/cli.js` executável
- [ ] `node dist/cli.js start` sobe sandbox em modo permissivo (curl funciona sem auth)
- [ ] `node dist/cli.js start --strict` rejeita FHIR sem bearer + retorna 401 para `/api/token` sem cert
- [ ] `pnpm --filter @fhir-brasil-examples/rnds-sandbox-express start`, abrir `http://127.0.0.1:3000`, clicar em todos os botões e ver as respostas FHIR
- [ ] No exemplo: clicar "Buscar Observations" → ver 4 obs; clicar "Submeter" → ver 201; clicar "Buscar Observations" de novo → ver 5 obs
- [ ] Verificar JWKS em `/.well-known/jwks.json` e usar a chave para validar a assinatura do token (jose / jwt.io)

## Notas

- O sandbox vive **dentro do monorepo** (`packages/rnds-sandbox/`), não como repo separado conforme PRE-197 originalmente sugeriu — para velocidade + reuso de CI/types/IG. Pode ser extraído depois sem fricção.
- AGENTS.md (que está em outra branch in-progress) precisará de uma linha em "Structure" + adicionar `rnds-sandbox` ao commit-scope quando essa outra branch mergear. Não incluído aqui para não atrapalhar.
- `pnpm-workspace.yaml` ganhou `examples/*` — `examples/medplum-integration/` (sem package.json) é tolerado pelo pnpm como aviso benigno.