### PR TITLE
fix(core): alinhar VATVolume aos limiares do GE Lunar CoreScan

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -1881,21 +1881,9 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   VATVolume: {
-    default: { max: 1500, min: 0, optimalMax: 800, optimalMin: 0, unit: 'cm³' },
+    default: { max: 852, min: 0, optimalMax: 600, optimalMin: 0, unit: 'cm³' },
     direction: 'lower-better',
-    source: 'ofenheimer-vat-2020',
-    variants: [
-      {
-        ageMin: 18,
-        range: { max: 1500, min: 0, optimalMax: 1000, optimalMin: 0, unit: 'cm³' },
-        sex: 'M',
-      },
-      {
-        ageMin: 18,
-        range: { max: 1000, min: 0, optimalMax: 500, optimalMin: 0, unit: 'cm³' },
-        sex: 'F',
-      },
-    ],
+    source: 'ge-corescan',
   },
 
   BMD_Total: {

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -81,6 +81,12 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     url: 'https://pubmed.ncbi.nlm.nih.gov/10966886/',
   },
 
+  'ge-corescan': {
+    abnt: 'GE HEALTHCARE. enCORE Software CoreScan: Visceral Adipose Tissue (VAT) assessment. Madison: GE Medical Systems Lunar, [s. d.]. (Documentação do fabricante do DEXA Lunar Prodigy; classificação Healthy 0–52 in³, Increased Risk 52,15–112,10 in³, At Risk 112,10+ in³, equivalente a 0–852 cm³, 854–1.837 cm³, 1.837+ cm³.)',
+    key: 'ge-corescan',
+    url: 'https://www.gehealthcare.com/products/bone-and-metabolic-health/encore',
+  },
+
   'geloneze-brams-2009': {
     abnt: 'GELONEZE, B. et al. HOMA1-IR and HOMA2-IR indexes in identifying insulin resistance and metabolic syndrome — Brazilian Metabolic Syndrome Study (BRAMS). Arquivos Brasileiros de Endocrinologia & Metabologia, v. 53, n. 2, p. 281-287, 2009.',
     doi: '10.1590/S0004-27302009000200020',


### PR DESCRIPTION
## Summary

- A faixa de referência `VATVolume` em `packages/core/src/reference-ranges.ts` estava baseada em **Ofenheimer 2020** (`0–1.500 cm³`, `optimalMax 800`), que descreve uma distribuição populacional — não uma classificação de risco clínica.
- Os laudos DEXA recebidos pelos usuários são **GE Lunar Prodigy** (CoreScan), com classificação própria do fabricante. Migrada a fonte de verdade para essa:
  - Saudável: 0–52 in³ (~0–852 cm³)
  - Risco aumentado: 52,15–112,10 in³ (~854–1.837 cm³)
  - Risco alto: 112,10+ in³ (~1.837+ cm³)
- Mapeado em duas faixas (verde/vermelho) usando `max=852 cm³` como teto da faixa saudável; `optimalMax=600 cm³`.
- Removidas as variantes por sexo — o CoreScan da GE não diferencia.
- Nova fonte `ge-corescan` adicionada em `sources.ts`. `ofenheimer-vat-2020` permanece em uso por `VATMass` e foi mantida no registry.

PR irmã ajustando o texto Resumo no `platform`: https://github.com/Precisa-Saude/platform/pull/new/fix/vat-visceral-thresholds

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@precisa-saude/fhir` (397 testes passam localmente)
- [x] `pnpm turbo run build --filter=@precisa-saude/fhir` (build OK)
- [ ] Após release do `@precisa-saude/fhir`, bump no `platform` e validar visualmente o gauge `Volume de Gordura Visceral` (banda verde até ~852, vermelha acima).