### PR TITLE
fix(core): adicionar warningMax em VATVolume para 3 faixas no gauge

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -1881,7 +1881,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   VATVolume: {
-    default: { max: 852, min: 0, optimalMax: 600, optimalMin: 0, unit: 'cm³' },
+    default: {
+      max: 852,
+      min: 0,
+      optimalMax: 600,
+      optimalMin: 0,
+      unit: 'cm³',
+      warningMax: 1837,
+    },
     direction: 'lower-better',
     source: 'ge-corescan',
   },


### PR DESCRIPTION
## Summary

A faixa de referência do GE Lunar CoreScan tem 3 zonas:
- Saudável: 0–852 cm³ (0–52 in³)
- Aumentado: 852–1.837 cm³ (52–112 in³)
- Alto: 1.837+ cm³ (112+ in³)

Antes do fix #34 ficava com `max=852` e nada além, então o `BiomarkerGauge` no `platform` mostrava só verde/vermelho, com tudo acima de 852 cm³ vermelho — inconsistente com o texto do Resumo que descreve a zona intermediária ("risco aumentado").

## Mudança

Adicionado `warningMax: 1837` ao `VATVolume.default`. O componente `BiomarkerGauge` no `platform` já suporta a zona âmbar entre `max` e `warningMax` automaticamente (precedente: `CAC_Percentile` usa o mesmo padrão).

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@precisa-saude/fhir` (397 testes passam)
- [ ] Após release e bump no `platform`, conferir visualmente que o gauge mostra 3 faixas (verde até 852, âmbar de 852 a 1.837, vermelha acima).