### PR TITLE
fix(ci): completa o .precisa.json para o doctor voltar a auditar

### DIFF
--- a/.precisa.json
+++ b/.precisa.json
@@ -12,5 +12,13 @@
     "conduct": "conduct@precisa-saude.com.br"
   },
   "nodeVersion": "22",
-  "pnpmVersion": "9.15.9"
+  "pnpmVersion": "9.15.9",
+  "publishPackages": [
+    "packages/core",
+    "packages/ocr-utils",
+    "packages/rnds",
+    "packages/rnds-sandbox"
+  ],
+  "siteFilter": "@fhir-brasil/site",
+  "siteProjectName": "fhir-brasil"
 }


### PR DESCRIPTION
O `.precisa.json` deste repo não validava contra o schema do `@precisa-saude/cli`, então `precisa doctor` abortava na validação e **não comparava template nenhum**.

Diagnóstico completo em Precisa-Saude/tooling#42: as issues mensais de "template drift" eram falso-positivo (o CLI não está instalado em nenhum repo), e o `doctor` também só saía não-zero em arquivo ausente — drift de conteúdo passava verde. Ambos corrigidos lá; este PR desbloqueia a auditoria aqui.

Depois de mergear, o `doctor` passa a rodar e a reportar o drift real deste repo.