### PR TITLE
fix(core): alinhar faixas da eAG aos cortes diagnósticos da HbA1c

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -2111,10 +2111,24 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'who-obesity-2000',
   },
 
-  // eAG - Estimated Average Glucose, derived from HbA1c (ADAG study)
+  // eAG — Estimated Average Glucose, derivada da HbA1c pela fórmula ADAG:
+  // eAG (mg/dL) = 28,7 × HbA1c(%) − 46,7 (NATHAN, D. M. et al. Translating the
+  // A1C assay into estimated average glucose values. Diabetes Care, v. 31, n. 8,
+  // p. 1473-1478, 2008. DOI: 10.2337/dc08-0545).
+  //
+  // As faixas espelham os cortes diagnósticos de HbA1c da SBD (ver entrada
+  // `HbA1c`) convertidos por essa fórmula, mantendo a eAG coerente com o
+  // marcador de origem:
+  //   optimalMax 105  ← HbA1c 5,3 % (teto do controle ótimo)
+  //   max        117  ← HbA1c 5,7 % (teto do não diabético → início do pré-diabetes)
+  //   warningMax 137  ← HbA1c 6,4 % (teto do pré-diabetes → acima disso, diabetes)
+  //
+  // Substitui a faixa anterior (optimalMax 126 = corte de glicemia de jejum;
+  // max 154 = meta terapêutica do diabético, HbA1c 7 %), que classificava como
+  // "Normal" valores já pré-diabéticos e diabéticos.
   eAG: {
-    default: { max: 154, min: 70, optimalMax: 126, optimalMin: 70, unit: 'mg/dL' },
-    source: 'tietz-7ed-2015',
+    default: { max: 117, min: 70, optimalMax: 105, optimalMin: 70, unit: 'mg/dL', warningMax: 137 },
+    source: 'sbd-diabetes-2024',
   },
 
   // INR - International Normalized Ratio (non-anticoagulated patients)


### PR DESCRIPTION
## Problema

Na página da Glicemia Média Estimada (eAG), as **bandas do gráfico** e a
**tabela clínica** (\"Resumo\") exibiam cortes diferentes:

- **Gráfico** (faixa de referência): 70 / 126 / 154 mg/dL
- **Tabela**: < 117 normal · 117–137 pré-diabetes · > 137 diabetes

A faixa da eAG usava `optimalMax 126` (que é o corte de **glicemia de
jejum**, não de eAG) e `max 154` (a **meta terapêutica** do diabético,
HbA1c 7%). Resultado: valores já pré-diabéticos e diabéticos apareciam
como \"Normal\" (verde) no gauge e no gráfico de histórico, contradizendo
a própria tabela educativa mostrada ao usuário.

## Correção

A eAG é derivada da HbA1c pela fórmula ADAG:

> eAG (mg/dL) = 28,7 × HbA1c(%) − 46,7
> (NATHAN, D. M. et al. *Translating the A1C assay into estimated average
> glucose values*. Diabetes Care, v. 31, n. 8, p. 1473-1478, 2008.
> DOI: 10.2337/dc08-0545)

As faixas agora espelham os cortes diagnósticos de HbA1c da SBD (mesma
fonte já usada em `HbA1c` e `Glucose`), convertidos por essa fórmula:

| Campo | Antes | Depois | HbA1c equiv. | Significado |
| ----- | ----- | ------ | ------------ | ----------- |
| `optimalMax` | 126 | **105** | 5,3% | teto do controle ótimo |
| `max` | 154 | **117** | 5,7% | teto do não diabético (início do pré-diabetes) |
| `warningMax` | — | **137** | 6,4% | teto do pré-diabetes (acima → diabetes) |

`min`/`optimalMin` (70) permanecem inalterados.

### Efeito no gauge / gráfico de histórico

- **Ideal** (verde): 70–105
- **Normal** (verde claro): 105–117
- **Elevado** (âmbar): 117–137 — pré-diabetes
- **Alto** (vermelho): > 137 — diabetes

Passa a coincidir com as linhas diagnósticas da tabela clínica. O
`warningMax` já é renderizado tanto pelo `BiomarkerGauge` quanto pelo
gráfico de histórico (`ChartContent`) no consumidor (platform).

### Fonte

`tietz-7ed-2015` → `sbd-diabetes-2024`, coerente com as entradas irmãs
`HbA1c` e `Glucose`.

## Testes

- `pnpm turbo run test lint typecheck --filter=@precisa-saude/fhir` — 402 testes passando
- Invariantes de faixa (`min ≤ max`, `optimalMin ≤ optimalMax`) e validação de fonte no `SOURCE_REGISTRY` OK