### PR TITLE
feat: consumir Header e OpenFooter compartilhados do @precisa-saude/ui no site

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,11 +175,11 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@precisa-saude/themes':
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.6.0
+        version: 1.6.0
       '@precisa-saude/ui':
-        specifier: ^1.5.0
-        version: 1.5.0(@base-ui/react@1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.562.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@3.23.0)
+        specifier: ^1.6.0
+        version: 1.6.0(@base-ui/react@1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.562.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@3.23.0)
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.4)
@@ -1295,8 +1295,8 @@ packages:
       prettier-plugin-tailwindcss:
         optional: true
 
-  '@precisa-saude/themes@1.5.0':
-    resolution: {integrity: sha512-7xuDOg9u51Ft7+FvRvzVaFiAA/v48LrcAcfqIrL29HGxBvDb/AkFCkNrhQv2Hh6WtwupBHyuwcTIud/lRFxACg==}
+  '@precisa-saude/themes@1.6.0':
+    resolution: {integrity: sha512-AsoqM9MeFvGVM4mpXhS9wUbgoMGkE/ZL9mKWRT7lMtO8mwxDmAsDLDTS2Y/iJma6CazmNtRr7fCw5wgDJ35hlw==}
     engines: {node: '>=22.0.0'}
 
   '@precisa-saude/tsconfig@1.5.0':
