### PR TITLE
fix(core): corrigir faixas clínicas após revisão Gemini 3.1 Pro

### DIFF
--- a/packages/core/src/__tests__/biomarkers.test.ts
+++ b/packages/core/src/__tests__/biomarkers.test.ts
@@ -221,6 +221,22 @@ describe('getDefinitionByCode', () => {
   it('should return undefined for invalid code', () => {
     expect(getDefinitionByCode('InvalidCode')).toBeUndefined();
   });
+
+  it('Urea usa LOINC 3091-6 (Urea, não BUN/3094-0)', () => {
+    // Revisão clínica (issue #41): LOINC 3094-0 é "Urea nitrogen" (BUN).
+    // A entrada brasileira deve usar 3091-6 (Urea em mg/dL) para alinhar
+    // com a faixa de referência de Ureia (15-50 mg/dL).
+    const def = getDefinitionByCode('Urea');
+    expect(def?.loinc).toBe('3091-6');
+    expect(def?.unit).toBe('mg/dL');
+    expect(def?.names.en).not.toContain('BUN');
+  });
+
+  it('Lipoprotein_a usa LOINC 43583-4 (nmol/L, não 10835-7 mg/dL)', () => {
+    const def = getDefinitionByCode('Lipoprotein_a');
+    expect(def?.loinc).toBe('43583-4');
+    expect(def?.unit).toBe('nmol/L');
+  });
 });
 
 describe('getDefinitionByLoinc', () => {

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -91,6 +91,24 @@ describe('getReferenceRange', () => {
       const range = getReferenceRange('HDL', context);
       expect(range).toEqual(biomarkerRangeDefinitions.HDL.default);
     });
+
+    it('HDL has no false upper bound at 60 mg/dL (SBC 2025)', () => {
+      // Revisão clínica (issue fhir-brasil#41): HDL alto é cardioprotetor;
+      // não deve marcar valores > 60 mg/dL como anormais.
+      const maleRange = getReferenceRange('HDL', { age: 30, biologicalSex: 'M' });
+      const femaleRange = getReferenceRange('HDL', { age: 30, biologicalSex: 'F' });
+      expect(maleRange?.max ?? 0).toBeGreaterThanOrEqual(100);
+      expect(femaleRange?.max ?? 0).toBeGreaterThanOrEqual(100);
+    });
+
+    it('Progesterone female reproductive-age variant covers luteal phase', () => {
+      // Revisão clínica (issue fhir-brasil#41): faixa feminina ampliada
+      // para abranger fase lútea (até ~20 ng/mL).
+      const range = getReferenceRange('Progesterone', { age: 30, biologicalSex: 'F' });
+      expect(range?.max ?? 0).toBeGreaterThanOrEqual(15);
+      const maleRange = getReferenceRange('Progesterone', { age: 30, biologicalSex: 'M' });
+      expect(maleRange?.max).toBeLessThan(2);
+    });
   });
 
   describe('age-specific variants', () => {

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -138,9 +138,13 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
     unit: 'nmol/L',
   },
   {
+    // LOINC 43583-4 = "Lipoprotein a [Moles/volume] in Serum or Plasma" (nmol/L).
+    // Anteriormente 10835-7 ("Lipoprotein a [Mass/volume]", mg/dL),
+    // incompatível com a unidade nmol/L declarada. SBC 2025 recomenda
+    // ensaio independente de isoforma reportado em nmol/L.
     category: 'coracao',
     code: 'Lipoprotein_a',
-    loinc: '10835-7',
+    loinc: '43583-4',
     names: {
       en: ['Lipoprotein (a)', 'Lp(a)'],
       pt: ['Lipoproteína (a)', 'Lp(a)'],
@@ -1474,11 +1478,16 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
     unit: 'mg/L',
   },
   {
+    // LOINC 3091-6 = "Urea [Mass/volume] in Serum or Plasma" (mg/dL).
+    // Anteriormente 3094-0 ("Urea nitrogen", BUN), inconsistente com a faixa
+    // de referência brasileira (15-50 mg/dL) e com os nomes pt-BR (Ureia).
+    // Aliases 'BUN' e 'Blood Urea Nitrogen' removidos para evitar matching
+    // de relatórios de BUN contra faixas de Ureia (BUN ≈ Ureia / 2,14).
     category: 'rins',
     code: 'Urea',
-    loinc: '3094-0',
+    loinc: '3091-6',
     names: {
-      en: ['Blood Urea Nitrogen', 'BUN', 'Urea'],
+      en: ['Urea'],
       pt: ['Ureia', 'Uréia'],
     },
     unit: 'mg/dL',

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -194,8 +194,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
+  // AMH — fortemente dependente de idade e sexo. As variantes femininas por
+  // faixa etária são a referência clínica; o `default` foi ajustado para
+  // refletir uma faixa adulta conservadora (~18-40 anos, mulheres em idade
+  // reprodutiva geral). optimalMax anterior (6.9 ng/mL) sobrepunha-se a
+  // valores sugestivos de SOP ou risco de OHSS; clinicamente, valores acima
+  // de ~4 ng/mL já merecem investigação.
   AMH: {
-    default: { max: 10.0, min: 1.0, optimalMax: 6.9, optimalMin: 2.0, unit: 'ng/mL' },
+    default: { max: 6.0, min: 1.0, optimalMax: 4.0, optimalMin: 1.5, unit: 'ng/mL' },
     source: 'tietz-7ed-2015',
     variants: [
       {
@@ -354,6 +360,12 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'sbc-ic-2018',
   },
 
+  // Razão BUN/Creatinina — faixa 10-20 aplica-se ao Nitrogênio Ureico (BUN).
+  // Laboratórios brasileiros que reportam Ureia (e não BUN) usam razão
+  // Ureia/Creatinina, cuja faixa normal é aproximadamente 21-43
+  // (Ureia ≈ BUN × 2,14). O biomarcador atualmente assume a convenção BUN;
+  // consumidores que dosem Ureia devem converter ou reportar como razão
+  // distinta. Ver issue #41 para alinhamento de nomenclatura/LOINC.
   BUN_Creatinine_Ratio: {
     default: { max: 20, min: 10, optimalMax: 18, optimalMin: 12, unit: '' },
     source: 'tietz-7ed-2015',
@@ -437,8 +449,11 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
+  // Colesterol total — SBC 2017/2025: valor desejável < 190 mg/dL para adultos,
+  // com ou sem jejum. Limite anterior (200 mg/dL) refletia a diretriz ATP III
+  // (NCEP, 2002), superada pelas atualizações brasileiras.
   Cholesterol: {
-    default: { max: 200, min: 0, optimalMax: 180, optimalMin: 0, unit: 'mg/dL' },
+    default: { max: 190, min: 0, optimalMax: 170, optimalMin: 0, unit: 'mg/dL' },
     source: 'sbc-lipids-2025',
   },
 
@@ -829,19 +844,25 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
+  // HDL — SBC 2017/2025: desejável > 40 mg/dL (♂) e > 50 mg/dL (♀).
+  // A diretriz NÃO define teto de normalidade — HDL alto é cardioprotetor.
+  // Limites superiores anteriormente fixados em 60 mg/dL geravam falsos
+  // alertas. Mantém-se `max` apenas como limite técnico do gauge (100 mg/dL),
+  // não como ponto de corte clínico; consumidores devem tratar `direction:
+  // higher-better` como sinal autoritativo.
   HDL: {
-    default: { max: 60, min: 40, optimalMax: 60, optimalMin: 50, unit: 'mg/dL' },
+    default: { max: 100, min: 40, optimalMax: 100, optimalMin: 50, unit: 'mg/dL' },
     direction: 'higher-better',
     source: 'sbc-lipids-2025',
     variants: [
       {
         ageMin: 18,
-        range: { max: 60, min: 40, optimalMax: 60, optimalMin: 45, unit: 'mg/dL' },
+        range: { max: 100, min: 40, optimalMax: 100, optimalMin: 45, unit: 'mg/dL' },
         sex: 'M',
       },
       {
         ageMin: 18,
-        range: { max: 60, min: 50, optimalMax: 60, optimalMin: 55, unit: 'mg/dL' },
+        range: { max: 100, min: 50, optimalMax: 100, optimalMin: 55, unit: 'mg/dL' },
         sex: 'F',
       },
     ],
@@ -1078,8 +1099,14 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'simopoulos-omega-ratio-2002',
   },
 
+  // Lp(a) — SBC 2025 (seção 3.1.1.2.7): níveis ≥ 50 mg/dL ou ≥ 125 nmol/L são
+  // considerados aumentados, com indicação de rastreamento em cascata familiar.
+  // A diretriz recomenda ensaio independente de isoforma medido em nmol/L; a
+  // unidade nmol/L é mantida aqui por refletir o padrão laboratorial atual.
+  // Limites anteriores (max=75) refletiam pontos de corte expressos em mg/dL,
+  // gerando incompatibilidade com a unidade nmol/L declarada.
   Lipoprotein_a: {
-    default: { max: 75, min: 0, optimalMax: 30, optimalMin: 0, unit: 'nmol/L' },
+    default: { max: 125, min: 0, optimalMax: 75, optimalMin: 0, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'sbc-lipids-2025',
   },
@@ -1193,8 +1220,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'harris-omega3-2004',
   },
 
+  // Ômega-3 Total (% de ácidos graxos eritrocitários) — Harris & von Schacky
+  // (2004) propõem ≥ 8% como zona ótima de proteção cardiovascular; valores
+  // entre 4% e 8% representam risco intermediário, < 4% risco alto.
+  // optimalMin anterior (5.5%) ficava em zona intermediária, contradizendo
+  // a literatura e o próprio texto educacional do `platform`.
   Omega3_Total: {
-    default: { max: 12.0, min: 3.0, optimalMax: 10.0, optimalMin: 5.5, unit: '%' },
+    default: { max: 12.0, min: 3.0, optimalMax: 10.0, optimalMin: 8.0, unit: '%' },
     source: 'harris-omega3-2004',
   },
 
@@ -1239,9 +1271,37 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
+  // Progesterona — varia drasticamente com a fase do ciclo menstrual.
+  // O schema atual não modela fase do ciclo, então adotamos faixas amplas
+  // por sexo: o `default` cobre homens/fase folicular/pós-menopausa; a
+  // variante feminina expande até a faixa esperada de fase lútea
+  // (~3-20 ng/mL). Interpretação correta exige correlação com a fase do
+  // ciclo, indisponível neste contexto.
   Progesterone: {
     default: { max: 0.9, min: 0.1, optimalMax: 0.7, optimalMin: 0.2, unit: 'ng/mL' },
     source: 'tietz-7ed-2015',
+    variants: [
+      {
+        ageMin: 18,
+        range: { max: 0.9, min: 0.1, optimalMax: 0.6, optimalMin: 0.2, unit: 'ng/mL' },
+        sex: 'M',
+      },
+      // Mulheres em idade reprodutiva: faixa que abarca fases folicular
+      // (0.1-0.9 ng/mL) e lútea (3-20 ng/mL). Sem contexto de fase do ciclo,
+      // valores intermediários (1-3 ng/mL) ficam em zona ambígua.
+      {
+        ageMax: 50,
+        ageMin: 18,
+        range: { max: 20.0, min: 0.1, optimalMax: 15.0, optimalMin: 0.2, unit: 'ng/mL' },
+        sex: 'F',
+      },
+      // Pós-menopausa: valores tipicamente < 0.5 ng/mL (sem ovulação).
+      {
+        ageMin: 51,
+        range: { max: 0.5, min: 0, optimalMax: 0.3, optimalMin: 0, unit: 'ng/mL' },
+        sex: 'F',
+      },
+    ],
   },
 
   Prolactin: {
@@ -1547,8 +1607,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     ],
   },
 
+  // Ureia — convenção brasileira (laboratórios reportam Ureia, não BUN).
+  // Faixa adulta de 15-50 mg/dL (Ureia ≈ BUN × 2,14). Limites anteriores
+  // (7-20 mg/dL) refletiam BUN/Nitrogênio Ureico, gerando falsos diagnósticos
+  // de azotemia em pacientes com Ureia normal. LOINC 3094-0 (BUN) também
+  // deve ser revisto em biomarkers.ts — ver issue #41.
   Urea: {
-    default: { max: 20, min: 7, optimalMax: 16, optimalMin: 10, unit: 'mg/dL' },
+    default: { max: 50, min: 15, optimalMax: 40, optimalMin: 20, unit: 'mg/dL' },
     source: 'tietz-7ed-2015',
   },
 


### PR DESCRIPTION
## Resumo

Fecha parcialmente #41. Corrige 8 das 23 faixas clínicas sinalizadas como `major` pela revisão Gemini 3.1 Pro Preview sobre `reference-ranges.ts`, **mais 2 LOINCs incompatíveis** identificados na mesma revisão. Após verificação manual das fontes, descobriu-se que **15 dos 23 achados originais já estavam mitigados** por variantes sexo/idade existentes — o modelo avaliava apenas o `default` sem considerar a resolução via `getReferenceRange(code, context)`.

## Verificação de fontes — descobertas críticas

Cinco PMIDs citados pelo modelo foram **fabricados ou trocados**:

| PMID Gemini | Realidade |
| --- | --- |
| 21336256 | Paper de cromatina em levedura (não Prolactin) |
| 29562364 | Existe mas não publica faixas numéricas de free T |
| 36375554 | Paper de pesticidas em abelhas (não HDL) |
| 35583875 | Review diferente (correto é Kronenberg 2022, PMID 36036785) |
| 15254075 | Paper de córtex visual (correto é Harris 2004, PMID 15208005) |

Por isso, **todas as fontes citadas neste PR vêm de chaves já registradas e verificadas em `SOURCE_REGISTRY`**: `sbc-lipids-2025`, `tietz-7ed-2015`, `harris-omega3-2004`. LOINCs verificados diretamente em loinc.org.

## Correções de faixa de referência

| Biomarcador | Mudança | Fonte verificada |
| --- | --- | --- |
| `Cholesterol` | `max: 200 → 190 mg/dL` | SBC 2017/2025 |
| `HDL` | Remove teto falso de 60 mg/dL | SBC 2025 (não define teto) |
| `Lipoprotein_a` | Alinha cortes à unidade nmol/L (≥125 = risco aumentado) | SBC 2025 (https://pmc.ncbi.nlm.nih.gov/articles/PMC12674852/) |
| `AMH` | `optimalMax: 6.9 → 4.0 ng/mL` no default | Tietz 7ed |
| `Urea` | `7-20 → 15-50 mg/dL` (convenção BR) | Tietz / SBPC/ML |
| `BUN_Creatinine_Ratio` | Comentário esclarecendo convenção BUN vs Ureia | Tietz |
| `Progesterone` | Adiciona variante feminina cobrindo fase lútea | Tietz |
| `Omega3_Total` | `optimalMin: 5.5 → 8.0%` | Harris & von Schacky 2004 (PMID 15208005) |

## Correções de LOINC

| Biomarcador | LOINC antes | LOINC agora | Motivo |
| --- | --- | --- | --- |
| `Urea` | 3094-0 (BUN, mg/dL) | 3091-6 (Urea, mg/dL) | Brasil reporta Ureia, não BUN; alinha com faixa 15-50 mg/dL. Verificado em https://loinc.org/3091-6/ |
| `Lipoprotein_a` | 10835-7 (Lp(a) mass, mg/dL) | 43583-4 (Lp(a) molar, nmol/L) | Unidade do biomarcador é nmol/L. Verificado em https://loinc.org/43583-4/ |

Aliases `'BUN'` e `'Blood Urea Nitrogen'` removidos de `Urea.names.en` para evitar matching de relatórios de BUN contra faixas de Ureia (BUN ≈ Ureia / 2,14 — coincidência numérica na faixa normal mascararia o erro).

`Omega3_Total` LOINC (35178-3, soro) **não foi alterado** — o código `62255-6` (RBC) sugerido pela revisão não pôde ser verificado em loinc.org (HTTP 500); preferimos manter o código existente a citar algo não verificado (regra de AGENTS.md).

## Por que os outros 15 "majors" não foram alterados

A maioria dos achados sobre estratificação sexo/idade (Estradiol, FSH, LH, SHBG, Testosterone, TestosteroneFree, DHEAS, BodyFatPct, FatMass, FatFreeMass, LeanMass, TotalMass, Ferritin, Prolactin) já estava resolvida no código atual — as variantes existem e são acionadas via `getReferenceRange(code, { biologicalSex, age, ... })`. O modelo enxergou apenas o `default` (caso "sem contexto") e interpretou erroneamente como falta de estratificação.

`BMD_Total` em `g/cm²` permanece como está; o biomarcador `TScore_Total` separado já cobre a interpretação clínica em desvios padrão (ISCD/OMS).

## Re-verificação Gemini sobre os 8 fixos de faixa

| Biomarcador | Antes | Depois |
| --- | --- | --- |
| AMH | major | **ok** |
| Cholesterol | major | **ok** |
| HDL | major | **ok** |
| Lipoprotein_a | major | **ok** |
| Urea | major | **ok** |
| BUN_Creatinine_Ratio | major | **ok** |
| Omega3_Total | major | **ok** |
| Progesterone | major | major* |

*Progesterone segue como `major` na re-revisão porque o modelo avalia o `default` sem contexto; a variante feminina ampliada (0.1-20 ng/mL, abrangendo fase lútea) só é acionada com `biologicalSex: 'F'`. Limitação arquitetural do schema (ausência de stratificação por fase do ciclo), não erro de dado.

## Follow-ups (issue #41 segue aberta)

- `Omega3_Total` LOINC: confirmar 62255-6 (RBC) quando loinc.org estiver acessível.
- Schema enhancement: adicionar `cyclePhase` ao `ReferenceRangeContext` para FSH/LH/Estradiol/Progesterone (breaking change na API pública).
- Conteúdo educacional em `apps/web` no repo platform: ajustes paralelos no `biomarker-explanations.ts` ainda pendentes (issue separada para abrir lá).

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@precisa-saude/fhir` → 401 testes passando (+4 novos: HDL sem teto, Progesterone lútea, Urea LOINC, Lipoprotein_a LOINC)
- [x] Re-revisão automatizada Gemini 3.1 Pro sobre os 8 fixos de faixa → 7/8 `ok`
- [x] LOINCs 3091-6 e 43583-4 verificados em loinc.org