### PR TITLE
fix(core): corrigir LOINC de Omega3_Total para RBC (99620-7)

### DIFF
--- a/packages/core/src/__tests__/biomarkers.test.ts
+++ b/packages/core/src/__tests__/biomarkers.test.ts
@@ -237,6 +237,14 @@ describe('getDefinitionByCode', () => {
     expect(def?.loinc).toBe('43583-4');
     expect(def?.unit).toBe('nmol/L');
   });
+
+  it('Omega3_Total usa LOINC 99620-7 (RBC, não 35178-3 Ser/Plas)', () => {
+    // Revisão clínica (issue #41): Índice Ômega-3 (Harris 2004) é medido
+    // em hemácias; 99620-7 alinha à matriz dos sibling EPA (75097-6) e
+    // DHA (75095-0).
+    const def = getDefinitionByCode('Omega3_Total');
+    expect(def?.loinc).toBe('99620-7');
+  });
 });
 
 describe('getDefinitionByLoinc', () => {

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -1000,9 +1000,18 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
     unit: 'nmol/L',
   },
   {
+    // LOINC 99620-7 = "Omega 3 fatty acids (w3) [Moles/volume] in RBC.lysate".
+    // Alinha à matriz das entradas irmãs Omega3_EPA (75097-6) e Omega3_DHA
+    // (75095-0), ambas em hemácias. Anteriormente 35178-3 (mesmo analito em
+    // Ser/Plas), incompatível com o uso clínico do Índice Ômega-3 (Harris &
+    // von Schacky 2004), que é definido em membranas de hemácias.
+    // Ressalva: LOINC declara moles/volume; o biomarcador armazena %.
+    // Não há LOINC vigente para "Omega 3 total em % em RBC" — o `Omega3_Index`
+    // (88998-0) cobre apenas EPA+DHA. Mantemos `unit: '%'` por consistência
+    // com EPA/DHA (75095-0/75097-6 são [Entitic substance], também não-%).
     category: 'nutrientes',
     code: 'Omega3_Total',
-    loinc: '35178-3',
+    loinc: '99620-7',
     names: {
       en: ['Omega-3 Total', 'Total Omega-3'],
       pt: ['Ômega-3 Total'],


### PR DESCRIPTION
Refs: #41

## Resumo

LOINC `35178-3` (\"Omega 3 fatty acids (w3) [Moles/volume] in Serum or Plasma\") → **`99620-7`** (\"Omega 3 fatty acids (w3) [Moles/volume] in RBC.lysate\").

Alinha à matriz das entradas irmãs `Omega3_EPA` (75097-6, \"Eicosapentaenoate in Red Blood Cells\") e `Omega3_DHA` (75095-0, \"Docosahexaenoate in Red Blood Cells\") — todas em hemácias, conforme a definição do Índice Ômega-3 (Harris & von Schacky 2004).

## LOINC fabricado pelo Gemini

O código `62255-6` sugerido pela revisão automatizada **não existe em LOINC v2.82** — confirmado via `tx.fhir.org/r4`, que retorna \"Unable to find code '62255-6' in http://loinc.org version 2.82\". Esse é o sexto código fabricado pelo modelo nesta revisão (somando-se aos 5 PMIDs já descartados no PR #42). Reforça a regra do AGENTS.md de verificar toda fonte antes de citar.

## Ressalva conhecida

O LOINC `99620-7` é declarado em **moles/volume**, enquanto o biomarcador armazena `%`. Não há LOINC vigente para \"Omega 3 total em % em RBC\" — o `Omega3_Index` (88998-0) cobre apenas o índice EPA+DHA, não o total ômega-3. Mantemos `unit: '%'` por consistência com EPA/DHA (75095-0/75097-6 são `[Entitic substance]`, também não-%).

A correção do `system` (Ser/Plas → RBC.lysate) é o ganho semântico principal; o ajuste de unidade requer um LOINC novo a ser solicitado ao Regenstrief Institute, fora do escopo deste PR.

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@precisa-saude/fhir` → 402 testes passando (+1 novo travando `Omega3_Total.loinc === '99620-7'`)
- [x] LOINC 99620-7 verificado via tx.fhir.org/r4 (\"display\": \"Omega 3 fatty acids (w3) [Moles/volume] in RBC.lysate\", version 2.82)
- [x] LOINC 62255-6 (sugestão original do modelo) confirmado como inexistente em LOINC v2.82