### PR TITLE
fix(calculators): corrige unidade da PCR no PhenoAge (mg/L → mg/dL)

### DIFF
--- a/packages/calculators/README.md
+++ b/packages/calculators/README.md
@@ -24,7 +24,7 @@ const result = phenoage.calculatePhenoAge({
   albumin: 42, // g/L
   creatinine: 80, // μmol/L
   glucose: 5.2, // mmol/L
-  crp: 1.5, // mg/L
+  crp: 1.5, // mg/L (PCR ultrassensível — convertida para mg/dL internamente)
   lymphocytePercent: 30,
   mcv: 88, // fL
   rdw: 13.2, // %
@@ -32,9 +32,15 @@ const result = phenoage.calculatePhenoAge({
   wbc: 6.0, // 10^9/L
 });
 
-console.log(result.phenoAge); // 42.3 (idade biológica)
-console.log(result.ageDifference); // -2.7 (anos mais jovem)
+console.log(result.phenoAge); // 39.5 (idade biológica)
+console.log(result.ageDifference); // -5.5 (anos mais jovem)
 ```
+
+> **Unidade da PCR:** o modelo de Levine foi ajustado sobre dados do NHANES IV,
+> onde a PCR é medida em **mg/dL**. O campo `crp` desta API permanece em
+> **mg/L** — a unidade reportada pelos laboratórios brasileiros (PCR
+> ultrassensível) — e o cálculo converte mg/L → mg/dL antes do termo
+> `0.0954·ln(PCR)`. Não pré-converta a PCR para mg/dL ao chamar a função.
 
 ### BrDMrisc — Risco de diabetes tipo 2
 

--- a/packages/calculators/src/__tests__/phenoage.test.ts
+++ b/packages/calculators/src/__tests__/phenoage.test.ts
@@ -81,6 +81,50 @@ describe('calculatePhenoAge', () => {
   });
 });
 
+describe('calculatePhenoAge — CRP unit handling (mg/L input → mg/dL in formula)', () => {
+  // Reference case verified against the published Liu et al. 2018 (corrected)
+  // formula and the longevity-tools.com calculator. Conventional-unit inputs
+  // from the source URL, converted to the SI units this calculator expects.
+  // hs-CRP stays in mg/L (0.3) — the calculator divides by 10 internally.
+  // Source of truth: NHANES IV `LBXCRP` is mg/dL; `0.0954·ln(CRP[mg/dL])`.
+  const referenceInput: PhenoAgeInput = {
+    albumin: 4.4 * 10, // 4.4 g/dL → 44 g/L
+    alkalinePhosphatase: 59, // U/L
+    chronologicalAge: 46,
+    creatinine: 1.13 * 88.4, // 1.13 mg/dL → 99.892 μmol/L
+    crp: 0.3, // mg/L
+    glucose: 85 / 18.0182, // 85 mg/dL → 4.717 mmol/L
+    lymphocytePercent: 33.6,
+    mcv: 99.8, // fL
+    rdw: 12, // %
+    wbc: 4.5, // 10^9/L
+  };
+
+  it('matches the published / longevity-tools reference value (36.5)', () => {
+    // Before the unit fix this returned 39.0 (CRP wrongly used in mg/L).
+    expect(calculatePhenoAge(referenceInput).phenoAge).toBeCloseTo(36.5, 1);
+  });
+
+  it('logs CRP in mg/dL, not mg/L (0.3 mg/L → ln(0.03 mg/dL))', () => {
+    const crp = calculatePhenoAge(referenceInput).breakdown.find((b) => b.key === 'crp');
+    expect(crp?.valueWithUnit).toBe('ln(0.030)');
+    // 0.0954 × ln(0.3 / 10), rounded to 4 dp
+    expect(crp?.contribution).toBeCloseTo(0.0954 * Math.log(0.03), 4);
+  });
+
+  it('clamps CRP below the limit of detection (0.1 mg/L)', () => {
+    const belowLod = calculatePhenoAge({ ...referenceInput, crp: 0.02 });
+    const atLod = calculatePhenoAge({ ...referenceInput, crp: 0.1 });
+    expect(belowLod.phenoAge).toBe(atLod.phenoAge);
+  });
+
+  it('higher CRP raises PhenoAge monotonically', () => {
+    const low = calculatePhenoAge({ ...referenceInput, crp: 0.5 }).phenoAge;
+    const high = calculatePhenoAge({ ...referenceInput, crp: 5 }).phenoAge;
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
 describe('validateBiomarkers', () => {
   it('should pass for healthy values', () => {
     const result = validateBiomarkers(healthyInput);

--- a/packages/calculators/src/phenoage/calculator.ts
+++ b/packages/calculators/src/phenoage/calculator.ts
@@ -8,7 +8,9 @@
 import {
   BIOMARKER_NAMES_PT,
   BIOMARKER_RANGES,
+  CRP_LOD_MG_L,
   GOMPERTZ_PARAMS,
+  MG_L_PER_MG_DL,
   PHENOAGE_COEFFICIENTS,
 } from './constants';
 import type { ComponentBreakdown, PhenoAgeInput, PhenoAgeResult } from './types';
@@ -20,7 +22,11 @@ import type { ComponentBreakdown, PhenoAgeInput, PhenoAgeResult } from './types'
 const calculateLinearPredictor = (
   input: PhenoAgeInput,
 ): { xb: number; breakdown: ComponentBreakdown[] } => {
-  const logCrp = Math.log(Math.max(input.crp, 0.1)); // Avoid log(0)
+  // Levine's CRP coefficient was fit on NHANES CRP in mg/dL, but `input.crp` is
+  // in mg/L (the unit Brazilian hs-CRP assays report). Clamp to the hs-CRP limit
+  // of detection (avoids log(0)/log(-)), then convert mg/L → mg/dL for the model.
+  const crpMgDl = Math.max(input.crp, CRP_LOD_MG_L) / MG_L_PER_MG_DL;
+  const logCrp = Math.log(crpMgDl);
 
   const components: Array<{
     key: string;
@@ -49,9 +55,9 @@ const calculateLinearPredictor = (
     },
     {
       coefficient: PHENOAGE_COEFFICIENTS.logCrp,
-      displayValue: `ln(${input.crp.toFixed(2)})`,
+      displayValue: `ln(${crpMgDl.toFixed(3)})`,
       key: 'crp',
-      unit: 'ln(mg/L)',
+      unit: 'ln(mg/dL)',
       value: logCrp,
     },
     {

--- a/packages/calculators/src/phenoage/constants.ts
+++ b/packages/calculators/src/phenoage/constants.ts
@@ -3,9 +3,26 @@
  *
  * Coefficients from Levine et al. (2018) Table 1
  * Units: albumin (g/L), creatinine (μmol/L), glucose (mmol/L),
- *        CRP (ln of mg/L), lymphocyte (%), MCV (fL), RDW (%),
- *        ALP (U/L), WBC (10^9/L), age (years)
+ *        CRP (mg/dL inside the log term — see note below), lymphocyte (%),
+ *        MCV (fL), RDW (%), ALP (U/L), WBC (10^9/L), age (years)
+ *
+ * CRP unit note: the original model was fit on NHANES IV CRP, which is reported
+ * in **mg/dL** (variable `LBXCRP`). The `logCrp` coefficient therefore expects
+ * `ln(CRP in mg/dL)`. Our public input (`PhenoAgeInput.crp`) stays in **mg/L**
+ * — the unit Brazilian hs-CRP assays report — and the calculator converts
+ * mg/L → mg/dL right before the log. See `CRP_LOD_MG_L` / `MG_L_PER_MG_DL`.
  */
+
+/** Milligrams per litre in one milligram per decilitre (1 mg/dL = 10 mg/L). */
+export const MG_L_PER_MG_DL = 10;
+
+/**
+ * hs-CRP limit of detection used to clamp CRP before the log transform (mg/L).
+ * Matches the NHANES hs-CRP lower limit of detection (~0.11 mg/L); values below
+ * it are not meaningfully measurable and would otherwise push `ln(CRP)` toward
+ * −∞. Expressed in mg/L because that is the unit of the public input.
+ */
+export const CRP_LOD_MG_L = 0.1;
 
 /**
  * Regression coefficients from the Cox proportional hazards model


### PR DESCRIPTION
## Resumo

O PhenoAge (Levine) estava **superestimando a idade biológica** porque
aplicava `ln()` sobre a PCR em **mg/L**, enquanto o coeficiente
`0.0954·ln(PCR)` do modelo foi ajustado sobre PCR em **mg/dL**. A correção
converte mg/L → mg/dL internamente, antes do termo logarítmico.

Descoberto ao comparar o resultado da Precisa (**39.0 anos**) com a
calculadora de referência [longevity-tools.com](https://www.longevity-tools.com/levine-pheno-age)
(**36.5 anos**) para o mesmo exame. Toda a diferença de ~2.5 anos vinha da PCR.

## Causa raiz

| | Antes | Depois |
| --- | --- | --- |
| Termo da PCR | `ln(0.3 mg/L)` | `ln(0.03 mg/dL)` |
| `xb` (caso de referência) | −9.331 | −9.551 |
| **PhenoAge** | **39.0** | **36.5** ✅ |

A diferença é exatamente `0.0954 · ln(10) ≈ 0.22` em `xb`.

O input público `crp` **permanece em mg/L** (unidade da PCR ultrassensível
reportada pelos laboratórios brasileiros) — nenhum chamador precisa mudar.
A conversão passou a ser feita dentro do cálculo.

## Verificação contra fontes primárias

1. **Fórmula publicada** — errata de Liu et al. 2018, PLoS Med
   ([PMC6388911](https://pmc.ncbi.nlm.nih.gov/articles/PMC6388911/)): termo
   literal `0.0954×ln(CRP)`, sobre a PCR do NHANES IV.
2. **Dados de treino (NHANES)** — `LBXCRP` (1999–2010) é **mg/dL**
   ([codebook 2009–2010](https://wwwn.cdc.gov/nchs/nhanes/2009-2010/CRP_F.htm));
   `LBXHSCRP` (2015+) é **mg/L**
   ([codebook 2015–2016](https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/2015/DataFiles/HSCRP_I.htm)).
3. **Implementação de referência** — pacote `dayoonkwon/BioAge` (laboratório
   da própria Levine) **divide a hs-CRP de 2015 por 10** para igualar as ondas
   em mg/dL:
   ```r
   # CRP in 2015 was measured in mg/L units and needs to be divided by 10
   #                                   to equal units in other waves.
   CRP_2015 <- transmute(CRP_2015, SEQN, LBXCRP = LBXHSCRP/10)
   ```

## Decisões de projeto

- **Mantido o input em mg/L.** A conversão mg/L → mg/dL acontece imediatamente
  antes do `ln`. `TARGET_UNITS.crp` e `BIOMARKER_RANGES.crp` (mg/L) continuam
  representando a unidade de entrada.
- **Mantido `ln(PCR)` simples** (fórmula publicada + longevity-tools), e **não**
  `ln(1+PCR)` usado pelo pacote BioAge. São convenções divergentes na literatura
  (a "confusão sobre a fórmula") que dão resultados diferentes em PCR baixa;
  alinhamos com a fórmula publicada.
- **Piso da PCR** mantido no limite de detecção da hs-CRP (~0.1 mg/L, alinhado
  ao LLOD do NHANES) para evitar `ln(0)`, agora como constante nomeada
  `CRP_LOD_MG_L`.

## Mudanças

- `phenoage/calculator.ts` — converte mg/L → mg/dL antes do `ln`; rótulo do
  breakdown agora `ln(mg/dL)`.
- `phenoage/constants.ts` — novas constantes `MG_L_PER_MG_DL` e `CRP_LOD_MG_L`;
  nota de unidade da PCR documentada.
- `__tests__/phenoage.test.ts` — caso de referência fixado em **36.5**, mais
  testes de unidade da PCR (mg/L→mg/dL), piso e monotonicidade.
- `README.md` — nota sobre a unidade da PCR; valores do exemplo atualizados
  (39.5 / −5.5) para refletir o cálculo corrigido.

## Impacto downstream

Ao atualizar a versão deste pacote no repositório `platform`, o PhenoAge
exibido cairá ~2–3 anos para exames com PCR baixa. O teste
`apps/web/src/features/phenoage/__tests__/calculator.test.ts` (espera **38.1**)
precisará ser reajustado no PR de bump da dependência.

## Testes

`pnpm turbo run lint typecheck test --filter=@precisa-saude/fhir-calculators` —
112 testes passando; cobertura 98.86% stmts / 92.38% branches.