### PR TITLE
ci: passar mismatches via env no publish-watch

### DIFF
--- a/.github/workflows/publish-watch.yml
+++ b/.github/workflows/publish-watch.yml
@@ -83,9 +83,11 @@ jobs:
       - name: Open issue on mismatch
         if: steps.check.outputs.mismatches != ''
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          MISMATCHES: ${{ steps.check.outputs.mismatches }}
         with:
           script: |
-            const mismatches = `${{ steps.check.outputs.mismatches }}`;
+            const mismatches = process.env.MISMATCHES;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             // Não duplica: se já existe uma issue aberta com este título,


### PR DESCRIPTION
## Resumo

- O step `Open issue on mismatch` do workflow `publish-watch` falhou com `SyntaxError: Invalid or unexpected token` em todas as rodadas após o tripwire detectar um mismatch real ([run 25871450921](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/25871450921), [25876469334](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/25876469334), [25878903480](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/25878903480), [25881274652](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/25881274652)).
- Causa: a saída do step (`steps.check.outputs.mismatches`) envolve cada pacote em backticks. A interpolação `${{ ... }}` é textual e injeta esses backticks no template literal JS do `actions/github-script`, terminando o literal antes do parser do Node.
- Correção: passar o valor via `env: MISMATCHES` e ler com `process.env.MISMATCHES` (padrão recomendado pelo próprio github-script para conteúdo com caracteres especiais).

A detecção continua correta — após o merge, a próxima rodada deve abrir a issue com o pacote `@precisa-saude/fhir-rnds@0.1.0` (que está no npm sem tag git correspondente; triagem separada).

## Test plan

- [ ] Após merge, disparar o workflow via `workflow_dispatch`.
- [ ] Confirmar que o step `Open issue on mismatch` passa.
- [ ] Confirmar que uma issue com labels `security,publish-watch` foi aberta listando o pacote com backticks preservados.