@@ -1305,8 +1305,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  '@precisa-saude/ui@1.5.0':
-    resolution: {integrity: sha512-l93EW8KV5ptwRpRtYm0uH6aVa+AFthmuEXxfZIPdw69d1IRBrDvqL4x2b4snRIPJ/1Lw9ZgeiTHPmfd4RsxiDA==}
+  '@precisa-saude/ui@1.6.0':
+    resolution: {integrity: sha512-0X1Btr5g7A8fKu8CA9gso3t4nJnxhtXav9RA0IvwRXCc5he7wp8WkNBJAb3opUU+gpvH8rYl0d2tvw+6hkvx6Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@base-ui/react': ^1.3.0
@@ -6657,13 +6657,13 @@ snapshots:
       prettier: 3.8.1
       prettier-plugin-packagejson: 3.0.2(prettier@3.8.1)
 
-  '@precisa-saude/themes@1.5.0': {}
+  '@precisa-saude/themes@1.6.0': {}
 
   '@precisa-saude/tsconfig@1.5.0(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
-  '@precisa-saude/ui@1.5.0(@base-ui/react@1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.562.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@3.23.0)':
+  '@precisa-saude/ui@1.6.0(@base-ui/react@1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.562.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@3.23.0)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1

--- a/site/package.json
+++ b/site/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
-    "@precisa-saude/themes": "^1.5.0",
-    "@precisa-saude/ui": "^1.5.0",
+    "@precisa-saude/themes": "^1.6.0",
+    "@precisa-saude/ui": "^1.6.0",
     "lucide-react": "^0.562.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -1,23 +1,4 @@
-const SOCIAL_LINKS = [
-  {
-    label: 'GitHub',
-    href: 'https://github.com/Precisa-Saude/fhir-brasil',
-    icon: (
-      <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current" aria-hidden="true">
-        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
-      </svg>
-    ),
-  },
-  {
-    label: 'npm',
-    href: 'https://www.npmjs.com/org/precisa-saude',
-    icon: (
-      <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current" aria-hidden="true">
-        <path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0Zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331Zm4 0h-2.666V8.667h5.334v5.331h-2.668v-4h-1.332v4h1.332Zm10.668 0h-1.332v-4h-1.334v4h-1.332v-4h-1.334v4h-2.668V8.667h8.002v5.331h-.002Z" />
-      </svg>
-    ),
-  },
-] as const;
+import { OpenFooter } from '@precisa-saude/ui';
 
 function PrecisaLogo() {
   return (
@@ -43,58 +24,40 @@ function PrecisaLogo() {
   );
 }
 
+const SOCIALS = [
+  {
+    href: 'https://github.com/Precisa-Saude/fhir-brasil',
+    icon: (
+      <svg aria-hidden="true" className="h-5 w-5 fill-current" viewBox="0 0 24 24">
+        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
+      </svg>
+    ),
+    label: 'GitHub',
+  },
+  {
+    href: 'https://www.npmjs.com/org/precisa-saude',
+    icon: (
+      <svg aria-hidden="true" className="h-5 w-5 fill-current" viewBox="0 0 24 24">
+        <path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0Zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331Zm4 0h-2.666V8.667h5.334v5.331h-2.668v-4h-1.332v4h1.332Zm10.668 0h-1.332v-4h-1.334v4h-1.332v-4h-1.334v4h-2.668V8.667h8.002v5.331h-.002Z" />
+      </svg>
+    ),
+    label: 'npm',
+  },
+];
+
+const DISCLAIMER =
+  'Este software é fornecido exclusivamente para fins informativos e educacionais. Não constitui aconselhamento médico, diagnóstico ou recomendação de tratamento. Os dados e cálculos fornecidos não substituem a avaliação de um profissional de saúde qualificado. Consulte sempre seu médico antes de tomar decisões baseadas em resultados laboratoriais.';
+
 export function Footer() {
   return (
-    <footer className="border-t border-ps-violet-dark/10 bg-ps-sand/50 transition-colors duration-200">
-      <div
-        className="mx-auto grid gap-4 px-4 py-10 md:px-0"
-        style={{
-          gridTemplateColumns: 'repeat(var(--grid-cols), 1fr)',
-          maxWidth: 'var(--grid-max-w)',
-          width: '100%',
-        }}
-      >
-        <div className="col-span-full md:col-span-12 md:col-start-2 3xl:col-start-3">
-          <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
-            <div className="flex flex-col items-center gap-2 sm:items-start">
-              <span className="font-margem text-xs tracking-wide text-ps-violet-dark/40">
-                Mantido por
-              </span>
-              <a
-                href="https://precisa-saude.com.br"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center transition-opacity hover:opacity-80"
-              >
-                <PrecisaLogo />
-                <span className="font-pausa text-xl text-ps-violet-light">Precisa Saúde</span>
-              </a>
-            </div>
-
-            <nav className="flex items-center gap-3">
-              {SOCIAL_LINKS.map((link) => (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={link.label}
-                  className="flex h-10 w-10 items-center justify-center rounded-full bg-ps-violet-dark/5 text-ps-violet-dark/50 transition-colors hover:bg-ps-violet-dark/10 hover:text-ps-violet-dark"
-                >
-                  {link.icon}
-                </a>
-              ))}
-            </nav>
-          </div>
-
-          <p className="mt-8 border-t border-ps-violet-dark/8 pt-6 text-justify font-margem text-xs leading-relaxed text-ps-violet-dark/30 [text-align-last:left]">
-            Este software é fornecido exclusivamente para fins informativos e educacionais. Não
-            constitui aconselhamento médico, diagnóstico ou recomendação de tratamento. Os dados e
-            cálculos fornecidos não substituem a avaliação de um profissional de saúde qualificado.
-            Consulte sempre seu médico antes de tomar decisões baseadas em resultados laboratoriais.
-          </p>
-        </div>
-      </div>
-    </footer>
+    <OpenFooter
+      brand={{
+        href: 'https://precisa-saude.com.br',
+        logo: <PrecisaLogo />,
+        name: 'Precisa Saúde',
+      }}
+      disclaimer={DISCLAIMER}
+      socials={SOCIALS}
+    />
   );
 }

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -24,30 +24,6 @@ function PrecisaLogo() {
   );
 }
 
-const SOCIALS = [
-  {
-    href: 'https://github.com/Precisa-Saude/fhir-brasil',
-    icon: (
-      <svg aria-hidden="true" className="h-5 w-5 fill-current" viewBox="0 0 24 24">
-        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
-      </svg>
-    ),
-    label: 'GitHub',
-  },
-  {
-    href: 'https://www.npmjs.com/org/precisa-saude',
-    icon: (
-      <svg aria-hidden="true" className="h-5 w-5 fill-current" viewBox="0 0 24 24">
-        <path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0Zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331Zm4 0h-2.666V8.667h5.334v5.331h-2.668v-4h-1.332v4h1.332Zm10.668 0h-1.332v-4h-1.334v4h-1.332v-4h-1.334v4h-2.668V8.667h8.002v5.331h-.002Z" />
-      </svg>
-    ),
-    label: 'npm',
-  },
-];
-
-const DISCLAIMER =
-  'Este software é fornecido exclusivamente para fins informativos e educacionais. Não constitui aconselhamento médico, diagnóstico ou recomendação de tratamento. Os dados e cálculos fornecidos não substituem a avaliação de um profissional de saúde qualificado. Consulte sempre seu médico antes de tomar decisões baseadas em resultados laboratoriais.';
-
 export function Footer() {
   return (
     <OpenFooter
@@ -56,8 +32,8 @@ export function Footer() {
         logo: <PrecisaLogo />,
         name: 'Precisa Saúde',
       }}
-      disclaimer={DISCLAIMER}
-      socials={SOCIALS}
+      githubUrl="https://github.com/Precisa-Saude/fhir-brasil"
+      npmUrl="https://www.npmjs.com/package/@precisa-saude/fhir"
     />
   );
 }

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -1,25 +1,30 @@
 import { Header } from '@precisa-saude/ui';
 import { useWideGrid } from '@precisa-saude/ui/hooks';
