### PR TITLE
chore(ci): publish-watch passa de cron 15min para diário

### DIFF
--- a/.github/workflows/publish-watch.yml
+++ b/.github/workflows/publish-watch.yml
@@ -1,7 +1,7 @@
 name: Publish watch
 
 # Tripwire — confirma que toda versão publicada no npm tem uma tag git
-# correspondente neste repo. Roda em cron de 15 em 15 min e ad-hoc via
+# correspondente neste repo. Roda em cron diário (08:00 UTC) e ad-hoc via
 # workflow_dispatch.
 #
 # Para cada pacote público em packages/**, compara a versão `latest` no
@@ -12,7 +12,7 @@ name: Publish watch
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Tripwire `publish-watch.yml` rodava a cada 15 min (`*/15 * * * *`, 96 runs/dia) — barulho no Actions sem ganho prático.
- Diário 08:00 UTC (`0 8 * * *`) mantém o sinal de supply-chain: detecta versão npm sem tag git correspondente em até 24h.
- `workflow_dispatch` continua disponível para checagem ad-hoc.

## Test plan

- [x] YAML válido (uma única linha alterada no `cron:`)
- [x] Workflow ainda disparável via `workflow_dispatch` (sem mudança em `on:`)