### PR TITLE
fix(core): corrige faixa da razão AA/EPA (1–15 sem fonte → 3,7–40,7)

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -299,10 +299,19 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'simopoulos-omega-ratio-2002',
   },
 
+  // Razão Ácido Araquidônico/EPA (sangue total) — `lower-better`: razão menor =
+  // menos eicosanoides pró-inflamatórios. NÃO há intervalo de referência
+  // validado em periódico para esta razão; o intervalo 3,7–40,7 é o de
+  // referência laboratorial do ensaio Quest/Cleveland HeartLab OmegaCheck®
+  // (população interna do laboratório, sem fonte primária publicada). É
+  // corroborado por Torrissen 2025 (>500 mil amostras de sangue total): a
+  // mediana brasileira (≈18,8) e as ocidentais (EUA ≈22,3; Europa ≈14,2) caem
+  // dentro do intervalo. Sem `optimal*`: não há corte ótimo de AA/EPA com fonte.
+  // Em telas de relatório único, prefira o intervalo impresso pelo laboratório.
   AA_EPA_Ratio: {
-    default: { max: 15.0, min: 1.0, optimalMax: 5.0, optimalMin: 1.5, unit: '' },
+    default: { max: 40.7, min: 3.7, unit: '' },
     direction: 'lower-better',
-    source: 'simopoulos-omega-ratio-2002',
+    source: 'torrissen-omega3-dbs-2025',
   },
 
   Arsenic: {

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -338,6 +338,13 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     isbn: '978-1-4557-4165-6',
     key: 'tietz-7ed-2015',
   },
+
+  'torrissen-omega3-dbs-2025': {
+    abnt: 'TORRISSEN, M. et al. Global variations in omega-3 fatty acid status and omega-6:omega-3 ratios: insights from > 500,000 whole-blood dried blood spot samples. Lipids in Health and Disease, v. 24, n. 1, p. 260, 2025.',
+    doi: '10.1186/s12944-025-02676-6',
+    key: 'torrissen-omega3-dbs-2025',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40783537/',
+  },
   // ---------------------------------------------------------------------------
   // Fontes internacionais — Coagulação
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problema

A faixa de referência da **Razão AA/EPA** (`AA_EPA_Ratio`) estava em **1–15**, sem fonte válida — citava `simopoulos-omega-ratio-2002`, que trata da razão **dietética** ômega-6/ômega-3, e não da razão AA/EPA medida no sangue. Resultado: o gráfico marcava como "Alto" (vermelho) valores que o próprio laboratório de origem considera **normais**.

## Investigação

Lendo os PDFs reais de um usuário (ensaio **Quest OmegaCheck®**, *sangue total*, "% by wt"), o intervalo de referência impresso é **3,7–40,7** (idêntico ao que o Function Health exibe — ambos derivam do Quest). Nossa extração havia armazenado `1–15` (o fallback do FHIR) em alguns relatórios e `3,7–40,7` em outros.

A proveniência do `3,7–40,7` foi rastreada: é um **intervalo laboratorial interno** do Cleveland HeartLab/Quest, **sem fonte primária publicada** (o ensaio "foi desenvolvido e validado no Cleveland HeartLab"; a linha AA/EPA do laudo não tem citação).

## Fonte (corroboração publicada)

Não existe intervalo de referência da razão AA/EPA validado em periódico. A melhor corroboração revisada por pares — e no mesmo compartimento (sangue total) — é:

> TORRISSEN, M. *et al.* Global variations in omega-3 fatty acid status and omega-6:omega-3 ratios: insights from > 500,000 whole-blood dried blood spot samples. *Lipids in Health and Disease*, v. 24, n. 1, p. 260, 2025. DOI: 10.1186/s12944-025-02676-6. PMID: 40783537.

Medianas de AA/EPA em sangue total (n = 595.480): **Brasil ≈ 18,8** · EUA ≈ 22,3 · Europa Ocidental ≈ 14,2 · Austrália ≈ 12,5 — todas **dentro** de 3,7–40,7. Japão e dados de eritrócito (compartimento diferente) foram descartados.

## Mudança

```diff
   AA_EPA_Ratio: {
-    default: { max: 15.0, min: 1.0, optimalMax: 5.0, optimalMin: 1.5, unit: '' },
+    default: { max: 40.7, min: 3.7, unit: '' },
     direction: 'lower-better',
-    source: 'simopoulos-omega-ratio-2002',
+    source: 'torrissen-omega3-dbs-2025',
   },
```

- Remove `optimalMin/optimalMax` — não há corte ótimo de AA/EPA com fonte; não inventamos.
- Comentário documenta honestamente que `3,7–40,7` é laboratorial (não publicado), corroborado por Torrissen.
- `simopoulos-omega-ratio-2002` permanece nos marcadores ômega-6 onde é pertinente.

`typecheck` + 402 testes do `packages/core` passam.

> **Nota de acompanhamento (fora deste PR):** a app deve preferir o intervalo impresso pelo laboratório quando presente (já armazenado em `referenceMin/Max`), usando esta faixa canônica só como fallback no gráfico de tendência combinado. Bug de extração (armazenou `1–15` em vez do intervalo do PDF) será aberto como issue separada.