-import { ExternalLink, Flame } from 'lucide-react';
+import { Code2, ExternalLink, Flame, Github, Package } from 'lucide-react';
 import { useState } from 'react';
 
+import pkg from '../../../package.json';
+
 const NAV_LINKS = [
-  { col: 5, href: '#exemplos', label: 'Exemplos', span: 2 },
-  { col: 7, href: '#pacotes', label: 'Pacotes', span: 2 },
-  { col: 9, href: '#open-source', label: 'Código Aberto', span: 3 },
+  { col: 5, href: '#exemplos', icon: Code2, label: 'Exemplos', span: 2 },
+  { col: 7, href: '#pacotes', icon: Package, label: 'Pacotes', span: 2 },
+  { col: 9, href: '#open-source', icon: Github, label: 'Código Aberto', span: 3 },
 ] as const;
 
 const GITHUB_URL = 'https://github.com/Precisa-Saude/fhir-brasil';
 
 const logo = (
   <a
-    className="inline-flex h-full items-center gap-1.5 font-margem text-xl font-bold tracking-tight text-white"
+    className="inline-flex h-full items-center gap-1.5 font-margem text-xl font-bold tracking-tight whitespace-nowrap text-white"
     href="#"
   >
     <Flame className="h-6 w-6 shrink-0 text-white" />
     fhir-brasil
   </a>
 );
