### PR TITLE
feat(core): faixas de referência para DHL/LDH e β-hidroxibutirato

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -323,6 +323,16 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
+  // β-Hidroxibutirato (BHB) sérico — corpos cetônicos. Faixa derivada de
+  // amostra populacional não-jejum (German National Cohort, n=304, 20–69 a)
+  // como percentis 2,5–97,5: 0,02–0,28 mmol/L. Em jejum prolongado ou
+  // cetose nutricional, valores acima de 0,5 mmol/L são esperados; o limite
+  // superior aqui reflete estado pós-prandial habitual, não jejum.
+  BetaHydroxybutyrate: {
+    default: { max: 0.28, min: 0.02, optimalMax: 0.28, optimalMin: 0.02, unit: 'mmol/L' },
+    source: 'klee-bhb-2020',
+  },
+
   BilirubinDirect: {
     default: { max: 0.3, min: 0, optimalMax: 0.2, optimalMin: 0, unit: 'mg/dL' },
     source: 'tietz-7ed-2015',
@@ -953,6 +963,30 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   Lactate: {
     default: { max: 2.2, min: 0.5, optimalMax: 1.8, optimalMin: 0.7, unit: 'mmol/L' },
     source: 'tietz-7ed-2015',
+  },
+
+  // DHL/LDH — método IFCC a 37 °C (padrão atual na maioria dos laboratórios
+  // brasileiros). Limites superiores de referência (97,5° percentil) obtidos
+  // por Schumann & Klauke (2002) em indivíduos ≥17 anos: 247 U/L (mulheres)
+  // e 248 U/L (homens). O IFCC publica apenas o limite superior; o limite
+  // inferior é fixado em 0 pois DHL baixa não tem significado clínico.
+  // Não comparar com método Wróblewski-LaDue (faixas mais antigas, ~240–480).
+  LDH: {
+    default: { max: 248, min: 0, optimalMax: 248, optimalMin: 0, unit: 'U/L' },
+    direction: 'lower-better',
+    source: 'schumann-ifcc-ldh-2002',
+    variants: [
+      {
+        ageMin: 17,
+        range: { max: 248, min: 0, optimalMax: 248, optimalMin: 0, unit: 'U/L' },
+        sex: 'M',
+      },
+      {
+        ageMin: 17,
+        range: { max: 247, min: 0, optimalMax: 247, optimalMin: 0, unit: 'U/L' },
+        sex: 'F',
+      },
+    ],
   },
 
   LDL: {

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -147,6 +147,13 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     url: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC5018018/',
   },
 
+  'klee-bhb-2020': {
+    abnt: 'KLEE, P. et al. Test validation, method comparison and reference range for the measurement of β-hydroxybutyrate in peripheral blood samples. Practical Laboratory Medicine, v. 18, e00146, 2020.',
+    doi: '10.1016/j.plabm.2019.e00146',
+    key: 'klee-bhb-2020',
+    url: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6999181/',
+  },
+
   'maisel-bnp-2002': {
     abnt: 'MAISEL, A. S. et al. Rapid measurement of B-type natriuretic peptide in the emergency diagnosis of heart failure. New England Journal of Medicine, v. 347, n. 3, p. 161-167, 2002.',
     doi: '10.1056/NEJMoa020233',
@@ -273,7 +280,6 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     key: 'sbem-vitamind-2014',
     url: 'https://pubmed.ncbi.nlm.nih.gov/25166032/',
   },
-
   // ---------------------------------------------------------------------------
   // Sociedade Brasileira de Patologia Clínica / Medicina Laboratorial
   // ---------------------------------------------------------------------------
@@ -285,6 +291,14 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     key: 'sbpc-ml-2021',
     url: 'https://bibliotecasbpc.org.br/index.php?P=4&C=0.2.443',
   },
+
+  'schumann-ifcc-ldh-2002': {
+    abnt: 'SCHUMANN, G.; KLAUKE, R. New IFCC reference procedures for the determination of catalytic activity concentrations of five enzymes in serum: preliminary upper reference limits obtained in hospitalized subjects. Clinica Chimica Acta, v. 327, n. 1-2, p. 69-79, 2003.',
+    doi: '10.1016/S0009-8981(02)00341-8',
+    key: 'schumann-ifcc-ldh-2002',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/12482620/',
+  },
+
   'schwedhelm-sdma-2011': {
     abnt: 'SCHWEDHELM, E. et al. Plasma symmetric dimethylarginine reference limits from the Framingham Offspring Cohort. Clinical Chemistry and Laboratory Medicine, v. 49, n. 11, p. 1907-1910, 2011.',
     doi: '10.1515/CCLM.2011.679',
@@ -324,7 +338,6 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     isbn: '978-1-4557-4165-6',
     key: 'tietz-7ed-2015',
   },
-
   // ---------------------------------------------------------------------------
   // Fontes internacionais — Coagulação
   // ---------------------------------------------------------------------------
@@ -344,6 +357,7 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     key: 'who-iron-2020',
     url: 'https://www.who.int/publications/i/item/9789240000124',
   },
+
   'who-obesity-2000': {
     abnt: 'WORLD HEALTH ORGANIZATION. Obesity: preventing and managing the global epidemic. WHO Technical Report Series, n. 894. Geneva: WHO, 2000.',
     isbn: '92-4-120894-5',


### PR DESCRIPTION
## Resumo

Adiciona faixas de referência para dois biomarcadores que estavam definidos em `BIOMARKER_DEFINITIONS` mas faltavam em `defaultReferenceRanges`. No precisa-saude/platform isso fazia consumidores renderizarem nada na área do gráfico para DHL (`figado`) e β-hidroxibutirato (`pancreas`).

### LDH / Desidrogenase Lática
- **Default**: max 248 U/L, min 0
- **Variants**: 248 U/L (M), 247 U/L (F), ambos ≥17 anos
- **Método**: IFCC a 37 °C (padrão laboratorial atual)
- **Fonte**: Schumann & Klauke, *Clin Chim Acta*, 2002 (PMID 12482620). Limites são o 97,5° percentil. O IFCC publica só o limite superior; o inferior fica em 0 pois DHL baixa não tem significado clínico.
- ⚠️ Não comparar com Wróblewski-LaDue (faixas mais antigas, ~240–480 U/L).

### Beta-hidroxibutirato
- **Default**: 0,02–0,28 mmol/L
- **Fonte**: Klee et al., *Pract Lab Med*, 2020 (PMC6999181). Cohort não-jejum (German National Cohort, n=304).
- ⚠️ Comentário no código alerta que valores >0,5 mmol/L em jejum prolongado ou cetose nutricional são esperados — o limite superior reflete estado pós-prandial habitual.

### Fontes registradas
- `schumann-ifcc-ldh-2002` — DOI 10.1016/S0009-8981(02)00341-8
- `klee-bhb-2020` — DOI 10.1016/j.plabm.2019.e00146

Cada valor foi confirmado por leitura direta do abstract/full-text via WebFetch — sem inferência por nome ou domínio, conforme regra de integridade de dados.

## Test plan

- [x] `pnpm test` — 397 testes passando, incluindo `sources.test.ts` (cobertura sobe de 99,5% para um valor maior)
- [x] `pnpm build` — typecheck + bundle limpos
- [ ] Após merge + release, bumpar `@precisa-saude/fhir` em `precisa-saude/platform`