### PR TITLE
fix(ocr-utils): exigir fronteira de token e contexto de valor na ancoragem

### DIFF
--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -2914,20 +2914,28 @@ export function toBiomarkerTests(): Record<
  * Biomarker search pattern for OCR text anchoring
  */
 export interface BiomarkerSearchPattern {
+  category: string | string[];
   code: string;
   loinc?: string;
   names: string[]; // All names (EN + PT) for this biomarker
+  unit?: string; // Absent for qualitative biomarkers (urine dipstick, etc.)
 }
 
 /**
  * Get all biomarker search patterns for OCR text anchoring
  * Returns a flat list of all biomarker codes with their searchable names
+ *
+ * `category` and `unit` are exposed so anchoring consumers can tell
+ * quantitative biomarkers from qualitative ones (which need different
+ * matching rules — a qualitative marker has no number next to it).
  */
 export function getAllSearchPatterns(): BiomarkerSearchPattern[] {
   return BIOMARKER_DEFINITIONS.map((def) => ({
+    category: def.category,
     code: def.code,
     ...(def.loinc && { loinc: def.loinc }),
     names: [...def.names.en, ...def.names.pt],
+    ...(def.unit && { unit: def.unit }),
   }));
 }
 

--- a/packages/ocr-utils/README.md
+++ b/packages/ocr-utils/README.md
@@ -47,7 +47,7 @@ console.log(result.filteredReference);
 
 Este pacote implementa um padrão de **ancoragem antes do LLM** para prevenir alucinações na extração de dados laboratoriais:
 
-1. **Ancoragem (este pacote):** Escaneia o texto OCR bruto procurando nomes de biomarcadores conhecidos usando correspondência exata de strings contra as 180+ definições de `@precisa-saude/fhir`.
+1. **Ancoragem (este pacote):** Escaneia o texto OCR bruto procurando nomes de biomarcadores conhecidos contra as 180+ definições de `@precisa-saude/fhir`.
 
 2. **Filtragem:** Gera uma referência LLM filtrada (`filteredReference`) contendo apenas os biomarcadores que foram realmente encontrados no texto. O LLM só pode extrair valores para biomarcadores presentes nesta lista.
 