+
+const mobileNavLinkClass =
+  'flex w-full items-center gap-3 rounded-md px-3 py-2.5 font-margem text-base text-foreground transition-colors hover:bg-muted';
 
 export function Nav() {
   const [open, setOpen] = useState(false);
@@ -55,26 +60,56 @@ export function Nav() {
   );
 
   const mobileNavItems = (
-    <div className="flex flex-col gap-4 px-6 py-6">
-      {NAV_LINKS.map((link) => (
-        <a
-          key={link.href}
-          className="font-margem text-base font-medium text-foreground/80 transition-colors hover:text-foreground"
-          href={link.href}
-          onClick={() => setOpen(false)}
-        >
-          {link.label}
-        </a>
-      ))}
-      <a
-        className="inline-flex items-center gap-1.5 font-margem text-sm font-medium text-foreground/80"
-        href={GITHUB_URL}
-        rel="noopener noreferrer"
-        target="_blank"
+    <div className="flex min-h-0 flex-1 flex-col">
+      <button
+        className="mb-2 flex cursor-pointer justify-center px-3 py-2"
+        onClick={() => {
+          setOpen(false);
+          window.scrollTo({ behavior: 'smooth', top: 0 });
+        }}
       >
-        GitHub
-        <ExternalLink className="h-3.5 w-3.5" />
-      </a>
+        <Flame className="size-8 text-primary" />
+      </button>
+      <div className="mb-2 border-t border-border" />
+
+      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto px-3">
+        {NAV_LINKS.map((link) => {
+          const Icon = link.icon;
+          return (
+            <a
+              key={link.href}
+              className={mobileNavLinkClass}
+              href={link.href}
+              onClick={() => setOpen(false)}
+            >
+              <Icon className="size-5" />
+              {link.label}
+            </a>
+          );
+        })}
+      </div>
+
+      <div className="border-t border-border" />
+      <div className="mt-auto px-3 pt-4 pb-4">
+        <a
+          className="inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-primary px-4 py-2.5 font-margem text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
+          href={GITHUB_URL}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <Github className="size-4" />
+          GitHub
+          <ExternalLink className="size-3.5" />
+        </a>
+      </div>
+
+      <div className="border-t border-border" />
+      <div
+        className="pt-3 pb-6 text-center font-margem text-xs text-muted-foreground"
+        style={{ paddingBottom: 'calc(1.5rem + env(safe-area-inset-bottom, 0px))' }}
+      >
+        v{pkg.version}
+      </div>
     </div>
   );
 

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -1,100 +1,95 @@
-import { useDesktop, useWideGrid } from '@precisa-saude/ui/hooks';
-import { cn } from '@precisa-saude/ui/utils';
-import { ExternalLink, Flame, Menu, X } from 'lucide-react';
+import { Header } from '@precisa-saude/ui';
+import { useWideGrid } from '@precisa-saude/ui/hooks';
+import { ExternalLink, Flame } from 'lucide-react';
 import { useState } from 'react';
 
 const NAV_LINKS = [
-  { label: 'Exemplos', href: '#exemplos', col: 5, span: 2 },
-  { label: 'Pacotes', href: '#pacotes', col: 7, span: 2 },
-  { label: 'Código Aberto', href: '#open-source', col: 9, span: 3 },
+  { col: 5, href: '#exemplos', label: 'Exemplos', span: 2 },
+  { col: 7, href: '#pacotes', label: 'Pacotes', span: 2 },
+  { col: 9, href: '#open-source', label: 'Código Aberto', span: 3 },
 ] as const;
 
-const gridStyle = {
-  gridTemplateColumns: 'repeat(var(--grid-cols), 1fr)',
-  maxWidth: 'var(--grid-max-w)',
-  width: '100%',
-} as const;
+const GITHUB_URL = 'https://github.com/Precisa-Saude/fhir-brasil';
+
+const logo = (
+  <a
+    className="inline-flex h-full items-center gap-1.5 font-margem text-xl font-bold tracking-tight text-white"
+    href="#"
+  >
+    <Flame className="h-6 w-6 shrink-0 text-white" />
+    fhir-brasil
+  </a>
+);
 
 export function Nav() {
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const desktop = useDesktop();
+  const [open, setOpen] = useState(false);
   const wide = useWideGrid();
   const offset = wide ? 1 : 0;
 
+  const navItems = (
+    <>
+      {NAV_LINKS.map((link) => (
+        <a
+          key={link.href}
+          className="hidden h-full items-center justify-center border-b-2 border-transparent font-margem text-base font-medium text-white/70 transition-colors hover:border-white hover:text-white lg:flex"
+          href={link.href}
+          style={{ gridColumn: `${link.col + offset} / span ${link.span}` }}
+        >
+          {link.label}
+        </a>
+      ))}
+    </>
+  );
+
+  const actions = (
+    <a
+      className="hidden items-center justify-center gap-1.5 self-center rounded-full bg-white/15 px-4 py-2 font-margem text-sm font-medium text-white transition-colors hover:bg-white/25 lg:inline-flex"
+      href={GITHUB_URL}
+      rel="noopener noreferrer"
+      style={{ gridColumn: `${12 + offset} / span 2` }}
+      target="_blank"
+    >
+      GitHub
+      <ExternalLink className="h-3.5 w-3.5" />
+    </a>
+  );
+
+  const mobileNavItems = (
+    <div className="flex flex-col gap-4 px-6 py-6">
+      {NAV_LINKS.map((link) => (
+        <a
+          key={link.href}
+          className="font-margem text-base font-medium text-foreground/80 transition-colors hover:text-foreground"
+          href={link.href}
+          onClick={() => setOpen(false)}
+        >
+          {link.label}
+        </a>
+      ))}
+      <a
+        className="inline-flex items-center gap-1.5 font-margem text-sm font-medium text-foreground/80"
+        href={GITHUB_URL}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GitHub
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </div>
+  );
+
   return (
-    <nav className="fixed top-0 z-50 w-full border-b border-white/10 bg-ps-violet-dark/95 backdrop-blur-md">
-      <div
-        className="mx-auto flex h-16 items-center justify-between px-4 md:grid md:items-stretch md:gap-4 md:px-0"
-        style={gridStyle}
-      >
-        <a
-          href="#"
-          className="inline-flex h-full items-center gap-1.5 font-margem text-xl font-bold tracking-tight text-white md:col-span-3"
-          style={desktop ? { gridColumnStart: 2 + offset } : undefined}
-        >
-          <Flame className="h-6 w-6 shrink-0 text-white" />
-          fhir-brasil
-        </a>
-
-        {NAV_LINKS.map((link) => (
-          <a
-            key={link.href}
-            href={link.href}
-            className="hidden h-full items-center justify-center border-b-2 border-transparent font-margem text-base font-medium text-white/70 transition-colors hover:border-white hover:text-white md:flex"
-            style={{ gridColumn: `${link.col + offset} / span ${link.span}` }}
-          >
-            {link.label}
-          </a>
-        ))}
-
-        <a
-          href="https://github.com/Precisa-Saude/fhir-brasil"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hidden self-center items-center justify-center gap-1.5 rounded-full bg-white/15 px-4 py-2 font-margem text-sm font-medium text-white transition-colors hover:bg-white/25 md:inline-flex"
-          style={{ gridColumn: `${12 + offset} / span 2` }}
-        >
-          GitHub
-          <ExternalLink className="h-3.5 w-3.5" />
-        </a>
-
-        <button
-          onClick={() => setMobileOpen(!mobileOpen)}
-          className="rounded-md p-2 text-white md:hidden"
-          aria-label={mobileOpen ? 'Fechar menu' : 'Abrir menu'}
-        >
-          {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-        </button>
-      </div>
-
-      <div
-        className={cn(
-          'overflow-hidden border-t border-white/10 bg-ps-violet-dark/95 backdrop-blur-md transition-all duration-200 md:hidden',
-          mobileOpen ? 'max-h-64' : 'max-h-0 border-t-0',
-        )}
-      >
-        <div className="flex flex-col gap-4 px-6 py-4">
-          {NAV_LINKS.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              onClick={() => setMobileOpen(false)}
-              className="font-margem text-base font-medium text-white/70 transition-colors hover:text-white"
-            >
-              {link.label}
-            </a>
-          ))}
-          <a
-            href="https://github.com/Precisa-Saude/fhir-brasil"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 font-margem text-sm font-medium text-white/70"
-          >
-            GitHub
-            <ExternalLink className="h-3.5 w-3.5" />
-          </a>
-        </div>
-      </div>
-    </nav>
+    <Header
+      actions={actions}
+      className="border-b border-white/10 bg-ps-violet-dark/95 backdrop-blur-md"
+      containerClassName="mx-auto px-4 md:px-0"
+      contentClassName="grid h-16 items-center gap-4"
+      iconClassName="text-white"
+      isMobileMenuOpen={open}
+      logo={logo}
+      mobileNavItems={mobileNavItems}
+      navItems={navItems}
+      onToggleMobileMenu={setOpen}
+    />
   );
 }

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@precisa-saude/ui/dist/**/*.{js,mjs}',
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Resumo

Migra o site do `fhir-brasil` para consumir os componentes compartilhados publicados no `@precisa-saude/ui` (release 1.4.0+):

- `Nav.tsx` agora usa `<Header>` (grid mode) em vez de reimplementar o layout manualmente. Preserva o visual atual (violet-dark + white actions) via `className`/`style`. Drawer mobile passa a usar o Base UI Dialog slide-out padrão do Header.
- `Footer.tsx` agora usa `<OpenFooter>`, reduzindo o arquivo a `brand`/`socials`/`disclaimer` (o markup/estilo vêm do pacote compartilhado).

O conteúdo (links de navegação, logo, textos, disclaimer) permanece igual — apenas a estrutura foi terceirizada para o pacote compartilhado.

## Test plan

- [x] `pnpm build` no site passa (inclui `tsc` + Vite build)
- [ ] Verificar visual no dev server (desktop + mobile drawer)
- [ ] CI verde

Refs: tooling#20 (Header/OpenFooter para OSS sites)