### PR TITLE
fix(core): D-Dímero — remove zonas ótimas e adiciona corte ajustado por idade

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -556,10 +556,27 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'tietz-7ed-2015',
   },
 
-  // D-Dímero: 500 ng/mL é o corte clínico padrão para exclusão de TEV
+  // D-Dímero — exame de exclusão de TEV (tromboembolismo venoso) com
+  // ponto de corte único, não uma faixa graduada. Valores < 500 ng/mL
+  // têm alto valor preditivo negativo; acima disso a investigação
+  // clínica decide. Removidos `optimalMin/optimalMax` porque a
+  // dicotomia clínica (positivo/negativo para exclusão) não é melhor
+  // representada por zonas verde/amarela. Em pacientes > 50 anos,
+  // diretrizes (ESC 2019, ACEP) recomendam corte ajustado pela idade:
+  // idade × 10 ng/mL (até 750 ng/mL aos 75+).
   DDimer: {
-    default: { max: 500, min: 0, optimalMax: 250, optimalMin: 0, unit: 'ng/mL' },
+    default: { max: 500, min: 0, unit: 'ng/mL' },
+    direction: 'lower-better',
     source: 'wells-ddimer-2003',
+    variants: [
+      // Corte ajustado por idade — ESC 2019 (Konstantinides et al.) e
+      // ACEP recomendam em pacientes não gestantes ≥ 50 anos com
+      // probabilidade clínica baixa/intermediária de TEV. Fórmula:
+      // idade × 10 ng/mL. Aproximação por faixas etárias.
+      { ageMax: 59, ageMin: 50, range: { max: 590, min: 0, unit: 'ng/mL' }, sex: 'all' },
+      { ageMax: 69, ageMin: 60, range: { max: 690, min: 0, unit: 'ng/mL' }, sex: 'all' },
+      { ageMin: 70, range: { max: 750, min: 0, unit: 'ng/mL' }, sex: 'all' },
+    ],
   },
 
   Omega3_DHA: {


### PR DESCRIPTION
## Resumo

Identificado na auditoria automatizada de conteúdo no repo
[platform](https://github.com/Precisa-Saude/platform) (PRs #465-#468).
O D-Dímero está modelado como faixa graduada com `optimalMin/Max`
(0–250 ng/mL ótimo, 0–500 ng/mL normal), o que não reflete o uso
clínico do exame:

- D-Dímero é um teste de **exclusão** de TEV (tromboembolismo
  venoso) com ponto de corte único. Valores abaixo de 500 ng/mL têm
  alto VPN; acima disso, investigação clínica decide. Um valor de
  150 ng/mL não é clinicamente "melhor" que 450 ng/mL — ambos são
  negativos.
- Apresentar zonas verde/amarela no gráfico (BiomarkerGauge) passa
  para o usuário a ideia incorreta de que valores baixos são
  preferíveis.

## Mudanças

- **Remove** `optimalMin: 0` e `optimalMax: 250` do `default`.
- **Adiciona** `direction: 'lower-better'` para deixar explícito que
  apenas o limite superior importa.
- **Adiciona variantes** ajustadas por idade (ESC 2019 — Konstantinides
  et al.; ACEP) em pacientes ≥ 50 anos. Fórmula clínica é `idade × 10
  ng/mL`, aproximada por faixas etárias:
  - 50–59 anos: 590 ng/mL
  - 60–69 anos: 690 ng/mL
  - ≥ 70 anos: 750 ng/mL

## Test plan

- [x] Sem testes específicos para DDimer no pacote.
- [x] 402 testes existentes do `@precisa-saude/fhir` passam.
- [x] Build do pacote completa sem warnings.
- [ ] Spot-check no gráfico do app web após o PR consumidor atualizar
      a versão de `@precisa-saude/fhir`.

## Próximos passos

No repo `platform`, vou rodar a auditoria automatizada novamente
passando contexto de usuário (sex, age) para `getReferenceRange()`
no script — assim o auditor pega as variantes reais em vez do
`default` (que para Estradiol/LH/FSH/Progesterone é
masculino/pós-menopausa).