### PR TITLE
ci: pin actions e tripwire publish-watch (postmortem TanStack)

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -73,9 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -87,9 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -102,9 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/_deploy-site.yml
+++ b/.github/workflows/_deploy-site.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Check for site changes
         id: changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             if (context.eventName === 'workflow_dispatch') {
@@ -60,11 +60,11 @@ jobs:
             const siteChanged = filenames.some(f => f.startsWith('site/'));
             core.setOutput('site_changed', siteChanged ? 'true' : 'false');
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.changes.outputs.site_changed == 'true'
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         if: steps.changes.outputs.site_changed == 'true'
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.changes.outputs.site_changed == 'true'
         with:
           node-version: 22
@@ -77,7 +77,7 @@ jobs:
       - name: Build site
         if: steps.changes.outputs.site_changed == 'true'
         run: pnpm turbo run build --filter=${{ inputs.site_filter }}...
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: steps.changes.outputs.site_changed == 'true'
         with:
           name: site-dist
@@ -90,15 +90,15 @@ jobs:
     if: always() && !cancelled() && needs.build-site.outputs.site_changed == 'true' && needs.build-site.result == 'success' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: site-dist
           path: ${{ inputs.site_path }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -161,7 +161,7 @@ jobs:
             }' > /tmp/slack-payload.json
 
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/_publish-ig.yml
+++ b/.github/workflows/_publish-ig.yml
@@ -30,15 +30,15 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.has-key.outputs.configured == 'true'
         with:
           ref: ${{ inputs.release_sha }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         if: steps.has-key.outputs.configured == 'true'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.has-key.outputs.configured == 'true'
         with:
           node-version: 22

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -33,13 +33,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.release_sha }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check for package changes across pushed commits
         id: changes
         if: inputs.require_package_changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           # Compares `before..after` from the push payload. Paginates explicitly
           # because `compareCommits` truncates at 300 files per page — a large
@@ -80,21 +80,21 @@ jobs:
       - name: Generate GitHub App token
         id: app-token
         if: "!inputs.require_package_changes || steps.changes.outputs.packages_changed == 'true'"
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: "!inputs.require_package_changes || steps.changes.outputs.packages_changed == 'true'"
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         if: "!inputs.require_package_changes || steps.changes.outputs.packages_changed == 'true'"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: "!inputs.require_package_changes || steps.changes.outputs.packages_changed == 'true'"
         with:
           node-version: 22

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
       - name: Open issue on drift
         if: steps.doctor.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -27,13 +27,13 @@ jobs:
     name: Publish tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/publish-watch.yml
+++ b/.github/workflows/publish-watch.yml
@@ -1,0 +1,139 @@
+name: Publish watch
+
+# Tripwire — confirma que toda versão publicada no npm tem uma tag git
+# correspondente neste repo. Roda em cron de 15 em 15 min e ad-hoc via
+# workflow_dispatch.
+#
+# Para cada pacote público em packages/**, compara a versão `latest` no
+# registry com as tags `v<versão>` deste repo. Se a versão do npm não
+# existe como tag local, abre uma issue de prioridade alta — sinal de
+# publicação fora do fluxo (workflow comprometido, token vazado,
+# republicação manual).
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: publish-watch
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Verify npm versions match git tags
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Compare npm latest vs git tags
+        id: check
+        run: |
+          set -e
+          mismatches=""
+          # Lista pacotes públicos do workspace. `pnpm m ls --json` retorna
+          # name, version, path, private para cada workspace package.
+          pnpm m ls --json --depth -1 > /tmp/ws.json
+          mapfile -t entries < <(
+            node -e '
+              const ws = JSON.parse(require("fs").readFileSync("/tmp/ws.json","utf8"));
+              for (const p of ws) {
+                if (p.private || !p.name) continue;
+                if (!p.name.startsWith("@")) continue;
+                process.stdout.write(p.name + "\n");
+              }
+            '
+          )
+          for name in "${entries[@]}"; do
+            [ -z "$name" ] && continue
+            npm_version=$(npm view "$name" version 2>/dev/null || true)
+            if [ -z "$npm_version" ]; then
+              echo "$name: not on npm yet, skipping"
+              continue
+            fi
+            # Tag convention: semantic-release emits `<name>@<ver>` for
+            # monorepos and `v<ver>` for single-package repos. Accept both.
+            if git rev-parse -q --verify "refs/tags/${name}@${npm_version}" >/dev/null 2>&1 \
+               || git rev-parse -q --verify "refs/tags/v${npm_version}" >/dev/null 2>&1; then
+              echo "$name@$npm_version: tag found"
+            else
+              echo "::warning::$name@$npm_version published on npm but no matching git tag in this repo"
+              mismatches="${mismatches}- \`${name}@${npm_version}\` (no matching tag)\n"
+            fi
+          done
+          if [ -n "$mismatches" ]; then
+            {
+              echo "mismatches<<EOF"
+              printf "%b" "$mismatches"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue on mismatch
+        if: steps.check.outputs.mismatches != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const mismatches = `${{ steps.check.outputs.mismatches }}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Não duplica: se já existe uma issue aberta com este título,
+            // só comenta nela com a evidência da rodada atual.
+            const title = 'publish-watch: versão npm sem tag git correspondente';
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,publish-watch',
+              per_page: 50,
+            });
+            const open = existing.find(i => i.title === title);
+
+            const body = [
+              '`publish-watch` detectou uma ou mais versões publicadas no npm que',
+              'não têm tag git correspondente neste repo. Isto pode indicar:',
+              '',
+              '- publicação fora do fluxo (workflow comprometido, token vazado, republicação manual)',
+              '- semantic-release configurado com convenção de tag diferente (revisar)',
+              '- pacote movido para outro repo sem atualizar o filtro do watch',
+              '',
+              '**Versões sem tag local:**',
+              '',
+              mismatches,
+              '',
+              `Log da rodada: ${runUrl}`,
+              '',
+              '## Próximos passos',
+              '',
+              '1. Conferir `npm view <pacote> time` para o horário da publicação.',
+              '2. Cruzar com runs de `_publish.yml` / `publish-tag.yml` recentes.',
+              '3. Se não há run correspondente, tratar como incidente: rotação de NPM_TOKEN, revisão de logs de auditoria do npm, deprecate da versão suspeita.',
+            ].join('\n');
+
+            if (open) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['security', 'publish-watch'],
+              });
+            }

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,11 +30,11 @@ jobs:
       should_run: ${{ steps.check.outputs.should_run }}
       review_round: ${{ steps.check.outputs.review_round }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Decide whether to run
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -95,7 +95,7 @@ jobs:
       GITHUB_MODELS_MODEL: openai/gpt-4o-mini
       MAX_DIFF_SIZE: '150000'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -390,7 +390,7 @@ jobs:
           SCRIPT
 
       - name: Post review
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
   "schedule": ["before 6am on saturday"],
   "timezone": "America/Sao_Paulo",
   "labels": ["dependencies"],
@@ -20,6 +25,11 @@
     {
       "matchPackagePatterns": ["^@precisa-saude/"],
       "groupName": "precisa-saude packages"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "pinDigests": true
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Resumo

Endurecimento dos workflows após o [postmortem do TanStack](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) (2026-05-11). A entrada do ataque (`pull_request_target` + cache poisoning + extração de OIDC) não existe aqui, mas duas lições independentes do postmortem se aplicam:

1. **Refs flutuantes de actions** — todas as `@vX` agora apontam para SHA imutável + comentário de versão (formato suportado pelo Renovate para bumps).
2. **Sem tripwire em registry** — TanStack soube do incidente por um terceiro 30 min depois. Novo `publish-watch.yml` roda cron de 15 min, compara `npm view <pkg> version` contra as tags git locais e abre issue `security`/`publish-watch` quando há divergência (publicação fora do fluxo).

## Mudanças

- **SHA pin** em `_checks.yml`, `_publish.yml`, `_release.yml`, `_publish-ig.yml`, `_deploy-site.yml`, `publish-tag.yml`, `review.yml`, `doctor.yml`
- **`publish-watch.yml`** (novo) — cron `*/15 * * * *` + `workflow_dispatch`; valida que cada `<name>@<latestNpm>` existe como tag local
- **`renovate.json`** — `helpers:pinGitHubActionDigests` + `pinDigests: true` no grupo `github-actions`

Origem dos templates: PR https://github.com/Precisa-Saude/tooling/pull/34. Após esse PR fazer release do `@precisa-saude/cli`, `precisa sync` torna esta PR um no-op.

## Próximos passos pós-merge

- Conferir que Settings → Environments → `npm-publish` tem revisor requerido (já presente no `_publish.yml`; gate só funciona se houver revisor).