### PR TITLE
chore(lint): remover override local redundante — test max-lines agora no preset compartilhado

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,12 +38,4 @@ export default [
       'max-lines': 'off',
     },
   },
-  {
-    // Tests data-driven (biomarkers, conversores, reference ranges) naturalmente
-    // ultrapassam 400 linhas por cobrirem tabelas. Não vale fragmentar.
-    files: ['**/__tests__/**/*.ts', '**/*.test.ts'],
-    rules: {
-      'max-lines': 'off',
-    },
-  },
 ];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@commitlint/cli": "^20.5.0",
     "@precisa-saude/agent-instructions": "^1.1.2",
     "@precisa-saude/commitlint-config": "^1.1.2",
-    "@precisa-saude/eslint-config": "^1.1.2",
+    "@precisa-saude/eslint-config": "^1.2.0",
     "@precisa-saude/prettier-config": "^1.1.2",
     "@precisa-saude/tsconfig": "^1.1.2",
     "@precisa-saude/worktree-cli": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@commitlint/cli@20.5.0(@types/node@22.19.17)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.7.3))
       '@precisa-saude/eslint-config':
-        specifier: ^1.1.2
-        version: 1.1.2(eslint@10.1.0(jiti@2.6.1))(jiti@2.6.1)(prettier@3.8.1)(tailwindcss@4.2.2)(typescript@5.7.3)
+        specifier: ^1.2.0
+        version: 1.2.0(eslint@10.1.0(jiti@2.6.1))(jiti@2.6.1)(prettier@3.8.1)(tailwindcss@4.2.2)(typescript@5.7.3)
       '@precisa-saude/prettier-config':
         specifier: ^1.1.2
         version: 1.1.2(prettier-plugin-packagejson@3.0.2(prettier@3.8.1))(prettier@3.8.1)
@@ -1277,8 +1277,8 @@ packages:
     peerDependencies:
       '@commitlint/cli': '>=19'
 
-  '@precisa-saude/eslint-config@1.1.2':
-    resolution: {integrity: sha512-Z1HJaTXuLfTvRNeTFcz/TBbi6vJt1Y4L7UhHEpDDl7dooPZGhTY/Sn7sNBLnGlJ4N59f5GkIuaMq5FaLPz+fyA==}
+  '@precisa-saude/eslint-config@1.2.0':
+    resolution: {integrity: sha512-ZT/2lacpVSNpfhaBt7HBL4NIf6JjE5S0iWh1XUvAgzHgikLx9AtOdQvsFHLlwBarhjr8fCZCbdWSOK5gwpfY9g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -6626,7 +6626,7 @@ snapshots:
       '@commitlint/cli': 20.5.0(@types/node@22.19.17)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.7.3)
       '@commitlint/config-conventional': 20.5.0
 
-  '@precisa-saude/eslint-config@1.1.2(eslint@10.1.0(jiti@2.6.1))(jiti@2.6.1)(prettier@3.8.1)(tailwindcss@4.2.2)(typescript@5.7.3)':
+  '@precisa-saude/eslint-config@1.2.0(eslint@10.1.0(jiti@2.6.1))(jiti@2.6.1)(prettier@3.8.1)(tailwindcss@4.2.2)(typescript@5.7.3)':
     dependencies:
       '@eslint/js': 9.39.4
       '@html-eslint/eslint-plugin': 0.52.1(eslint@10.1.0(jiti@2.6.1))(jiti@2.6.1)


### PR DESCRIPTION
## Resumo

\`@precisa-saude/eslint-config@1.2.0\` (tooling PRs #18 + #19) passou a trazer o override de arquivos de teste/benchmark no preset base. O override local daqui virou redundante — este PR remove.

## Mudanças

- \`eslint.config.js\`: remove o bloco local que desligava \`max-lines\` pra \`**/__tests__/**/*.ts\` e \`**/*.test.ts\`. A mesma regra (mais ampla, cobrindo também benchmarks) agora vive em \`@precisa-saude/eslint-config/base\`.
- \`package.json\`: bump \`@precisa-saude/eslint-config\` de \`^1.1.2\` → \`^1.2.0\`.

## O que fica no eslint.config.js local

- Override de \`parserOptions.project: false\` pra arquivos de teste — é necessidade específica do fhir (testes ficam fora do tsconfig dos pacotes pra manter \`tsc --noEmit\` rápido), não do preset compartilhado.
- Override de dados médicos (\`biomarkers.ts\`, \`dexa-zone-data.ts\`, \`reference-ranges.ts\`, \`units.ts\` com \`sort-objects\` + \`max-lines\` off) — específico desses arquivos de dados, não generalizável pro preset.

## Test plan

- [x] \`pnpm turbo run lint --force\` passa local (7/7 tasks verde)
- [ ] CI verde