### PR TITLE
fix(core): Relação PSA livre/total como higher-better

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -2084,11 +2084,12 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   // Relação PSA livre/total — `higher-better`: razão maior = menor risco de
-  // câncer de próstata, logo não há limite superior "ruim". >25% baixo risco
-  // (verde), 15–25% intermediário (âmbar), <15% maior risco (vermelho). `min`
-  // (25) delimita o verde e `warningMin` (15) a faixa de atenção.
+  // câncer de próstata, logo não há limite superior "ruim" (acima do normal é
+  // verde). Faixas alinhadas à tabela clínica: >25% baixo risco (verde),
+  // 10–25% atenção — intermediário/moderado (âmbar), <10% alto risco >50%
+  // (vermelho). `min` (25) delimita o verde e `warningMin` (10) o vermelho.
   PSA_FreeRatio: {
-    default: { max: 100, min: 25, optimalMax: 100, optimalMin: 30, unit: '%', warningMin: 15 },
+    default: { max: 100, min: 25, optimalMax: 100, optimalMin: 30, unit: '%', warningMin: 10 },
     direction: 'higher-better',
     source: 'sturgeon-nacb-2008',
   },

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -2085,9 +2085,11 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
 
   // Relação PSA livre/total — `higher-better`: razão maior = menor risco de
   // câncer de próstata, logo não há limite superior "ruim" (acima do normal é
-  // verde). Faixas alinhadas à tabela clínica: >25% baixo risco (verde),
+  // verde). Faixas alinhadas à tabela clínica: ≥25% baixo risco (verde),
   // 10–25% atenção — intermediário/moderado (âmbar), <10% alto risco >50%
-  // (vermelho). `min` (25) delimita o verde e `warningMin` (10) o vermelho.
+  // (vermelho). Limites: `min` (25) é o piso do verde e `warningMin` (10) o
+  // piso do âmbar — o vermelho é estritamente abaixo de 10% (< 10%); 10%
+  // pertence ao âmbar, conforme a faixa "10–15% moderado" da tabela.
   PSA_FreeRatio: {
     default: { max: 100, min: 25, optimalMax: 100, optimalMin: 30, unit: '%', warningMin: 10 },
     direction: 'higher-better',

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -2083,12 +2083,13 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'sturgeon-nacb-2008',
   },
 
-  // Relação PSA livre/total — risco de câncer de próstata é inversamente
-  // proporcional: >25% baixo risco (verde), 15–25% intermediário (âmbar),
-  // <15% maior risco (vermelho). `min` (25) delimita o verde e `warningMin`
-  // (15) a faixa de atenção.
+  // Relação PSA livre/total — `higher-better`: razão maior = menor risco de
+  // câncer de próstata, logo não há limite superior "ruim". >25% baixo risco
+  // (verde), 15–25% intermediário (âmbar), <15% maior risco (vermelho). `min`
+  // (25) delimita o verde e `warningMin` (15) a faixa de atenção.
   PSA_FreeRatio: {
     default: { max: 100, min: 25, optimalMax: 100, optimalMin: 30, unit: '%', warningMin: 15 },
+    direction: 'higher-better',
     source: 'sturgeon-nacb-2008',
   },
 


### PR DESCRIPTION
## Problema

`PSA_FreeRatio` (Relação PSA livre/total) não tinha `direction`, então era inferido como `range` (faixa bilateral). No gráfico, isso pinta **valores altos de vermelho ("Alto")** — sugerindo que uma razão alta é ruim. É o oposto: **quanto maior a razão, menor o risco de câncer de próstata** (>25% = baixo risco). O conteúdo educativo (tabela na página) deixa isso claro, e o gráfico contradizia a tabela.

## Correção

```diff
   PSA_FreeRatio: {
     default: { max: 100, min: 25, optimalMax: 100, optimalMin: 30, unit: '%', warningMin: 15 },
+    direction: 'higher-better',
     source: 'sturgeon-nacb-2008',
   },
```

Com `higher-better`, o gráfico:
- não tem zona "ruim" superior (acima do normal é verde);
- mantém a base correta: **verde ≥25%, âmbar 15–25%, vermelho <15%** (via `warningMin`, do PR #51).

`typecheck` + 402 testes do `packages/core` passam.
