### PR TITLE
fix(docs): corrigir exemplos da home + expor source nas faixas

### DIFF
--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -3,11 +3,21 @@ import { describe, expect, it } from 'vitest';
 import {
   applyFallbackReferenceRanges,
   biomarkerRangeDefinitions,
+  type BiomarkerReferenceRange,
   defaultReferenceRanges,
   getFallbackReferenceRange,
   getReferenceRange,
   type ReferenceRangeContext,
 } from '../reference-ranges';
+
+/**
+ * Expected default range with the definition's source key propagated —
+ * mirrors what `getReferenceRange` returns.
+ */
+function expectedDefault(code: keyof typeof biomarkerRangeDefinitions): BiomarkerReferenceRange {
+  const def = biomarkerRangeDefinitions[code];
+  return def.source ? { ...def.default, source: def.source } : def.default;
+}
 
 describe('biomarkerRangeDefinitions', () => {
   it('should contain biomarker range definitions', () => {
@@ -44,17 +54,15 @@ describe('defaultReferenceRanges', () => {
   });
 
   it('should match default values from definitions', () => {
-    expect(defaultReferenceRanges.HDL).toEqual(biomarkerRangeDefinitions.HDL.default);
-    expect(defaultReferenceRanges.Cholesterol).toEqual(
-      biomarkerRangeDefinitions.Cholesterol.default,
-    );
+    expect(defaultReferenceRanges.HDL).toEqual(expectedDefault('HDL'));
+    expect(defaultReferenceRanges.Cholesterol).toEqual(expectedDefault('Cholesterol'));
   });
 });
 
 describe('getReferenceRange', () => {
   it('should return default range when no context provided', () => {
     const range = getReferenceRange('HDL');
-    expect(range).toEqual(biomarkerRangeDefinitions.HDL.default);
+    expect(range).toEqual(expectedDefault('HDL'));
   });
 
   it('should return undefined for unknown biomarker', () => {
@@ -65,7 +73,7 @@ describe('getReferenceRange', () => {
     const context: ReferenceRangeContext = { age: 30, biologicalSex: 'M' };
     const range = getReferenceRange('Cholesterol', context);
     // Cholesterol has no sex-specific variants
-    expect(range).toEqual(biomarkerRangeDefinitions.Cholesterol.default);
+    expect(range).toEqual(expectedDefault('Cholesterol'));
   });
 
   describe('sex-specific variants', () => {
@@ -89,7 +97,7 @@ describe('getReferenceRange', () => {
     it('should return default when sex not provided', () => {
       const context: ReferenceRangeContext = { age: 30 };
       const range = getReferenceRange('HDL', context);
-      expect(range).toEqual(biomarkerRangeDefinitions.HDL.default);
+      expect(range).toEqual(expectedDefault('HDL'));
     });
 
     it('HDL has no false upper bound at 60 mg/dL (SBC 2025)', () => {
@@ -145,7 +153,7 @@ describe('getReferenceRange', () => {
     it('should return default when age not provided', () => {
       const context: ReferenceRangeContext = { biologicalSex: 'M' };
       const range = getReferenceRange('AMH', context);
-      expect(range).toEqual(biomarkerRangeDefinitions.AMH.default);
+      expect(range).toEqual(expectedDefault('AMH'));
     });
   });
 
@@ -280,7 +288,7 @@ describe('getReferenceRange', () => {
       // hasPregnancyVariant is true, so non-pregnancy variants are also
       // skipped → default.
       const range = getReferenceRange('TSH', context);
-      expect(range).toEqual(biomarkerRangeDefinitions.TSH.default);
+      expect(range).toEqual(expectedDefault('TSH'));
     });
 
     it('pregnant=undefined is treated as non-pregnant (conservative fallback)', () => {

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -44,6 +44,12 @@ export interface BiomarkerReferenceRange {
   min?: number;
   optimalMax?: number;
   optimalMin?: number;
+  /**
+   * Chave de fonte bibliográfica (ex.: `'sbc-lipids-2025'`). Propagada
+   * do `BiomarkerRangeDefinition` no momento da consulta; ausente em
+   * faixas declaradas diretamente sem uma definição completa.
+   */
+  source?: string;
   unit: string;
   warningMax?: number;
 }
@@ -2136,7 +2142,10 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
  * This is derived from biomarkerRangeDefinitions defaults
  */
 export const defaultReferenceRanges: Record<string, BiomarkerReferenceRange> = Object.fromEntries(
-  Object.entries(biomarkerRangeDefinitions).map(([code, def]) => [code, def.default]),
+  Object.entries(biomarkerRangeDefinitions).map(([code, def]) => [
+    code,
+    def.source ? { ...def.default, source: def.source } : def.default,
+  ]),
 );
 
 /**
@@ -2152,9 +2161,12 @@ export function getReferenceRange(
   const definition = biomarkerRangeDefinitions[testCode];
   if (!definition) return undefined;
 
+  const withSource = (range: BiomarkerReferenceRange): BiomarkerReferenceRange =>
+    definition.source ? { ...range, source: definition.source } : range;
+
   // If no context or no variants, return default
   if (!context || !definition.variants || definition.variants.length === 0) {
-    return definition.default;
+    return withSource(definition.default);
   }
 
   const { age, biologicalSex, pregnancyTrimester, pregnant } = context;
@@ -2217,11 +2229,11 @@ export function getReferenceRange(
       continue;
     }
 
-    return variant.range;
+    return withSource(variant.range);
   }
 
   // No matching variant found - return default
-  return definition.default;
+  return withSource(definition.default);
 }
 
 /**

--- a/site/src/components/CodeExamples.tsx
+++ b/site/src/components/CodeExamples.tsx
@@ -13,8 +13,8 @@ const TABS = [
     label: 'Faixas de Referência',
     code: `import { getReferenceRange, normalizeCode } from '@precisa-saude/fhir'
 
-// Normaliza aliases — "colesterol HDL", "HDL-C" → "HDL"
-const code = normalizeCode('colesterol HDL') // "HDL"
+// Normaliza aliases de código para a forma canônica
+const code = normalizeCode('Tiroxina_T4') // "T4Total"
 
 // Faixa personalizada por sexo e idade
 const range = getReferenceRange('HDL', {
@@ -24,10 +24,12 @@ const range = getReferenceRange('HDL', {
 
 console.log(range)
 // {
-//   min: 40,
-//   optimalMin: 60,
+//   min: 50,
+//   max: 100,
+//   optimalMin: 55,
+//   optimalMax: 100,
 //   unit: 'mg/dL',
-//   source: 'SBC - Atualização da Diretriz de Dislipidemias 2017'
+//   source: 'sbc-lipids-2025',
 // }`,
   },
   {
@@ -36,19 +38,38 @@ console.log(range)
 import type { LabReportData, LabObservationData, UserProfileData } from '@precisa-saude/fhir'
 
 const report: LabReportData = {
+  reportId: 'report-123',
+  userId: 'user-456',
   laboratoryName: 'Laboratório Exemplo',
-  reportDate: '2025-03-15',
+  collectionDate: '2025-03-15T08:00:00.000Z',
+  createdAt: '2025-03-15T14:00:00.000Z',
+  overallStatus: 'NORMAL',
 }
 
 const observations: LabObservationData[] = [
-  { code: 'GLU', value: 92, unit: 'mg/dL' },
-  { code: 'HBA1C', value: 5.4, unit: '%' },
+  {
+    reportId: 'report-123',
+    biomarkerCode: 'Glucose',
+    biomarkerName: 'Glicose',
+    value: 92,
+    unit: 'mg/dL',
+    flag: '',
+  },
+  {
+    reportId: 'report-123',
+    biomarkerCode: 'HbA1c',
+    biomarkerName: 'Hemoglobina Glicada',
+    value: 5.4,
+    unit: '%',
+    flag: '',
+  },
 ]
 
 const profile: UserProfileData = {
+  userId: 'user-456',
   name: 'Maria Silva',
   birthDate: '1980-06-15',
-  biologicalSex: 'F',
+  gender: 'female',
 }
 
 // Retorna FHIR R4 Bundle completo


### PR DESCRIPTION
## Resumo

Os exemplos em https://fhir-brasil.dev.br/#exemplos haviam divergido
da API real exportada. Como ficam como strings literais em
`site/src/components/CodeExamples.tsx`, o TypeScript não os valida e o
drift passou despercebido — dois dos cinco snippets não compilavam e
um terceiro falharia em runtime.

- **Faixas de Referência**: `normalizeCode('colesterol HDL')` não
  retornava `'HDL'` (a string não está no `codeAliasToCanonicalMap`).
  Trocado por um alias real (`Tiroxina_T4` → `T4Total`). Faixa HDL
  feminina 18+ corrigida: `{ min: 50, max: 100, optimalMin: 55,
  optimalMax: 100, unit: 'mg/dL' }` (era `{ min: 40, optimalMin: 60 }`).
- **Converter para FHIR**: campos renomeados para os reais
  (`reportId`, `userId`, `collectionDate`, `overallStatus`,
  `biomarkerCode`/`biomarkerName`, `flag`, `gender`); códigos
  canônicos `Glucose`/`HbA1c` no lugar de `GLU`/`HBA1C`.
- **PhenoAge, RNDS, OCR**: verificados — sem mudanças necessárias.

Adicionalmente, para que o campo `source` mostrado no exemplo
realmente exista no retorno: `BiomarkerReferenceRange` ganhou um
`source?: string` opcional, e `getReferenceRange` / `defaultReferenceRanges`
agora propagam a chave de fonte (ex.: `'sbc-lipids-2025'`) da
`BiomarkerRangeDefinition`. `SOURCE_REGISTRY` segue interno — apenas a
chave curta é exposta.

## Test plan

- [x] `pnpm --filter @precisa-saude/fhir test` — 402/402 passam
- [x] `pnpm turbo run typecheck` — limpo
- [x] `pnpm --filter @fhir-brasil/site build` — limpo
- [ ] Conferir `#exemplos` no site renderizado e validar cada snippet visualmente