@@ -62,15 +62,57 @@ PDF → OCR → findBiomarkersInText() → filteredReference → LLM → valores
                         o LLM pode extrair
 ```
 
+### Regras de correspondência
+
+Uma âncora falsa é cara: ela envia ao LLM uma referência de biomarcadores que
+não estão no documento, convidando o modelo a preencher valores inexistentes.
+Por isso a correspondência é conservadora:
+
+- **Fronteira de token** — o nome precisa aparecer inteiro. `Color` não casa
+  dentro de "Colorectal", nem `Cholesterol` dentro de "Hypercholesterolemia".
+  Plurais impressos pelos laboratórios ("Proteínas", "Cetonas") continuam
+  ancorando no nome singular do catálogo.
+- **Nome mais longo vence** — em sobreposição, o casamento mais específico
+  prevalece: "HDL Cholesterol" ancora `HDL`, não `Cholesterol`; "Blood Glucose"
+  ancora `Glucose`, não `Blood_Urine`.
+- **Nomes de uma linha só** — nos layouts em coluna dos laudos, linhas
+  consecutivas são biomarcadores distintos, então um nome composto não
+  atravessa quebra de linha ("Colesterol\nHDL" não vira "Colesterol HDL").
+- **Co-ocorrência de valor para nomes genéricos** — nomes que também são
+  palavras comuns (`Color`, `Protein`, `Blood`, `Volume`, `Peso`) só ancoram se
+  a linha carregar um valor: um número, uma unidade conhecida, ou um termo
+  qualitativo esperado ("Negativo", "Ausente", "Amarelo Citrino"). "Specimen
+  type: Blood" não ancora; "Sangue Oculto: Negativo" ancora.
+- **Contexto genético é descartado** — símbolos de gene colidem com nomes de
+  biomarcador (o gene `APOB` vs. a lipoproteína `ApoB`). Linhas com acesso
+  RefSeq (`NM_000384.2`), notação HGVS (`p.Trp448*`, `c.1234A>G`), `rs` do dbSNP
+  ou vocabulário de laudo genético não ancoram. É o contexto que decide, não uma
+  lista de símbolos proibidos — bani-los quebraria laudos lipídicos reais.
+
 ## API
 
 ### `findBiomarkersInText(ocrText: string): AnchorResult`
 
-Escaneia texto OCR e retorna todos os biomarcadores encontrados.
+Escaneia texto OCR e retorna todos os biomarcadores encontrados — um casamento
+por código, o de maior confiança.
 
-- `result.matches` — Lista de biomarcadores encontrados com código, LOINC, nome e posição
+- `result.matches` — Lista de biomarcadores encontrados com código, LOINC, nome, confiança e posição
 - `result.filteredReference` — Referência formatada para enviar ao LLM
 - `result.stats` — Estatísticas de execução (total de padrões, encontrados, tempo)
+
+`position` é o índice no texto normalizado (sem acentos, minúsculas, espaços
+horizontais colapsados), não no texto OCR original.
+
+#### Confiança
+
+`match.confidence` reflete a qualidade do casamento — nome completo ao lado de
+um valor não é a mesma coisa que uma menção solta em prosa:
+
+| Valor | Constante                   | Significado                                                              |
+| ----- | --------------------------- | ------------------------------------------------------------------------ |
+| `1.0` | `CONFIDENCE_VALUE_ADJACENT` | Nome específico com valor na mesma linha (`Glicose: 95 mg/dL`)           |
+| `0.7` | `CONFIDENCE_NAME_ONLY`      | Nome específico sem valor por perto (cabeçalho de seção, menção solta)   |
+| `0.4` | `CONFIDENCE_AMBIGUOUS`      | Nome genérico que só ancorou por causa do valor ao lado (`Cor: Amarelo`) |
 
 ### `getMatchedCodes(result: AnchorResult): string[]`
 

--- a/packages/ocr-utils/src/__tests__/anchor.test.ts
+++ b/packages/ocr-utils/src/__tests__/anchor.test.ts
@@ -124,10 +124,12 @@ describe('findBiomarkersInText — falsos positivos (issue #59)', () => {
   });
 
   it('should require a token boundary instead of matching inside a word', () => {
-    const condition = findBiomarkersInText('Familial Hypercholesterolemia');
+    // Linhas com número e sem marcador genético: o único mecanismo capaz de
+    // barrar a âncora aqui é a fronteira de token.
+    const condition = findBiomarkersInText('Hipercolesterolemia familiar: risco 12 pontos');
     expect(condition.matches.some((m) => m.code === 'Cholesterol')).toBe(false);
 
-    const cancer = findBiomarkersInText('Colorectal, Endocrine, Gastric Cancer');
+    const cancer = findBiomarkersInText('Colorectal cancer screening: 3 exames solicitados');
     expect(cancer.matches.some((m) => m.code === 'Color_Urine')).toBe(false);
   });
 
@@ -154,6 +156,11 @@ describe('findBiomarkersInText — falsos positivos (issue #59)', () => {
 
     const lipids = findBiomarkersInText('Apolipoproteína B: 85 mg/dL');
     expect(lipids.matches.some((m) => m.code === 'ApoB')).toBe(true);
+
+    // O token que colide com o símbolo do gene é justamente a abreviação:
+    // fora de contexto genético ela precisa continuar ancorando.
+    const abbreviated = findBiomarkersInText('ApoB: 85 mg/dL');
+    expect(abbreviated.matches.some((m) => m.code === 'ApoB')).toBe(true);
   });
 
   it('should suppress matches inside HGVS and dbSNP notation', () => {

--- a/packages/ocr-utils/src/__tests__/anchor.test.ts
+++ b/packages/ocr-utils/src/__tests__/anchor.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { findBiomarkersInText, getMatchedCodes } from '../anchor';
+import {
+  CONFIDENCE_AMBIGUOUS,
+  CONFIDENCE_NAME_ONLY,
+  CONFIDENCE_VALUE_ADJACENT,
+  findBiomarkersInText,
+  getMatchedCodes,
+} from '../anchor';
+
+/** Trecho do laudo de painel genético reportado na issue #59. */
+const GENETIC_PANEL_TEXT = `Specimen type: Blood
+APOB      NM_000384.2   Familial Hypercholesterolemia
+APC       NM_000038.5   Colorectal, Endocrine, Gastric Cancer
+This sequence change creates a premature translational stop signal
+(p.Trp448*) in the BRIP1 gene. It is expected to result in an absent
+or disrupted protein product.`;
 
 describe('findBiomarkersInText', () => {
   it('should find exact English biomarker names', () => {
@@ -92,6 +106,93 @@ describe('findBiomarkersInText', () => {
     const result = findBiomarkersInText('Hemoglobina 14.2 g/dL');
     const match = result.matches.find((m) => m.code === 'Hgb');
     expect(match?.position).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should anchor plural forms printed by labs', () => {
+    const result = findBiomarkersInText('Proteínas: Ausente\nCetonas: Negativo');
+    expect(result.matches.some((m) => m.code === 'Protein_Urine')).toBe(true);
+    expect(result.matches.some((m) => m.code === 'Ketones_Urine')).toBe(true);
+  });
+});
+
+describe('findBiomarkersInText — falsos positivos (issue #59)', () => {
+  it('should return zero anchors for a genetic panel report', () => {
+    const result = findBiomarkersInText(GENETIC_PANEL_TEXT);
+    expect(result.matches).toEqual([]);
+    expect(result.stats.matchedCount).toBe(0);
+    expect(result.filteredReference).toContain('NO MATCHING BIOMARKERS');
+  });
+
+  it('should require a token boundary instead of matching inside a word', () => {
+    const condition = findBiomarkersInText('Familial Hypercholesterolemia');
+    expect(condition.matches.some((m) => m.code === 'Cholesterol')).toBe(false);
+
+    const cancer = findBiomarkersInText('Colorectal, Endocrine, Gastric Cancer');
+    expect(cancer.matches.some((m) => m.code === 'Color_Urine')).toBe(false);
+  });
+
+  it('should not anchor generic names without a value on the line', () => {
+    const specimen = findBiomarkersInText('Specimen type: Blood');
+    expect(specimen.matches.some((m) => m.code === 'Blood_Urine')).toBe(false);
+
+    const prose = findBiomarkersInText('It is expected to result in a disrupted protein product');
+    expect(prose.matches.some((m) => m.code === 'Protein_Urine')).toBe(false);
+  });
+
+  it('should still anchor qualitative urine markers next to their result', () => {
+    const result = findBiomarkersInText(
+      'Cor: Amarelo Citrino\nProteínas: Ausente\nSangue Oculto: Negativo',
+    );
+    expect(result.matches.some((m) => m.code === 'Color_Urine')).toBe(true);
+    expect(result.matches.some((m) => m.code === 'Protein_Urine')).toBe(true);
+    expect(result.matches.some((m) => m.code === 'Blood_Urine')).toBe(true);
+  });
+
+  it('should suppress a gene symbol that collides with a biomarker name', () => {
+    const genetic = findBiomarkersInText('APOB   NM_000384.2   Familial Hypercholesterolemia');
+    expect(genetic.matches.some((m) => m.code === 'ApoB')).toBe(false);
+
+    const lipids = findBiomarkersInText('Apolipoproteína B: 85 mg/dL');
+    expect(lipids.matches.some((m) => m.code === 'ApoB')).toBe(true);
+  });
+
+  it('should suppress matches inside HGVS and dbSNP notation', () => {
+    const hgvs = findBiomarkersInText('Blood 2 variants: c.1234A>G and rs4149056 detected');
+    expect(hgvs.matches.some((m) => m.code === 'Blood_Urine')).toBe(false);
+  });
+
+  it('should let the longest name win when matches overlap', () => {
+    const hdl = findBiomarkersInText('HDL Cholesterol 55 mg/dL');
+    expect(hdl.matches.some((m) => m.code === 'HDL')).toBe(true);
+    expect(hdl.matches.some((m) => m.code === 'Cholesterol')).toBe(false);
+
+    const bloodGlucose = findBiomarkersInText('Blood Glucose 95 mg/dL');
+    expect(bloodGlucose.matches.some((m) => m.code === 'Glucose')).toBe(true);
+    expect(bloodGlucose.matches.some((m) => m.code === 'Blood_Urine')).toBe(false);
+
+    const total = findBiomarkersInText('Colesterol Total: 195 mg/dL');
+    expect(total.matches.some((m) => m.code === 'Cholesterol')).toBe(true);
+  });
+
+  it('should not merge two biomarkers listed on consecutive lines into one name', () => {
+    const result = findBiomarkersInText('PERFIL LIPÍDICO\nColesterol\nHDL\nLDL');
+    expect(getMatchedCodes(result)).toContain('Cholesterol');
+    expect(getMatchedCodes(result)).toContain('HDL');
+  });
+
+  it('should grade confidence by match quality instead of always reporting 1.0', () => {
+    const withValue = findBiomarkersInText('Glicose: 95 mg/dL');
+    expect(withValue.matches.find((m) => m.code === 'Glucose')?.confidence).toBe(
+      CONFIDENCE_VALUE_ADJACENT,
+    );
+
+    const heading = findBiomarkersInText('PERFIL LIPÍDICO\nColesterol\nHDL');
+    expect(heading.matches.find((m) => m.code === 'HDL')?.confidence).toBe(CONFIDENCE_NAME_ONLY);
+
+    const qualitative = findBiomarkersInText('Cor: Amarelo Citrino');
+    expect(qualitative.matches.find((m) => m.code === 'Color_Urine')?.confidence).toBe(
+      CONFIDENCE_AMBIGUOUS,
+    );
   });
 });
 

--- a/packages/ocr-utils/src/anchor.ts
+++ b/packages/ocr-utils/src/anchor.ts
@@ -384,6 +384,12 @@ function collectCandidates(normalizedText: string): Candidate[] {
  * Longest match wins: drop a match fully contained in a longer one, so
  * `Cholesterol` doesn't anchor inside `HDL Cholesterol` and `Blood` doesn't
  * anchor inside `Blood Glucose`.
+ *
+ * Strictly longer, not longer-or-equal: containment plus equal length means an
+ * identical span, which only happens when two distinct catalog names match the
+ * same text (a singular and its plural form, say). Dropping one of those by
+ * catalog order would silently lose a code, and losing an anchor is worse than
+ * keeping both — `findBiomarkersInText` dedups per code anyway.
  */
 function resolveOverlaps(candidates: Candidate[]): Candidate[] {
   const sorted = [...candidates].sort(

--- a/packages/ocr-utils/src/anchor.ts
+++ b/packages/ocr-utils/src/anchor.ts
@@ -4,12 +4,18 @@
  * Scans OCR text for biomarker names BEFORE sending to LLM.
  * This prevents hallucination by constraining what biomarkers
  * the LLM is allowed to extract.
+ *
+ * Matching is deliberately conservative: a name only anchors when it appears
+ * as a whole token, is not swallowed by a longer biomarker name, is not inside
+ * a genetic report line, and — for generic single-word names — sits on a line
+ * that actually carries a value.
  */
 
 import {
   type BiomarkerSearchPattern,
   generateFilteredLLMReference,
   getAllSearchPatterns,
+  UNIT_TO_UCUM,
 } from '@precisa-saude/fhir';
 
 export interface AnchorMatch {
@@ -31,17 +37,39 @@ export interface AnchorResult {
 }
 
 /**
+ * Confidence assigned to a specific biomarker name found on a line that also
+ * carries a value (a number, a unit, or an expected qualitative term).
+ */
+export const CONFIDENCE_VALUE_ADJACENT = 1.0;
+
+/**
+ * Confidence assigned to a specific biomarker name with no value evidence
+ * nearby — a section heading, or a mention in prose.
+ */
+export const CONFIDENCE_NAME_ONLY = 0.7;
+
+/**
+ * Confidence assigned to a generic/ambiguous name (`Color`, `Protein`,
+ * `Blood`, …) that only anchored because a value was found next to it.
+ */
+export const CONFIDENCE_AMBIGUOUS = 0.4;
+
+/** Cap on how many occurrences of the same name are inspected per document. */
+const MAX_OCCURRENCES_PER_NAME = 5;
+
+/**
  * Normalize text for comparison:
  * - Removes diacritics (ã→a, ç→c, é→e)
  * - Converts to lowercase
- * - Normalizes whitespace
+ * - Collapses horizontal whitespace, but KEEPS line breaks — the line is the
+ *   context window used to decide whether a match is a real biomarker mention
  */
 function normalize(text: string): string {
   return text
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
-    .replace(/\s+/g, ' ');
+    .replace(/[^\S\n]+/g, ' ');
 }
 
 const UNAMBIGUOUS_SHORT_NAMES = new Set([
@@ -80,10 +108,143 @@ const UNAMBIGUOUS_SHORT_NAMES = new Set([
   'tav',
 ]);
 
-type PatternEntry = { original: string; code: string; loinc?: string };
+/**
+ * Single-word catalog names that are ordinary words in EN/PT, so seeing them
+ * proves nothing on its own. They only anchor when the line also carries a
+ * value. Qualitative urine markers (`Color`, `Protein`, `Blood`, …) are
+ * detected automatically — see `isQualitativeUrine` — and don't belong here.
+ */
+const CONTEXT_REQUIRED_NAMES = new Set([
+  'bacteria', // Bacteria_Urine — tem unidade, escapa da regra automática
+  'bacterias', // Bacteria_Urine
+  'lead', // Lead — verbo/substantivo comuníssimo em inglês
+  'peso', // TotalMass
+  'saturation', // TransferrinSaturation — "oxygen saturation", "saturation index"
+  'tap', // ProthrombinTime — "tap" em inglês
+  'volume', // VATVolume
+  'weight', // TotalMass
+]);
+
+/**
+ * Qualitative results expected next to a non-numeric biomarker
+ * (urine dipstick, sediment, appearance). Normalized, single tokens —
+ * "não reagente" is covered by `reagente`, "não detectado" by `detectado`.
+ */
+const QUALITATIVE_VALUE_TERMS = new Set([
+  'absent',
+  'alguns',
+  'amarela',
+  'amarelo',
+  'anormal',
+  'ausencia',
+  'ausente',
+  'ausentes',
+  'citrino',
+  'claro',
+  'clear',
+  'cloudy',
+  'colorless',
+  'detectado',
+  'detected',
+  'escuro',
+  'incolor',
+  'indetectavel',
+  'limpido',
+  'moderada',
+  'moderado',
+  'negativa',
+  'negative',
+  'negativo',
+  'normais',
+  'normal',
+  'numerosos',
+  'ocasional',
+  'positiva',
+  'positive',
+  'positivo',
+  'present',
+  'presente',
+  'presentes',
+  'raras',
+  'raro',
+  'raros',
+  'reagente',
+  'trace',
+  'traces',
+  'tracos',
+  'turvo',
+  'undetectable',
+  'yellow',
+]);
+
+/**
+ * Signals that a line comes from a genetic/molecular report rather than from a
+ * panel of measured values. Gene symbols collide with biomarker names (`APOB`
+ * the gene vs. `ApoB` the lipoprotein), so the context — not a static HGNC
+ * blocklist — is what tells them apart. Blocking the token itself would break
+ * real lipid panels.
+ */
+const GENETIC_CONTEXT_PATTERNS: RegExp[] = [
+  /\b[nx][mrpc]_\d{6,}/, // RefSeq: NM_000384.2, NP_, NR_, XM_
+  /\bens[gtp]\d{6,}/, // Ensembl: ENSG00000084674
+  /\bp\.[a-z]{3}\d/, // HGVS proteína: p.Trp448*
+  /\bc\.\d+[acgt]?[>_+-]/, // HGVS codificante: c.1234A>G, c.76_78del
+  /\brs\d{4,}\b/, // dbSNP
+  /\bgenes?\b/,
+  /\bvariante?s?\b/,
+  /\bexons?\b/,
+  /\bzygosity\b/,
+  /\bzigosidade\b/,
+  /\balleles?\b/,
+  /\balelos?\b/,
+  /\bmutations?\b/,
+  /\bmutac(ao|oes)\b/,
+  /\bpathogenic/,
+  /\bpatogenic/,
+  /\bheterozyg/,
+  /\bhomozyg/,
+  /\bheterozigot/,
+  /\bhomozigot/,
+  /\bsequence change\b/,
+];
+
+const DIGIT_PATTERN = /\d/;
+
+/** Unit tokens reused from the core catalog instead of a parallel list. */
+let cachedUnitTokens: Set<string> | null = null;
+
+function getUnitTokens(): Set<string> {
+  if (!cachedUnitTokens) {
+    cachedUnitTokens = new Set(
+      Object.keys(UNIT_TO_UCUM)
+        .map((unit) => normalize(unit).trim())
+        .filter(Boolean),
+    );
+  }
+  return cachedUnitTokens;
+}
+
+interface PatternEntry {
+  ambiguous: boolean;
+  code: string;
+  loinc?: string;
+  original: string;
+}
+
+interface NamePattern {
+  entries: PatternEntry[];
+  /** Built on first use — most names never match a given document. */
+  regex: RegExp | null;
+}
+
+interface Candidate {
+  end: number;
+  entries: PatternEntry[];
+  start: number;
+}
 
 let cachedPatterns: BiomarkerSearchPattern[] | null = null;
-let cachedNormalized: Map<string, PatternEntry[]> | null = null;
+let cachedNamePatterns: Map<string, NamePattern> | null = null;
 
 function getPatterns(): BiomarkerSearchPattern[] {
   if (!cachedPatterns) {
@@ -92,76 +253,225 @@ function getPatterns(): BiomarkerSearchPattern[] {
   return cachedPatterns;
 }
 
-function getNormalizedPatterns(): Map<string, PatternEntry[]> {
-  if (!cachedNormalized) {
-    const patterns = getPatterns();
-    const map = new Map<string, PatternEntry[]>();
-    for (const pattern of patterns) {
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build a whole-token matcher for a normalized name.
+ *
+ * Lookarounds instead of `\b` because names may start or end with a non-word
+ * character (`Lp(a)`), where `\b` asserts the wrong thing.
+ *
+ * A multi-word name must sit on a single line: in the column layouts labs
+ * print, consecutive lines are separate biomarkers, and allowing a line break
+ * inside a name turns "Colesterol\nHDL" into the name "Colesterol HDL".
+ * A wrapped name still anchors through its head token when that token is a
+ * name of its own ("Colesterol\nTotal" → `Cholesterol`).
+ *
+ * The trailing optional `s` keeps the plurals labs actually print
+ * ("Proteínas", "Cetonas") anchored to the singular catalog name — without
+ * letting `proteína` match inside `proteinúria`.
+ */
+function buildNamePattern(normalizedName: string): RegExp {
+  const body = normalizedName.split(' ').map(escapeRegExp).join('[^\\S\\n]+');
+  const plural = /\p{L}$/u.test(normalizedName) ? 's?' : '';
+  return new RegExp(`(?<![\\p{L}\\p{N}])${body}${plural}(?![\\p{L}\\p{N}])`, 'gu');
+}
+
+function isQualitativeUrine(pattern: BiomarkerSearchPattern): boolean {
+  const categories = Array.isArray(pattern.category) ? pattern.category : [pattern.category];
+  return categories.includes('urina') && !pattern.unit;
+}
+
+/**
+ * A name is ambiguous when it is a single token that also reads as ordinary
+ * text. Multi-word names (`Occult Blood`, `Urine Protein`) are specific enough
+ * on their own.
+ */
+function isAmbiguousName(normalizedName: string, pattern: BiomarkerSearchPattern): boolean {
+  if (normalizedName.includes(' ')) {
+    return false;
+  }
+  return CONTEXT_REQUIRED_NAMES.has(normalizedName) || isQualitativeUrine(pattern);
+}
+
+function getNamePatterns(): Map<string, NamePattern> {
+  if (!cachedNamePatterns) {
+    const map = new Map<string, NamePattern>();
+    for (const pattern of getPatterns()) {
       for (const name of pattern.names) {
-        const normalized = normalize(name);
-        const existing = map.get(normalized) || [];
-        existing.push({
+        const normalized = normalize(name).trim();
+        if (!normalized) {
+          continue;
+        }
+        if (normalized.length < 3 && !UNAMBIGUOUS_SHORT_NAMES.has(normalized)) {
+          continue;
+        }
+        let slot = map.get(normalized);
+        if (!slot) {
+          slot = { entries: [], regex: null };
+          map.set(normalized, slot);
+        }
+        slot.entries.push({
+          ambiguous: isAmbiguousName(normalized, pattern),
           code: pattern.code,
           ...(pattern.loinc && { loinc: pattern.loinc }),
           original: name,
         });
-        map.set(normalized, existing);
       }
     }
-    cachedNormalized = map;
+    cachedNamePatterns = map;
   }
-  return cachedNormalized;
+  return cachedNamePatterns;
+}
+
+function getLineBounds(text: string, position: number): { end: number; start: number } {
+  const start = text.lastIndexOf('\n', position) + 1;
+  const nextBreak = text.indexOf('\n', position);
+  return { end: nextBreak === -1 ? text.length : nextBreak, start };
+}
+
+function hasGeneticContext(line: string): boolean {
+  return GENETIC_CONTEXT_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+/**
+ * Does this line carry something that looks like a measured result?
+ * A digit, a known unit, or an expected qualitative term.
+ */
+function hasValueEvidence(line: string): boolean {
+  if (DIGIT_PATTERN.test(line)) {
+    return true;
+  }
+  const unitTokens = getUnitTokens();
+  for (const token of line.split(/[^\p{L}\p{N}%/]+/u)) {
+    if (token && (unitTokens.has(token) || QUALITATIVE_VALUE_TERMS.has(token))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Cheap pre-filter before the (much costlier) boundary regex.
+ *
+ * Sound because `normalize` collapses horizontal whitespace to a single space
+ * and a name never spans a line break: whenever the pattern can match, the
+ * literal name is a substring of the text.
+ */
+function collectCandidates(normalizedText: string): Candidate[] {
+  const candidates: Candidate[] = [];
+  for (const [name, slot] of getNamePatterns()) {
+    if (!normalizedText.includes(name)) {
+      continue;
+    }
+    const { entries } = slot;
+    const regex = (slot.regex ??= buildNamePattern(name));
+    regex.lastIndex = 0;
+    let occurrences = 0;
+    let match = regex.exec(normalizedText);
+    while (match !== null && occurrences < MAX_OCCURRENCES_PER_NAME) {
+      candidates.push({ end: match.index + match[0].length, entries, start: match.index });
+      occurrences += 1;
+      match = regex.exec(normalizedText);
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Longest match wins: drop a match fully contained in a longer one, so
+ * `Cholesterol` doesn't anchor inside `HDL Cholesterol` and `Blood` doesn't
+ * anchor inside `Blood Glucose`.
+ */
+function resolveOverlaps(candidates: Candidate[]): Candidate[] {
+  const sorted = [...candidates].sort(
+    (a, b) => b.end - b.start - (a.end - a.start) || a.start - b.start,
+  );
+  const accepted: Candidate[] = [];
+  for (const candidate of sorted) {
+    const length = candidate.end - candidate.start;
+    const swallowed = accepted.some(
+      (other) =>
+        other.start <= candidate.start &&
+        candidate.end <= other.end &&
+        other.end - other.start > length,
+    );
+    if (!swallowed) {
+      accepted.push(candidate);
+    }
+  }
+  return accepted;
 }
 
 /**
  * Find all biomarker names present in OCR text.
- * Uses exact string matching on normalized text.
- * Returns unique matches (same biomarker won't be matched twice).
+ *
+ * Matching is whole-token, longest-match-wins, and context-aware: matches
+ * inside genetic report lines are discarded, and generic names only anchor
+ * when a value sits on the same line. Returns one match per biomarker code —
+ * the highest-confidence occurrence.
  */
 export function findBiomarkersInText(ocrText: string): AnchorResult {
   const startTime = Date.now();
   const normalizedText = normalize(ocrText);
-  const matchedCodes = new Set<string>();
-  const matches: AnchorMatch[] = [];
-  const normalizedPatterns = getNormalizedPatterns();
+  const bestByCode = new Map<string, AnchorMatch>();
+  const geneticLines = new Map<number, boolean>();
+  const valueLines = new Map<number, boolean>();
 
-  for (const [normalizedName, entries] of normalizedPatterns) {
-    if (normalizedName.length < 3 && !UNAMBIGUOUS_SHORT_NAMES.has(normalizedName)) {
+  for (const candidate of resolveOverlaps(collectCandidates(normalizedText))) {
+    const { end: lineEnd, start: lineStart } = getLineBounds(normalizedText, candidate.start);
+
+    let genetic = geneticLines.get(lineStart);
+    if (genetic === undefined) {
+      genetic = hasGeneticContext(normalizedText.slice(lineStart, lineEnd));
+      geneticLines.set(lineStart, genetic);
+    }
+    if (genetic) {
       continue;
     }
 
-    let position = -1;
-    if (normalizedName.length <= 4) {
-      const regex = new RegExp(`\\b${normalizedName}\\b`);
-      const match = regex.exec(normalizedText);
-      if (match) {
-        position = match.index;
-      }
-    } else {
-      position = normalizedText.indexOf(normalizedName);
+    let hasValue = valueLines.get(lineStart);
+    if (hasValue === undefined) {
+      hasValue = hasValueEvidence(normalizedText.slice(lineStart, lineEnd));
+      valueLines.set(lineStart, hasValue);
     }
 
-    if (position !== -1) {
-      for (const entry of entries) {
-        if (!matchedCodes.has(entry.code)) {
-          matchedCodes.add(entry.code);
-          matches.push({
-            code: entry.code,
-            confidence: 1.0,
-            loinc: entry.loinc,
-            matchedName: entry.original,
-            position,
-          });
-        }
+    for (const entry of candidate.entries) {
+      if (entry.ambiguous && !hasValue) {
+        continue;
+      }
+
+      let confidence = CONFIDENCE_NAME_ONLY;
+      if (entry.ambiguous) {
+        confidence = CONFIDENCE_AMBIGUOUS;
+      } else if (hasValue) {
+        confidence = CONFIDENCE_VALUE_ADJACENT;
+      }
+
+      const existing = bestByCode.get(entry.code);
+      const better =
+        !existing ||
+        confidence > existing.confidence ||
+        (confidence === existing.confidence && candidate.start < existing.position);
+      if (better) {
+        bestByCode.set(entry.code, {
+          code: entry.code,
+          confidence,
+          loinc: entry.loinc,
+          matchedName: entry.original,
+          position: candidate.start,
+        });
       }
     }
   }
 
+  const matches = Array.from(bestByCode.values()).sort((a, b) => a.position - b.position);
   const scanTimeMs = Date.now() - startTime;
-  const matchedCodesArray = Array.from(matchedCodes);
 
   return {
-    filteredReference: generateFilteredLLMReference(matchedCodesArray),
+    filteredReference: generateFilteredLLMReference(matches.map((m) => m.code)),
     matches,
     stats: {
       matchedCount: matches.length,

--- a/packages/ocr-utils/src/index.ts
+++ b/packages/ocr-utils/src/index.ts
@@ -1,2 +1,8 @@
 export type { AnchorMatch, AnchorResult } from './anchor';
-export { findBiomarkersInText, getMatchedCodes } from './anchor';
+export {
+  CONFIDENCE_AMBIGUOUS,
+  CONFIDENCE_NAME_ONLY,
+  CONFIDENCE_VALUE_ADJACENT,
+  findBiomarkersInText,
+  getMatchedCodes,
+} from './anchor';


### PR DESCRIPTION
## Problema

`findBiomarkersInText()` casava **substrings** para qualquer nome com 5+
caracteres (`normalizedText.indexOf(name)`), sem fronteira de token nem
qualquer evidência de que o trecho fosse a menção de um biomarcador
**medido**.

O laudo de painel genético da issue #59 — sem nenhum valor numérico,
unidade ou faixa de referência — produzia 5 âncoras, todas com
`confidence: 1.0`:

| Código          | Veio de                              |
| --------------- | ------------------------------------ |
| `ApoB`          | símbolo do gene `APOB`               |
| `Cholesterol`   | "Familial Hyper**cholesterol**emia"  |
| `Color_Urine`   | "**Color**ectal Cancer"              |
| `Protein_Urine` | "disrupted **protein** product"      |
| `Blood_Urine`   | "Specimen type: **Blood**"           |

Falso positivo aqui é caro: a âncora decide qual referência de
biomarcadores entra no prompt do LLM. Um documento sem biomarcador algum
ia ao modelo com uma referência sem sentido, convidando-o a preencher
valores inexistentes — e `confidence: 1.0` comunicava certeza onde não
havia nenhuma.

Não era específico de laudo genético: **qualquer** texto contendo
"protein", "Blood" ou "Colorectal" ancorava.

## Solução

### `@precisa-saude/fhir` (core)

`BiomarkerSearchPattern` passa a expor `category` e `unit` — campos
opcionais e aditivos. Sem eles a camada de ancoragem não tinha como
distinguir um biomarcador quantitativo de um qualitativo.

### `@precisa-saude/fhir-ocr-utils`

- **Fronteira de token** por lookaround (`\b` falharia em nomes como
  `Lp(a)`), com plural opcional para os plurais que os laboratórios
  imprimem ("Proteínas", "Cetonas") — sem deixar `proteína` casar dentro
  de `proteinúria`.
- **Nome mais longo vence** em sobreposição: "HDL Cholesterol" ancora
  `HDL`, não `Cholesterol`; "Blood Glucose" ancora `Glucose`, não
  `Blood_Urine`.
- **Nome composto não atravessa quebra de linha** — nos layouts em coluna
  dos laudos, linhas consecutivas são biomarcadores distintos, então
  "Colesterol\nHDL" não vira o nome "Colesterol HDL".
- **Co-ocorrência de valor para nomes genéricos** — nomes que também são
  palavras comuns só ancoram se a linha carregar número, unidade
  conhecida ou termo qualitativo esperado. A regra é derivada de
  `category: 'urina'` + ausência de `unit`, então acompanha o catálogo;
  uma lista curta e comentada cobre os genéricos fora de urina
  (`volume`, `peso`, `lead`, …).
- **Contexto genético é descartado** — linhas com acesso RefSeq
  (`NM_000384.2`), HGVS (`p.Trp448*`, `c.1234A>G`), `rs` do dbSNP ou
  vocabulário de laudo genético não ancoram. É o contexto que separa o
  gene `APOB` da lipoproteína `ApoB`; banir o token quebraria laudos
  lipídicos reais.
- **`confidence` graduada** no lugar do `1.0` fixo:

  | Valor | Constante                   | Significado                                     |
  | ----- | --------------------------- | ----------------------------------------------- |
  | `1.0` | `CONFIDENCE_VALUE_ADJACENT` | Nome específico com valor na mesma linha        |
  | `0.7` | `CONFIDENCE_NAME_ONLY`      | Nome específico sem valor por perto             |
  | `0.4` | `CONFIDENCE_AMBIGUOUS`      | Nome genérico que só ancorou pelo valor ao lado |

## Verificação

**Antes → depois** no texto da issue:

```
ANTES:  5 âncoras @ 1.00 (ApoB, Cholesterol, Blood_Urine, Color_Urine, Protein_Urine)
DEPOIS: 0 âncoras
```

**Recall sem regressão.** Laudo laboratorial completo (hemograma +
lipídico + bioquímica + urina) pela CLI, antes e depois: os **mesmos 18
códigos**.

**Performance.** A correspondência com regex custava ~110 ms na primeira
chamada. Um pré-filtro `indexOf` (correto porque um nome nunca atravessa
quebra de linha e os espaços já vêm normalizados) mais construção
preguiçosa das regex trouxe para ~3 ms a frio e ~0,05 ms a quente.

**Testes.** Os 14 testes existentes passam sem edição — nenhum precisou
ser ajustado. 10 novos cobrem a reprodução exata da issue, fronteira de
token, gate de valor, positivos qualitativos de urina preservados,
supressão de contexto genético, sobreposição e as faixas de confiança.
Cobertura de branches de `anchor.ts` em 97,4% (limite 80%).

`pnpm turbo run lint typecheck test` — 583 testes, tudo verde.

Closes #59
