### PR TITLE
fix(ci): sincronizar versão do pacote rnds com o root

### DIFF
--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 const rootPkg = JSON.parse(readFileSync('package.json', 'utf-8'));
 const version = rootPkg.version;
 
-const packages = ['packages/core', 'packages/calculators', 'packages/ocr-utils'];
+const packages = ['packages/core', 'packages/calculators', 'packages/ocr-utils', 'packages/rnds'];
 
 for (const dir of packages) {
   const pkgPath = join(dir, 'package.json');


### PR DESCRIPTION
## Summary

- Adiciona `packages/rnds` ao array de pacotes em `scripts/sync-versions.js`.
- Corrige o falso-positivo recorrente do `publish-watch` reportado em #39 (já com 187 comentários, dispara a cada 15 min).

## Contexto

O pacote `@precisa-saude/fhir-rnds` estava no fluxo de publicação (`ci.yml` → `_publish.yml`) mas ausente de `scripts/sync-versions.js`. Como semantic-release sincroniza apenas os pacotes listados no script, o `rnds` ficou congelado em `0.1.0` desde o release `v0.3.0` (2026-04-01, commit `225bea8`), enquanto o root foi até `0.15.4`.

O `publish-watch` procura pela tag `v<versão-no-npm>` ou `<nome>@<versão>`. Com `latest = 0.1.0` no npm e sem tag `v0.1.0` no repo (a mais antiga é `v0.1.8`), o tripwire reporta mismatch a cada cron.

Não é incidente de segurança: a publicação de `0.1.0` foi feita pelo próprio workflow legítimo no release v0.3.0.

## Efeito após merge

- No próximo `semantic-release`, `packages/rnds/package.json` será bumpado para a versão root (`0.15.5` ou superior).
- `_publish.yml` publica `@precisa-saude/fhir-rnds@<root>`, e a tag `v<root>` passa a casar com o `latest` no npm.
- `publish-watch` para de disparar; issue #39 pode ser fechada com referência a este PR.
- Efeito colateral: o `rnds` pula de `0.1.0` direto para a versão root (gap cosmético no histórico do pacote).

## Test plan

- [x] `pnpm turbo run test` passa (pre-push hook)
- [ ] Após merge: confirmar que próximo release publica `@precisa-saude/fhir-rnds@<root>` com tag correspondente
- [ ] Confirmar que próximo cron do `publish-watch` (após o release) não dispara nova comment em #39

Refs: #39