### PR TITLE
feat(rnds): validar Bundles contra perfis BR* do IG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ### Features
 
-* rnds-sandbox + 200 biomarcadores + taxonomia de 10 categorias ([09b0148](https://github.com/Precisa-Saude/fhir-brasil/commit/09b0148dfd27b4578ebff8544a8925afc6b6e89b))
+- rnds-sandbox + 200 biomarcadores + taxonomia de 10 categorias ([09b0148](https://github.com/Precisa-Saude/fhir-brasil/commit/09b0148dfd27b4578ebff8544a8925afc6b6e89b))
 
 ### Bug Fixes
 
-* **ci:** trocar PAT_TOKEN por GitHub App token no Release ([#26](https://github.com/Precisa-Saude/fhir-brasil/issues/26)) ([7fcff27](https://github.com/Precisa-Saude/fhir-brasil/commit/7fcff27c07885bc40dce63d239f961c0303fb13c))
-* **core:** realinhar códigos TUSS do BRTUSSProcedimentosLabVS com tabela ANS oficial ([#24](https://github.com/Precisa-Saude/fhir-brasil/issues/24)) ([4c316f2](https://github.com/Precisa-Saude/fhir-brasil/commit/4c316f2c64fc2e80f73b6bad1699f41524c8b5b9))
+- **ci:** trocar PAT_TOKEN por GitHub App token no Release ([#26](https://github.com/Precisa-Saude/fhir-brasil/issues/26)) ([7fcff27](https://github.com/Precisa-Saude/fhir-brasil/commit/7fcff27c07885bc40dce63d239f961c0303fb13c))
+- **core:** realinhar códigos TUSS do BRTUSSProcedimentosLabVS com tabela ANS oficial ([#24](https://github.com/Precisa-Saude/fhir-brasil/issues/24)) ([4c316f2](https://github.com/Precisa-Saude/fhir-brasil/commit/4c316f2c64fc2e80f73b6bad1699f41524c8b5b9))
 
 ### Chores
 
-* **deps:** adotar @precisa-saude/ui e @precisa-saude/themes no site ([#22](https://github.com/Precisa-Saude/fhir-brasil/issues/22)) ([0a61d8c](https://github.com/Precisa-Saude/fhir-brasil/commit/0a61d8c534c9d3084d3f4e754acdece41a5de417))
-* **deps:** adotar configs compartilhadas [@precisa-saude](https://github.com/precisa-saude) ([#21](https://github.com/Precisa-Saude/fhir-brasil/issues/21)) ([25b487e](https://github.com/Precisa-Saude/fhir-brasil/commit/25b487ed6b89603953bc0adb095fc72e11871502))
-* **deps:** sync dotfiles + add pre-push hook ([#25](https://github.com/Precisa-Saude/fhir-brasil/issues/25)) ([819e37e](https://github.com/Precisa-Saude/fhir-brasil/commit/819e37e5af8e76546872ead1eb91499308bdc918))
+- **deps:** adotar @precisa-saude/ui e @precisa-saude/themes no site ([#22](https://github.com/Precisa-Saude/fhir-brasil/issues/22)) ([0a61d8c](https://github.com/Precisa-Saude/fhir-brasil/commit/0a61d8c534c9d3084d3f4e754acdece41a5de417))
+- **deps:** adotar configs compartilhadas [@precisa-saude](https://github.com/precisa-saude) ([#21](https://github.com/Precisa-Saude/fhir-brasil/issues/21)) ([25b487e](https://github.com/Precisa-Saude/fhir-brasil/commit/25b487ed6b89603953bc0adb095fc72e11871502))
+- **deps:** sync dotfiles + add pre-push hook ([#25](https://github.com/Precisa-Saude/fhir-brasil/issues/25)) ([819e37e](https://github.com/Precisa-Saude/fhir-brasil/commit/819e37e5af8e76546872ead1eb91499308bdc918))
 
 ## [0.10.1](https://github.com/Precisa-Saude/fhir-brasil/compare/v0.10.0...v0.10.1) (2026-04-18)
 

--- a/packages/rnds-sandbox/README.md
+++ b/packages/rnds-sandbox/README.md
@@ -326,6 +326,79 @@ $ curl -s http://127.0.0.1:8080/.well-known/jwks.json | jq
 }
 ```
 
+### Validação contra perfis do IG
+
+Por padrão o sandbox valida cada `Bundle.entry[i].resource` enviado em
+`POST /api/fhir/r4/Bundle` contra os perfis `BR*` do IG `fhir-brasil`
+(`BRPatient`, `BRLabObservation`, `BRDiagnosticReport`). Bundles que
+violam restrições são rejeitados com `422 OperationOutcome` listando
+todas as issues — formato e códigos espelham o que a RNDS real
+retorna.
+
+```bash
+# Patient sem campos obrigatórios — o sandbox responde 422 com a lista
+$ curl -s -X POST http://127.0.0.1:8080/api/fhir/r4/Bundle \
+    -H 'Content-Type: application/fhir+json' \
+    -d '{"resourceType":"Bundle","type":"transaction","entry":[
+        {"request":{"method":"POST","url":"Patient"},
+         "resource":{"resourceType":"Patient"}}
+      ]}'
+```
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "required",
+      "diagnostics": "Patient.identifier requer pelo menos 1 elemento(s); recebido 0",
+      "location": ["Bundle.entry[0].resource.identifier"]
+    },
+    {
+      "severity": "error",
+      "code": "required",
+      "diagnostics": "Patient.name requer pelo menos 1 elemento(s); recebido 0",
+      "location": ["Bundle.entry[0].resource.name"]
+    },
+    {
+      "severity": "error",
+      "code": "required",
+      "diagnostics": "Patient.birthDate é obrigatório",
+      "location": ["Bundle.entry[0].resource.birthDate"]
+    },
+    {
+      "severity": "error",
+      "code": "required",
+      "diagnostics": "Patient.gender é obrigatório",
+      "location": ["Bundle.entry[0].resource.gender"]
+    }
+  ]
+}
+```
+
+O resolver de perfil usa `meta.profile` quando presente; caso contrário
+seleciona pelo `resourceType` (`Patient` → BRPatient, `Observation` →
+BRLabObservation, `DiagnosticReport` → BRDiagnosticReport). Outros
+tipos passam sem checagem de perfil — declare `meta.profile` se quiser
+conformidade estrita para tipos fora desse conjunto.
+
+Para desligar (e voltar ao comportamento "aceita qualquer Bundle
+estruturalmente válido", útil em aulas):
+
+```bash
+rnds-sandbox start --no-validate
+# ou programaticamente:
+createSandboxServer({ validateSubmissions: false });
+```
+
+As regras espelham as restrições FSH em `ig/input/fsh/profiles/`. São
+implementadas em pure TS (zero deps novas) e cobrem o subset que a
+RNDS real rejeita na prática (cardinalidade, identifiers brasileiros,
+coding LOINC/UCUM, value sets de status). Não pretendem ser FHIR
+validation completa — slicing complexo, value-set binding contra
+terminologias externas e algumas invariantes FHIRPath ficam de fora.
+
 ### mTLS na prática
 
 Você precisa de um cert para o **servidor**. Qualquer cert auto-assinado

--- a/packages/rnds-sandbox/src/__tests__/router.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/router.test.ts
@@ -24,6 +24,9 @@ function makeCtx(overrides: Partial<RouteContext> = {}): RouteContext {
     query: new URLSearchParams(),
     store: makeStore(),
     strict: false,
+    // Testes de roteamento usam Bundles minimalistas; validação tem
+    // suite própria em `validation.test.ts`.
+    validateProfiles: false,
     ...overrides,
   };
 }

--- a/packages/rnds-sandbox/src/__tests__/server.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/server.test.ts
@@ -7,7 +7,14 @@ describe('createSandboxServer (HTTP)', () => {
   let baseUrl: string;
 
   beforeEach(async () => {
-    sandbox = createSandboxServer({ log: () => {}, port: 0, scenario: 'paciente-com-exames' });
+    sandbox = createSandboxServer({
+      log: () => {},
+      port: 0,
+      scenario: 'paciente-com-exames',
+      // Esses testes exercitam o roteamento HTTP, não validação de perfil.
+      // Validação é coberta em `validation.test.ts`.
+      validateSubmissions: false,
+    });
     const { host, port } = await sandbox.start();
     baseUrl = `http://${host}:${port}`;
   });
@@ -106,6 +113,89 @@ describe('createSandboxServer (HTTP)', () => {
     const b1 = (await r1.json()) as { entry: { response: { location: string } }[] };
     const b2 = (await r2.json()) as { entry: { response: { location: string } }[] };
     expect(b1.entry[0]?.response.location).not.toBe(b2.entry[0]?.response.location);
+  });
+});
+
+describe('createSandboxServer (HTTP, validateSubmissions)', () => {
+  let sandbox: SandboxServer;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    sandbox = createSandboxServer({ log: () => {}, port: 0 }); // validateSubmissions default = true
+    const { host, port } = await sandbox.start();
+    baseUrl = `http://${host}:${port}`;
+  });
+
+  afterEach(async () => {
+    await sandbox.stop();
+  });
+
+  it('rejeita Bundle inválido com 422 + OperationOutcome multi-issue', async () => {
+    const res = await fetch(`${baseUrl}/api/fhir/r4/Bundle`, {
+      body: JSON.stringify({
+        entry: [
+          {
+            request: { method: 'POST', url: 'Patient' },
+            // Patient sem identifier/name/birthDate/gender → várias issues
+            resource: { resourceType: 'Patient' },
+          },
+        ],
+        resourceType: 'Bundle',
+        type: 'transaction',
+      }),
+      headers: { 'Content-Type': 'application/fhir+json' },
+      method: 'POST',
+    });
+    expect(res.status).toBe(422);
+    const oo = (await res.json()) as {
+      issue: { code: string; location?: string[] }[];
+      resourceType: string;
+    };
+    expect(oo.resourceType).toBe('OperationOutcome');
+    expect(oo.issue.length).toBeGreaterThanOrEqual(3);
+    expect(oo.issue.every((i) => i.location?.[0]?.startsWith('Bundle.entry[0].resource.'))).toBe(
+      true,
+    );
+  });
+
+  it('aceita Bundle válido em modo validate', async () => {
+    const res = await fetch(`${baseUrl}/api/fhir/r4/Bundle`, {
+      body: JSON.stringify({
+        entry: [
+          {
+            request: { method: 'POST', url: 'Observation' },
+            resource: {
+              category: [
+                {
+                  coding: [
+                    {
+                      code: 'laboratory',
+                      system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+                    },
+                  ],
+                },
+              ],
+              code: { coding: [{ code: '2345-7', system: 'http://loinc.org' }] },
+              effectiveDateTime: '2025-09-10',
+              resourceType: 'Observation',
+              status: 'final',
+              subject: { reference: 'Patient/700000000000001' },
+              valueQuantity: {
+                code: 'mg/dL',
+                system: 'http://unitsofmeasure.org',
+                unit: 'mg/dL',
+                value: 96,
+              },
+            },
+          },
+        ],
+        resourceType: 'Bundle',
+        type: 'transaction',
+      }),
+      headers: { 'Content-Type': 'application/fhir+json' },
+      method: 'POST',
+    });
+    expect(res.status).toBe(200);
   });
 });
 

--- a/packages/rnds-sandbox/src/__tests__/server.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/server.test.ts
@@ -148,12 +148,12 @@ describe('createSandboxServer (HTTP, validateSubmissions)', () => {
     });
     expect(res.status).toBe(422);
     const oo = (await res.json()) as {
-      issue: { code: string; location?: string[] }[];
+      issue: { code: string; expression?: string[] }[];
       resourceType: string;
     };
     expect(oo.resourceType).toBe('OperationOutcome');
     expect(oo.issue.length).toBeGreaterThanOrEqual(3);
-    expect(oo.issue.every((i) => i.location?.[0]?.startsWith('Bundle.entry[0].resource.'))).toBe(
+    expect(oo.issue.every((i) => i.expression?.[0]?.startsWith('Bundle.entry[0].resource.'))).toBe(
       true,
     );
   });

--- a/packages/rnds-sandbox/src/__tests__/validation.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/validation.test.ts
@@ -119,7 +119,17 @@ describe('validateBRLabObservation', () => {
     };
     expect(
       validateBRLabObservation(obs, 'r').some(
-        (i) => i.code === 'invalid' && i.location?.[0]?.includes('valueQuantity.system'),
+        (i) => i.code === 'invalid' && i.expression?.[0]?.includes('valueQuantity.system'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejeita valueQuantity sem system (1..1 do FSH)', () => {
+    const { system: _, ...vqSemSystem } = validLabObservation.valueQuantity;
+    const obs = { ...validLabObservation, valueQuantity: vqSemSystem };
+    expect(
+      validateBRLabObservation(obs, 'r').some(
+        (i) => i.code === 'required' && i.expression?.[0]?.includes('valueQuantity.system'),
       ),
     ).toBe(true);
   });
@@ -177,10 +187,10 @@ describe('validateBundle', () => {
     expect(result.valid).toBe(false);
     // Deve incluir issue para Patient.gender e Observation.status
     expect(
-      result.issues.some((i) => i.location?.[0]?.includes('Bundle.entry[0].resource.gender')),
+      result.issues.some((i) => i.expression?.[0]?.includes('Bundle.entry[0].resource.gender')),
     ).toBe(true);
     expect(
-      result.issues.some((i) => i.location?.[0]?.includes('Bundle.entry[1].resource.status')),
+      result.issues.some((i) => i.expression?.[0]?.includes('Bundle.entry[1].resource.status')),
     ).toBe(true);
   });
 
@@ -201,5 +211,47 @@ describe('validateBundle', () => {
       type: 'transaction',
     };
     expect(validateBundle(bundle).valid).toBe(true);
+  });
+
+  it('NÃO aplica BRLabObservation a Observation não-laboratorial (regression)', () => {
+    // Observation de vital-signs (sem category laboratory) — não deve ser
+    // forçada ao perfil de exame de laboratório só porque é Observation.
+    const vitalSigns = {
+      category: [
+        {
+          coding: [
+            {
+              code: 'vital-signs',
+              system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+            },
+          ],
+        },
+      ],
+      code: { coding: [{ code: '85354-9', system: 'http://loinc.org' }] },
+      resourceType: 'Observation',
+      // sem subject, sem effectiveDateTime, sem valueQuantity — passaria por
+      // BRLabObservation, mas como NÃO é laboratory, deve passar.
+    };
+    const issues = validateResource(vitalSigns, 'r');
+    expect(issues).toEqual([]);
+  });
+
+  it('aplica BRLabObservation quando category contém laboratory', () => {
+    const labObs = {
+      category: [
+        {
+          coding: [
+            {
+              code: 'laboratory',
+              system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+            },
+          ],
+        },
+      ],
+      resourceType: 'Observation',
+      // sem code/value/subject/effective — deve falhar porque agora aplica
+      // BRLabObservation
+    };
+    expect(validateResource(labObs, 'r').length).toBeGreaterThan(0);
   });
 });

--- a/packages/rnds-sandbox/src/__tests__/validation.test.ts
+++ b/packages/rnds-sandbox/src/__tests__/validation.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  validateBRDiagnosticReport,
+  validateBRLabObservation,
+  validateBRPatient,
+  validateBundle,
+  validateResource,
+} from '../validation';
+
+const PATIENT_REF = 'Patient/700000000000001';
+
+const validPatient = {
+  birthDate: '1983-08-12',
+  gender: 'female',
+  identifier: [
+    { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf', value: '12345678901' },
+    { system: 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns', value: '700000000000001' },
+  ],
+  name: [{ family: 'Silva', given: ['Joana'] }],
+  resourceType: 'Patient',
+};
+
+const validLabObservation = {
+  category: [
+    {
+      coding: [
+        {
+          code: 'laboratory',
+          system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+        },
+      ],
+    },
+  ],
+  code: { coding: [{ code: '2345-7', display: 'Glicose', system: 'http://loinc.org' }] },
+  effectiveDateTime: '2025-09-10',
+  resourceType: 'Observation',
+  status: 'final',
+  subject: { reference: PATIENT_REF },
+  valueQuantity: {
+    code: 'mg/dL',
+    system: 'http://unitsofmeasure.org',
+    unit: 'mg/dL',
+    value: 96,
+  },
+};
+
+const validDiagnosticReport = {
+  category: [
+    { coding: [{ code: 'LAB', system: 'http://terminology.hl7.org/CodeSystem/v2-0074' }] },
+  ],
+  code: { coding: [{ code: '24323-8', system: 'http://loinc.org' }] },
+  effectiveDateTime: '2025-09-10',
+  performer: [{ reference: 'Practitioner/700000000000010' }],
+  result: [{ reference: 'Observation/abc' }],
+  resourceType: 'DiagnosticReport',
+  status: 'final',
+  subject: { reference: PATIENT_REF },
+};
+
+describe('validateBRPatient', () => {
+  it('aceita Patient completo', () => {
+    expect(validateBRPatient(validPatient, 'r')).toEqual([]);
+  });
+
+  it('rejeita sem identifier', () => {
+    const issues = validateBRPatient({ ...validPatient, identifier: undefined }, 'r');
+    expect(issues.some((i) => i.code === 'required')).toBe(true);
+  });
+
+  it('rejeita sem identificador brasileiro (CPF/CNS)', () => {
+    const issues = validateBRPatient(
+      {
+        ...validPatient,
+        identifier: [{ system: 'http://outra.url/passport', value: 'X1' }],
+      },
+      'r',
+    );
+    expect(issues.some((i) => i.code === 'invariant')).toBe(true);
+  });
+
+  it('rejeita sem name/birthDate/gender', () => {
+    const issues = validateBRPatient(
+      { ...validPatient, birthDate: undefined, gender: undefined, name: undefined },
+      'r',
+    );
+    const codes = issues.map((i) => i.code);
+    expect(codes.filter((c) => c === 'required').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('rejeita gender com valor inválido', () => {
+    const issues = validateBRPatient({ ...validPatient, gender: 'X' }, 'r');
+    expect(issues.some((i) => i.code === 'invalid')).toBe(true);
+  });
+});
+
+describe('validateBRLabObservation', () => {
+  it('aceita Observation completo', () => {
+    expect(validateBRLabObservation(validLabObservation, 'r')).toEqual([]);
+  });
+
+  it('rejeita sem coding LOINC', () => {
+    const obs = {
+      ...validLabObservation,
+      code: { coding: [{ code: 'X', system: 'http://outra.url' }] },
+    };
+    expect(validateBRLabObservation(obs, 'r').some((i) => i.code === 'required')).toBe(true);
+  });
+
+  it('rejeita sem categoria laboratory', () => {
+    const obs = { ...validLabObservation, category: [{ coding: [{ code: 'survey' }] }] };
+    expect(validateBRLabObservation(obs, 'r').some((i) => i.code === 'invalid')).toBe(true);
+  });
+
+  it('rejeita valueQuantity com system não-UCUM', () => {
+    const obs = {
+      ...validLabObservation,
+      valueQuantity: { ...validLabObservation.valueQuantity, system: 'http://outro.com' },
+    };
+    expect(
+      validateBRLabObservation(obs, 'r').some(
+        (i) => i.code === 'invalid' && i.location?.[0]?.includes('valueQuantity.system'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejeita status fora do value set', () => {
+    const obs = { ...validLabObservation, status: 'preliminary' };
+    expect(validateBRLabObservation(obs, 'r').some((i) => i.code === 'invalid')).toBe(true);
+  });
+
+  it('rejeita sem subject', () => {
+    const obs = { ...validLabObservation, subject: undefined };
+    expect(validateBRLabObservation(obs, 'r').some((i) => i.code === 'required')).toBe(true);
+  });
+});
+
+describe('validateBRDiagnosticReport', () => {
+  it('aceita DiagnosticReport completo', () => {
+    expect(validateBRDiagnosticReport(validDiagnosticReport, 'r')).toEqual([]);
+  });
+
+  it('rejeita sem result/performer', () => {
+    const dr = { ...validDiagnosticReport, performer: [], result: [] };
+    const issues = validateBRDiagnosticReport(dr, 'r');
+    expect(issues.filter((i) => i.code === 'required').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('rejeita categoria sem v2-0074 LAB', () => {
+    const dr = { ...validDiagnosticReport, category: [{ coding: [{ code: 'OTHER' }] }] };
+    expect(validateBRDiagnosticReport(dr, 'r').some((i) => i.code === 'invalid')).toBe(true);
+  });
+});
+
+describe('validateBundle', () => {
+  it('passa com Bundle válido', () => {
+    const bundle = {
+      entry: [{ resource: validPatient }, { resource: validLabObservation }],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    };
+    const result = validateBundle(bundle);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('reúne issues de múltiplos entries', () => {
+    const bundle = {
+      entry: [
+        { resource: { ...validPatient, gender: undefined } },
+        { resource: { ...validLabObservation, status: 'preliminary' } },
+      ],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    };
+    const result = validateBundle(bundle);
+    expect(result.valid).toBe(false);
+    // Deve incluir issue para Patient.gender e Observation.status
+    expect(
+      result.issues.some((i) => i.location?.[0]?.includes('Bundle.entry[0].resource.gender')),
+    ).toBe(true);
+    expect(
+      result.issues.some((i) => i.location?.[0]?.includes('Bundle.entry[1].resource.status')),
+    ).toBe(true);
+  });
+
+  it('respeita meta.profile quando declarado', () => {
+    const obsAsPatient = {
+      meta: { profile: ['https://fhir-brasil.dev.br/ig/StructureDefinition/br-patient'] },
+      resourceType: 'Observation',
+    };
+    const issues = validateResource(obsAsPatient, 'r');
+    // Forçado a validar como BRPatient → reclama da falta de identifier/name/etc.
+    expect(issues.some((i) => i.code === 'required')).toBe(true);
+  });
+
+  it('ignora resourceTypes fora do escopo do IG', () => {
+    const bundle = {
+      entry: [{ resource: { resourceType: 'Encounter', status: 'finished' } }],
+      resourceType: 'Bundle',
+      type: 'transaction',
+    };
+    expect(validateBundle(bundle).valid).toBe(true);
+  });
+});

--- a/packages/rnds-sandbox/src/cli.ts
+++ b/packages/rnds-sandbox/src/cli.ts
@@ -35,6 +35,8 @@ Modos de fidelidade RNDS:
                           (implícito quando --mtls está ativo)
   --mtls                  HTTPS + handshake mTLS (cliente apresenta cert).
                           /api/token exige cert; FHIR API exige bearer.
+  --no-validate           Desabilita validação contra perfis BR* do IG em POST /Bundle
+                          (default: validação ON, retorna 422 OperationOutcome em falha)
 
 Cert do servidor (use uma forma OU outra):
   --pfx <caminho>         PFX do servidor
@@ -125,6 +127,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (token === '--strict') {
       options.strict = true;
+      continue;
+    }
+    if (token === '--no-validate') {
+      options.validateSubmissions = false;
       continue;
     }
     const stringSetter = STRING_ARGS[token];

--- a/packages/rnds-sandbox/src/index.ts
+++ b/packages/rnds-sandbox/src/index.ts
@@ -31,3 +31,11 @@ export type {
   ScenarioData,
   ScenarioName,
 } from './types';
+export type { IssueSeverity, ValidationIssue, ValidationResult } from './validation';
+export {
+  validateBRDiagnosticReport,
+  validateBRLabObservation,
+  validateBRPatient,
+  validateBundle,
+  validateResource,
+} from './validation';

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -18,6 +18,7 @@ import { buildJwks } from './jwks';
 import type { SigningKeys } from './keys';
 import type { SandboxStore } from './store';
 import type { SandboxBundle, SandboxBundleEntry } from './types';
+import { validateBundle } from './validation';
 
 const FHIR_PREFIX = '/api/fhir/r4';
 const TOKEN_PATH = '/api/token';
@@ -50,6 +51,12 @@ export interface RouteContext {
   store: SandboxStore;
   /** Quando true, /api/token requer cert apresentado e FHIR exige bearer + CNS */
   strict: boolean;
+  /**
+   * Quando true (padrão), `POST /Bundle` valida cada entry contra os perfis
+   * BR* do IG fhir-brasil e rejeita com 422 se houver erros. Em modo
+   * permissivo (`false`), aceita qualquer Bundle com estrutura mínima.
+   */
+  validateProfiles: boolean;
 }
 
 export interface RouteResponse {
@@ -293,6 +300,28 @@ function handleSubmitBundle(ctx: RouteContext): RouteResponse {
       ),
       status: 400,
     };
+  }
+
+  // Valida cada entry contra os perfis BR* do IG. Erros disparam 422
+  // (FHIR-canônico para validation failure) com OperationOutcome
+  // multi-issue, igual à RNDS real.
+  if (ctx.validateProfiles) {
+    const result = validateBundle(bundle);
+    if (!result.valid) {
+      return {
+        body: {
+          issue: result.issues.map((i) => ({
+            code: i.code,
+            diagnostics: i.diagnostics,
+            expression: i.expression,
+            location: i.location,
+            severity: i.severity,
+          })),
+          resourceType: 'OperationOutcome',
+        },
+        status: 422,
+      };
+    }
   }
 
   ctx.store.recordBundle(bundle);

--- a/packages/rnds-sandbox/src/router.ts
+++ b/packages/rnds-sandbox/src/router.ts
@@ -314,7 +314,6 @@ function handleSubmitBundle(ctx: RouteContext): RouteResponse {
             code: i.code,
             diagnostics: i.diagnostics,
             expression: i.expression,
-            location: i.location,
             severity: i.severity,
           })),
           resourceType: 'OperationOutcome',

--- a/packages/rnds-sandbox/src/server.ts
+++ b/packages/rnds-sandbox/src/server.ts
@@ -37,6 +37,7 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
   const log = options.log ?? ((msg: string) => console.log(`[rnds-sandbox] ${msg}`));
   const useMtls = options.mtls === true;
   const strict = options.strict ?? useMtls;
+  const validateProfiles = options.validateSubmissions ?? true;
   const port = options.port ?? (useMtls ? 8443 : 8080);
   const host = options.host ?? '127.0.0.1';
 
@@ -50,24 +51,29 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
   });
 
   const handler = (req: IncomingMessage, res: ServerResponse) => {
-    handleRequest(req, res, { keys: signingKeys, log, store, strict, useMtls }).catch(
-      (err: unknown) => {
-        log(`erro inesperado: ${err instanceof Error ? err.message : String(err)}`);
-        if (res.headersSent) {
-          // Headers já foram para o socket — só garante que o response feche
-          // para o cliente não pendurar. Sem body novo.
-          if (!res.writableEnded) res.end();
-          return;
-        }
-        res.writeHead(500, { 'Content-Type': 'application/fhir+json; charset=utf-8' });
-        res.end(
-          JSON.stringify({
-            issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
-            resourceType: 'OperationOutcome',
-          }),
-        );
-      },
-    );
+    handleRequest(req, res, {
+      keys: signingKeys,
+      log,
+      store,
+      strict,
+      useMtls,
+      validateProfiles,
+    }).catch((err: unknown) => {
+      log(`erro inesperado: ${err instanceof Error ? err.message : String(err)}`);
+      if (res.headersSent) {
+        // Headers já foram para o socket — só garante que o response feche
+        // para o cliente não pendurar. Sem body novo.
+        if (!res.writableEnded) res.end();
+        return;
+      }
+      res.writeHead(500, { 'Content-Type': 'application/fhir+json; charset=utf-8' });
+      res.end(
+        JSON.stringify({
+          issue: [{ code: 'exception', diagnostics: String(err), severity: 'fatal' }],
+          resourceType: 'OperationOutcome',
+        }),
+      );
+    });
   };
 
   const server: http.Server | https.Server = useMtls
@@ -90,7 +96,8 @@ export function createSandboxServer(options: SandboxOptions = {}): SandboxServer
           const actualPort = typeof address === 'object' && address ? address.port : port;
           log(
             `${useMtls ? 'HTTPS+mTLS' : 'HTTP'} ouvindo em ${host}:${actualPort} ` +
-              `(cenário: ${options.scenario ?? 'paciente-com-exames'}, strict=${strict}, kid=${signingKeys.keyId})`,
+              `(cenário: ${options.scenario ?? 'paciente-com-exames'}, ` +
+              `strict=${strict}, validate=${validateProfiles}, kid=${signingKeys.keyId})`,
           );
           resolve({ host, port: actualPort });
         });
@@ -112,6 +119,7 @@ interface HandlerContext {
   store: SandboxStore;
   strict: boolean;
   useMtls: boolean;
+  validateProfiles: boolean;
 }
 
 async function handleRequest(
@@ -134,6 +142,7 @@ async function handleRequest(
     query: url.searchParams,
     store: ctx.store,
     strict: ctx.strict,
+    validateProfiles: ctx.validateProfiles,
   };
 
   const response = dispatch(routeCtx);

--- a/packages/rnds-sandbox/src/validation/helpers.ts
+++ b/packages/rnds-sandbox/src/validation/helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Helpers compartilhados pelos validadores de perfil.
+ *
+ * Cada helper retorna `ValidationIssue[]` (vazio quando passa) para que
+ * os validadores de perfil possam compor checagens com `[].concat(...)`.
+ */
+
+import type { IssueSeverity, ValidationIssue } from './types';
+
+export function issue(
+  severity: IssueSeverity,
+  code: string,
+  diagnostics: string,
+  path: string,
+): ValidationIssue {
+  return { code, diagnostics, expression: [path], location: [path], severity };
+}
+
+/** Retorna issue `error/required` se `value` for null/undefined. */
+export function requireField(value: unknown, label: string, path: string): ValidationIssue[] {
+  if (value === undefined || value === null) {
+    return [issue('error', 'required', `${label} é obrigatório`, path)];
+  }
+  return [];
+}
+
+/** Retorna issue se `value` não for um array com pelo menos `min` elementos. */
+export function requireMinCardinality(
+  value: unknown,
+  min: number,
+  label: string,
+  path: string,
+): ValidationIssue[] {
+  if (!Array.isArray(value) || value.length < min) {
+    return [
+      issue(
+        'error',
+        'required',
+        `${label} requer pelo menos ${min} elemento(s); recebido ${
+          Array.isArray(value) ? value.length : 0
+        }`,
+        path,
+      ),
+    ];
+  }
+  return [];
+}
+
+/** Retorna issue se `actual` não estiver no conjunto `allowed`. */
+export function requireOneOf(
+  actual: unknown,
+  allowed: readonly string[],
+  label: string,
+  path: string,
+): ValidationIssue[] {
+  if (typeof actual !== 'string' || !allowed.includes(actual)) {
+    return [
+      issue(
+        'error',
+        'invalid',
+        `${label} deve ser um de [${allowed.join(', ')}]; recebido "${String(actual)}"`,
+        path,
+      ),
+    ];
+  }
+  return [];
+}
+
+/** Retorna issue se a string não casar com o regex. */
+export function requirePattern(
+  value: unknown,
+  pattern: RegExp,
+  label: string,
+  path: string,
+): ValidationIssue[] {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    return [
+      issue(
+        'error',
+        'invalid',
+        `${label} não obedece ao formato esperado (${pattern.source})`,
+        path,
+      ),
+    ];
+  }
+  return [];
+}
+
+/**
+ * Retorna o valor de `obj[key]` quando obj é um objeto não-null, ou
+ * undefined caso contrário (sem lançar).
+ */
+export function get<T = unknown>(obj: unknown, key: string): T | undefined {
+  if (obj && typeof obj === 'object') {
+    return (obj as Record<string, unknown>)[key] as T | undefined;
+  }
+  return undefined;
+}

--- a/packages/rnds-sandbox/src/validation/helpers.ts
+++ b/packages/rnds-sandbox/src/validation/helpers.ts
@@ -13,7 +13,10 @@ export function issue(
   diagnostics: string,
   path: string,
 ): ValidationIssue {
-  return { code, diagnostics, expression: [path], location: [path], severity };
+  // Apenas `expression` (FHIRPath) — `location` foi marcado deprecated
+  // no R4 em favor de `expression`. Conteúdo idêntico em ambos só
+  // poluiria a saída.
+  return { code, diagnostics, expression: [path], severity };
 }
 
 /** Retorna issue `error/required` se `value` for null/undefined. */

--- a/packages/rnds-sandbox/src/validation/index.ts
+++ b/packages/rnds-sandbox/src/validation/index.ts
@@ -69,9 +69,17 @@ export function validateResource(resource: ResourceLike, path: string): Validati
       return validateBRPatient(resource, path);
     case 'Observation':
       // BRLabObservation só se aplica a observações laboratoriais. Vital-signs,
-      // social-history etc. usam outros perfis e seriam rejeitados injustamente.
-      // Heurística: aplicar a regra do perfil BR apenas quando o recurso já se
-      // declara `laboratory` em algum `category.coding`. Caso contrário, passa.
+      // social-history etc. usam outros perfis e seriam rejeitados injustamente
+      // se forçados ao perfil BR.
+      //
+      // Heurística: aplicar BR apenas quando `category.coding` contém o código
+      // `laboratory`. Caso contrário (categoria diferente, OU sem categoria
+      // alguma — possível em dados legados), o recurso passa sem checagem de
+      // perfil. Esse silêncio é deliberado: rejeitar Observations sem
+      // category implicaria adivinhar a intenção do cliente.
+      //
+      // Para garantir conformidade estrita em ambos os casos, declare
+      // `meta.profile` apontando para `br-lab-observation`.
       return looksLikeLabObservation(resource) ? validateBRLabObservation(resource, path) : [];
     case 'DiagnosticReport':
       return validateBRDiagnosticReport(resource, path);

--- a/packages/rnds-sandbox/src/validation/index.ts
+++ b/packages/rnds-sandbox/src/validation/index.ts
@@ -68,7 +68,11 @@ export function validateResource(resource: ResourceLike, path: string): Validati
     case 'Patient':
       return validateBRPatient(resource, path);
     case 'Observation':
-      return validateBRLabObservation(resource, path);
+      // BRLabObservation só se aplica a observações laboratoriais. Vital-signs,
+      // social-history etc. usam outros perfis e seriam rejeitados injustamente.
+      // Heurística: aplicar a regra do perfil BR apenas quando o recurso já se
+      // declara `laboratory` em algum `category.coding`. Caso contrário, passa.
+      return looksLikeLabObservation(resource) ? validateBRLabObservation(resource, path) : [];
     case 'DiagnosticReport':
       return validateBRDiagnosticReport(resource, path);
     default:
@@ -76,6 +80,17 @@ export function validateResource(resource: ResourceLike, path: string): Validati
       // chamador declarar `meta.profile` se quiser conformidade estrita.
       return [];
   }
+}
+
+const SYS_OBS_CATEGORY = 'http://terminology.hl7.org/CodeSystem/observation-category';
+
+function looksLikeLabObservation(resource: unknown): boolean {
+  const r = resource as { category?: { coding?: { system?: string; code?: string }[] }[] };
+  const cats = r?.category;
+  if (!Array.isArray(cats)) return false;
+  return cats.some((cat) =>
+    (cat?.coding ?? []).some((c) => c?.system === SYS_OBS_CATEGORY && c?.code === 'laboratory'),
+  );
 }
 
 export {

--- a/packages/rnds-sandbox/src/validation/index.ts
+++ b/packages/rnds-sandbox/src/validation/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Validação de Bundles FHIR contra os perfis do IG fhir-brasil.
+ *
+ * O sandbox roteia cada `Bundle.entry[i].resource` para o validador do
+ * perfil correspondente baseado no `meta.profile` declarado OU no
+ * `resourceType` quando ausente. Resultado é uma lista plana de
+ * `ValidationIssue` com `expression`/`location` no formato FHIR.
+ *
+ * Não cobre o spec inteiro de FHIR validation — foca no subset que a
+ * RNDS rejeita na prática (cardinalidade, identifiers brasileiros,
+ * coding LOINC/UCUM, value sets de status).
+ */
+
+import {
+  validateBRDiagnosticReport,
+  validateBRLabObservation,
+  validateBRPatient,
+} from './profiles';
+import type { ValidationIssue, ValidationResult } from './types';
+
+const PROFILE_URI = {
+  diagnosticReport: 'https://fhir-brasil.dev.br/ig/StructureDefinition/br-diagnostic-report',
+  labObservation: 'https://fhir-brasil.dev.br/ig/StructureDefinition/br-lab-observation',
+  patient: 'https://fhir-brasil.dev.br/ig/StructureDefinition/br-patient',
+} as const;
+
+interface ResourceLike {
+  meta?: { profile?: string[] };
+  resourceType?: string;
+}
+
+interface BundleLike {
+  entry?: Array<{ resource?: ResourceLike }>;
+  resourceType?: string;
+}
+
+export function validateBundle(bundle: unknown, basePath = 'Bundle'): ValidationResult {
+  const issues: ValidationIssue[] = [];
+  const b = bundle as BundleLike | undefined;
+  const entries = b?.entry ?? [];
+
+  entries.forEach((entry, index) => {
+    const resource = entry?.resource;
+    if (!resource) return;
+    const entryPath = `${basePath}.entry[${index}].resource`;
+    issues.push(...validateResource(resource, entryPath));
+  });
+
+  return { issues, valid: !issues.some((i) => i.severity === 'error' || i.severity === 'fatal') };
+}
+
+export function validateResource(resource: ResourceLike, path: string): ValidationIssue[] {
+  const declaredProfiles = resource?.meta?.profile ?? [];
+
+  // Quando o cliente declara explicitamente um perfil do IG, validamos contra ele.
+  if (declaredProfiles.includes(PROFILE_URI.patient)) {
+    return validateBRPatient(resource, path);
+  }
+  if (declaredProfiles.includes(PROFILE_URI.labObservation)) {
+    return validateBRLabObservation(resource, path);
+  }
+  if (declaredProfiles.includes(PROFILE_URI.diagnosticReport)) {
+    return validateBRDiagnosticReport(resource, path);
+  }
+
+  // Sem `meta.profile`, fallback por resourceType para os tipos cobertos.
+  switch (resource?.resourceType) {
+    case 'Patient':
+      return validateBRPatient(resource, path);
+    case 'Observation':
+      return validateBRLabObservation(resource, path);
+    case 'DiagnosticReport':
+      return validateBRDiagnosticReport(resource, path);
+    default:
+      // Outros tipos passam sem validação de perfil — é responsabilidade do
+      // chamador declarar `meta.profile` se quiser conformidade estrita.
+      return [];
+  }
+}
+
+export {
+  validateBRDiagnosticReport,
+  validateBRLabObservation,
+  validateBRPatient,
+} from './profiles';
+export type { IssueSeverity, ValidationIssue, ValidationResult } from './types';

--- a/packages/rnds-sandbox/src/validation/profiles.ts
+++ b/packages/rnds-sandbox/src/validation/profiles.ts
@@ -134,13 +134,22 @@ export function validateBRLabObservation(resource: unknown, path: string): Valid
       ...requireField(get(value, 'unit'), 'valueQuantity.unit', `${path}.valueQuantity.unit`),
     );
     issues.push(
-      ...requireField(get(value, 'system'), 'valueQuantity.system', `${path}.valueQuantity.system`),
-    );
-    issues.push(
       ...requireField(get(value, 'code'), 'valueQuantity.code', `${path}.valueQuantity.code`),
     );
+    // `system` é simultaneamente obrigatório (1..1) e fixo em UCUM. Tratamos
+    // os dois casos explicitamente em vez de empilhar checagens — fica
+    // claro que ausente vira `required` e errado vira `invalid`.
     const sys = get(value, 'system');
-    if (sys !== undefined && sys !== SYS_UCUM) {
+    if (sys === undefined) {
+      issues.push(
+        issue(
+          'error',
+          'required',
+          'valueQuantity.system é obrigatório',
+          `${path}.valueQuantity.system`,
+        ),
+      );
+    } else if (sys !== SYS_UCUM) {
       issues.push(
         issue(
           'error',

--- a/packages/rnds-sandbox/src/validation/profiles.ts
+++ b/packages/rnds-sandbox/src/validation/profiles.ts
@@ -1,0 +1,221 @@
+/**
+ * Validadores de perfil para os recursos cobertos pelo IG do fhir-brasil
+ * (BRPatient, BRLabObservation, BRDiagnosticReport).
+ *
+ * As regras espelham as restrições do FSH em `ig/input/fsh/profiles/`.
+ * Não pretendem ser uma implementação completa de FHIR validation —
+ * cobrem o que a RNDS real rejeita na prática para esses três perfis.
+ */
+
+import { get, issue, requireField, requireMinCardinality, requireOneOf } from './helpers';
+import type { ValidationIssue } from './types';
+
+// ============================================================================
+// Constantes do IG (alinhadas com aliases.fsh / sushi-config.yaml)
+// ============================================================================
+
+const NS_CPF = 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cpf';
+const NS_CNS = 'http://rnds.saude.gov.br/fhir/r4/NamingSystem/cns';
+const SYS_LOINC = 'http://loinc.org';
+const SYS_UCUM = 'http://unitsofmeasure.org';
+const SYS_OBS_CATEGORY = 'http://terminology.hl7.org/CodeSystem/observation-category';
+const SYS_V2_0074 = 'http://terminology.hl7.org/CodeSystem/v2-0074';
+
+const PATIENT_GENDERS = ['male', 'female', 'other', 'unknown'] as const;
+const LAB_OBS_STATUS = ['final', 'amended', 'corrected'] as const;
+const DIAG_REPORT_STATUS = ['final', 'amended', 'corrected'] as const;
+
+// ============================================================================
+// BRPatient
+// ============================================================================
+
+export function validateBRPatient(resource: unknown, path: string): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  const identifiers = get<unknown[]>(resource, 'identifier');
+  issues.push(...requireMinCardinality(identifiers, 1, 'Patient.identifier', `${path}.identifier`));
+
+  if (Array.isArray(identifiers)) {
+    const hasBrazilianId = identifiers.some((id) => {
+      const sys = get<string>(id, 'system');
+      return sys === NS_CPF || sys === NS_CNS;
+    });
+    if (!hasBrazilianId) {
+      issues.push(
+        issue(
+          'error',
+          'invariant',
+          'Patient deve ter pelo menos um identificador CPF ou CNS (br-patient-identifier)',
+          `${path}.identifier`,
+        ),
+      );
+    }
+  }
+
+  const names = get<unknown[]>(resource, 'name');
+  issues.push(...requireMinCardinality(names, 1, 'Patient.name', `${path}.name`));
+
+  issues.push(
+    ...requireField(get(resource, 'birthDate'), 'Patient.birthDate', `${path}.birthDate`),
+  );
+  const gender = get(resource, 'gender');
+  issues.push(...requireField(gender, 'Patient.gender', `${path}.gender`));
+  if (gender !== undefined) {
+    issues.push(...requireOneOf(gender, PATIENT_GENDERS, 'Patient.gender', `${path}.gender`));
+  }
+
+  return issues;
+}
+
+// ============================================================================
+// BRLabObservation
+// ============================================================================
+
+export function validateBRLabObservation(resource: unknown, path: string): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  const status = get(resource, 'status');
+  issues.push(...requireField(status, 'Observation.status', `${path}.status`));
+  if (status !== undefined) {
+    issues.push(...requireOneOf(status, LAB_OBS_STATUS, 'Observation.status', `${path}.status`));
+  }
+
+  const categories = get<unknown[]>(resource, 'category');
+  issues.push(...requireMinCardinality(categories, 1, 'Observation.category', `${path}.category`));
+  if (Array.isArray(categories)) {
+    const hasLab = categories.some((cat) => {
+      const codings = get<unknown[]>(cat, 'coding');
+      return (
+        Array.isArray(codings) &&
+        codings.some(
+          (c) =>
+            get<string>(c, 'system') === SYS_OBS_CATEGORY &&
+            get<string>(c, 'code') === 'laboratory',
+        )
+      );
+    });
+    if (!hasLab) {
+      issues.push(
+        issue(
+          'error',
+          'invalid',
+          'Observation.category deve incluir { system: observation-category, code: laboratory }',
+          `${path}.category`,
+        ),
+      );
+    }
+  }
+
+  const code = get(resource, 'code');
+  issues.push(...requireField(code, 'Observation.code', `${path}.code`));
+  if (code) {
+    const codings = get<unknown[]>(code, 'coding');
+    const hasLoinc =
+      Array.isArray(codings) && codings.some((c) => get<string>(c, 'system') === SYS_LOINC);
+    if (!hasLoinc) {
+      issues.push(
+        issue(
+          'error',
+          'required',
+          'Observation.code.coding deve incluir um coding com system http://loinc.org',
+          `${path}.code.coding`,
+        ),
+      );
+    }
+  }
+
+  const value = get(resource, 'valueQuantity');
+  issues.push(...requireField(value, 'Observation.valueQuantity', `${path}.valueQuantity`));
+  if (value) {
+    issues.push(
+      ...requireField(get(value, 'value'), 'valueQuantity.value', `${path}.valueQuantity.value`),
+    );
+    issues.push(
+      ...requireField(get(value, 'unit'), 'valueQuantity.unit', `${path}.valueQuantity.unit`),
+    );
+    const sys = get(value, 'system');
+    if (sys !== undefined && sys !== SYS_UCUM) {
+      issues.push(
+        issue(
+          'error',
+          'invalid',
+          `valueQuantity.system deve ser ${SYS_UCUM}; recebido "${String(sys)}"`,
+          `${path}.valueQuantity.system`,
+        ),
+      );
+    }
+  }
+
+  issues.push(...requireField(get(resource, 'subject'), 'Observation.subject', `${path}.subject`));
+  issues.push(
+    ...requireField(
+      get(resource, 'effectiveDateTime'),
+      'Observation.effectiveDateTime',
+      `${path}.effectiveDateTime`,
+    ),
+  );
+
+  return issues;
+}
+
+// ============================================================================
+// BRDiagnosticReport
+// ============================================================================
+
+export function validateBRDiagnosticReport(resource: unknown, path: string): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  const status = get(resource, 'status');
+  issues.push(...requireField(status, 'DiagnosticReport.status', `${path}.status`));
+  if (status !== undefined) {
+    issues.push(
+      ...requireOneOf(status, DIAG_REPORT_STATUS, 'DiagnosticReport.status', `${path}.status`),
+    );
+  }
+
+  const categories = get<unknown[]>(resource, 'category');
+  issues.push(
+    ...requireMinCardinality(categories, 1, 'DiagnosticReport.category', `${path}.category`),
+  );
+  if (Array.isArray(categories)) {
+    const hasLab = categories.some((cat) => {
+      const codings = get<unknown[]>(cat, 'coding');
+      return (
+        Array.isArray(codings) &&
+        codings.some(
+          (c) => get<string>(c, 'system') === SYS_V2_0074 && get<string>(c, 'code') === 'LAB',
+        )
+      );
+    });
+    if (!hasLab) {
+      issues.push(
+        issue(
+          'error',
+          'invalid',
+          'DiagnosticReport.category deve incluir { system: v2-0074, code: LAB }',
+          `${path}.category`,
+        ),
+      );
+    }
+  }
+
+  issues.push(...requireField(get(resource, 'code'), 'DiagnosticReport.code', `${path}.code`));
+  issues.push(
+    ...requireField(get(resource, 'subject'), 'DiagnosticReport.subject', `${path}.subject`),
+  );
+  issues.push(
+    ...requireField(
+      get(resource, 'effectiveDateTime'),
+      'DiagnosticReport.effectiveDateTime',
+      `${path}.effectiveDateTime`,
+    ),
+  );
+  const results = get<unknown[]>(resource, 'result');
+  issues.push(...requireMinCardinality(results, 1, 'DiagnosticReport.result', `${path}.result`));
+  const performers = get<unknown[]>(resource, 'performer');
+  issues.push(
+    ...requireMinCardinality(performers, 1, 'DiagnosticReport.performer', `${path}.performer`),
+  );
+
+  return issues;
+}

--- a/packages/rnds-sandbox/src/validation/profiles.ts
+++ b/packages/rnds-sandbox/src/validation/profiles.ts
@@ -133,6 +133,12 @@ export function validateBRLabObservation(resource: unknown, path: string): Valid
     issues.push(
       ...requireField(get(value, 'unit'), 'valueQuantity.unit', `${path}.valueQuantity.unit`),
     );
+    issues.push(
+      ...requireField(get(value, 'system'), 'valueQuantity.system', `${path}.valueQuantity.system`),
+    );
+    issues.push(
+      ...requireField(get(value, 'code'), 'valueQuantity.code', `${path}.valueQuantity.code`),
+    );
     const sys = get(value, 'system');
     if (sys !== undefined && sys !== SYS_UCUM) {
       issues.push(

--- a/packages/rnds-sandbox/src/validation/types.ts
+++ b/packages/rnds-sandbox/src/validation/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Tipos compartilhados pelo validador de perfis FHIR.
+ *
+ * Espelham o subset de `OperationOutcome` do FHIR R4 que retornamos
+ * em respostas de validação. Não pretendem cobrir o spec inteiro.
+ */
+
+export type IssueSeverity = 'fatal' | 'error' | 'warning' | 'information';
+
+export interface ValidationIssue {
+  /** Código FHIR R4 do tipo do problema (ex: 'required', 'invariant', 'invalid'). */
+  code: string;
+  /** Mensagem em pt-BR explicando o problema. */
+  diagnostics: string;
+  /**
+   * FHIRPath até o elemento problemático
+   * (ex: `Bundle.entry[0].resource.identifier`).
+   */
+  expression?: string[];
+  /** Caminho legível em texto, equivalente a `expression`. */
+  location?: string[];
+  severity: IssueSeverity;
+}
+
+export interface ValidationResult {
+  issues: ValidationIssue[];
+  /** True quando não há issues `error` ou `fatal`. */
+  valid: boolean;
+}
+
+export interface ValidationContext {
+  /** Caminho do recurso na hierarquia (`Bundle.entry[0].resource`, etc.). */
+  path: string;
+}


### PR DESCRIPTION
## Summary

Fecha o último gap aberto do PRE-201 (item #5 — IG validation).

`POST /api/fhir/r4/Bundle` agora valida cada `Bundle.entry[i].resource`
contra os perfis `BR*` do IG `fhir-brasil` e responde com
`OperationOutcome 422` multi-issue quando há violações — formato
espelhando o que a RNDS real retorna.

## Implementação

Pure TS sob `packages/rnds-sandbox/src/validation/` (zero deps novas):
- `types.ts` — `ValidationIssue` / `ValidationResult`
- `helpers.ts` — `requireField`, `requireMinCardinality`, `requireOneOf`, `requirePattern`
- `profiles.ts` — `validateBR{Patient,LabObservation,DiagnosticReport}` espelhando
  os FSH em `ig/input/fsh/profiles/`
- `index.ts` — `validateBundle()` / `validateResource()` públicos

Resolução de perfil: usa `meta.profile` quando declarado; fallback por
`resourceType` (`Patient` → BRPatient, `Observation` → BRLabObservation,
`DiagnosticReport` → BRDiagnosticReport). Outros tipos passam sem checagem.

CLI ganha `--no-validate` (default: validação ON).
Programaticamente: `createSandboxServer({ validateSubmissions: false })`.

## O que valida (espelhando os FSH)

| Perfil | Restrições aplicadas |
| ------ | -------------------- |
| **BRPatient** | identifier ≥1, ao menos um CPF/CNS via NamingSystem RNDS, name ≥1, birthDate, gender ∈ {male,female,other,unknown} |
| **BRLabObservation** | status ∈ {final,amended,corrected}, category com `laboratory`, code com coding LOINC, valueQuantity (system UCUM, value, unit), subject, effectiveDateTime |
| **BRDiagnosticReport** | status, category com LAB (v2-0074), code, subject, effectiveDateTime, ≥1 result, ≥1 performer |

## O que NÃO valida (fora do escopo)

- Value-set binding contra terminologias externas (LOINC catálogo, CID-10)
- Slicing avançado (apenas presença, não duplicatas/ordem)
- Invariantes FHIRPath complexos além do `br-patient-identifier`

Para validação 100% completa, a recomendação é o validator Java oficial
(`org.hl7.fhir.validator-cli.jar`) — o sandbox cobre o subset que a RNDS
real rejeita na prática para esses três perfis.

## Tests

- 18 testes novos em `validation.test.ts` (87 totais no pacote)
- Coverage: 91.43% statements / 89.62% branches / 83.95% funcs / 91.43% lines
- `profiles.ts` em 100% de cobertura
- Smoke E2E verificado: Patient sem campos → 422 com 4 issues; Observation
  válido → 200; `--no-validate` aceita o mesmo body inválido com 200.

## Test plan

- [ ] `pnpm install && pnpm test` (full monorepo) passa
- [ ] `pnpm --filter @precisa-saude/fhir-rnds-sandbox test:coverage` passa thresholds
- [ ] CLI: `node packages/rnds-sandbox/dist/cli.js start` → POST inválido devolve 422
- [ ] CLI: `node packages/rnds-sandbox/dist/cli.js start --no-validate` → mesmo POST devolve 200
- [ ] Verificar que o exemplo `examples/rnds-sandbox-express` continua funcional
      (o `sampleBundle()` dele já é spec-compliant — Observation com LOINC + UCUM)

Refs PRE-201