### PR TITLE
ci: bump pnpm/action-setup para v5 (Node.js 24)

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/_deploy-site.yml
+++ b/.github/workflows/_deploy-site.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/checkout@v6
         if: steps.changes.outputs.site_changed == 'true'
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         if: steps.changes.outputs.site_changed == 'true'
       - uses: actions/setup-node@v6
         if: steps.changes.outputs.site_changed == 'true'

--- a/.github/workflows/_publish-ig.yml
+++ b/.github/workflows/_publish-ig.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{ inputs.release_sha }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         if: steps.has-key.outputs.configured == 'true'
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ref: ${{ inputs.release_sha }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -91,7 +91,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         if: "!inputs.require_package_changes || steps.changes.outputs.packages_changed == 'true'"
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Resumo

- Atualiza `pnpm/action-setup` de `@v4` para `@v5` em todos os workflows.
- v5.0.0 apenas troca o runtime do action de Node.js 20 para Node.js 24.
- Sem mudança no pnpm bundled (continua compatível com `packageManager: pnpm@9.x`).

## Por quê

GitHub deprecou Node.js 20 nos runners; `pnpm/action-setup@v4` ainda roda em Node 20 e dispara warning em todo job. A partir de 2026-06-02 o runner força Node 24 por padrão; em 2026-09-16 Node 20 é removido. Resolvendo agora antes de quebrar.

Notas:
- Ficamos em v5 (não v6) porque v6 também troca o pnpm bundled para v11, o que poderia conflitar com nosso `packageManager: pnpm@9.15.9`.

## Test plan

- [ ] CI passa sem o warning de Node.js 20 deprecation.
- [ ] Todos os jobs que dependem de pnpm rodam normalmente.