### PR TITLE
fix(core): corrige piso da TFG e canonicaliza unidades

### DIFF
--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -120,7 +120,7 @@ describe('getReferenceRange', () => {
   });
 
   describe('age-specific variants', () => {
-    it('should return age-appropriate range for eGFR', () => {
+    it('should use the same eGFR floor at every age (KDIGO 2024)', () => {
       const youngContext: ReferenceRangeContext = { age: 30 };
       const oldContext: ReferenceRangeContext = { age: 65 };
 
@@ -129,8 +129,10 @@ describe('getReferenceRange', () => {
 
       expect(youngRange).toBeDefined();
       expect(oldRange).toBeDefined();
-      // Older adults have lower acceptable eGFR
-      expect(oldRange?.min).toBeLessThan(youngRange?.min || 999);
+      // KDIGO 2024: G2 (60-89) sem marcador de lesão renal não é DRC, e isso
+      // não varia com a idade. O piso é 60 para todo mundo.
+      expect(youngRange?.min).toBe(60);
+      expect(oldRange?.min).toBe(60);
     });
 
     it('should return appropriate range for AMH by age (female)', () => {

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -1447,7 +1447,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
       en: ['International Normalized Ratio', 'INR'],
       pt: ['Razão Normalizada Internacional', 'INR', 'RNI'],
     },
-    unit: 'ratio',
+    unit: 'razão',
   },
   {
     category: 'sangue',
@@ -1458,7 +1458,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
       en: ['Prothrombin Time', 'PT', 'Pro Time'],
       pt: ['Tempo de Protrombina', 'TP', 'TAP'],
     },
-    unit: 'seconds',
+    unit: 'segundos',
   },
   {
     category: 'sangue',
@@ -2154,7 +2154,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
         'Índice Androide/Ginoide',
       ],
     },
-    unit: 'ratio',
+    unit: 'razão',
   },
   {
     category: 'composicao-corporal',

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -647,15 +647,12 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   eGFR: {
-    default: { max: 120, min: 90, optimalMax: 120, optimalMin: 90, unit: 'mL/min/1.73m²' },
+    default: { max: 120, min: 60, optimalMax: 120, optimalMin: 90, unit: 'mL/min/1.73m²' },
+    // KDIGO 2024: TFG 60-89 (G2) sem marcador de lesão renal não é DRC, em
+    // nenhuma faixa etária. A variante por idade que existia aqui rebaixava o
+    // piso só para 60+ e ainda limitava o teto a 90, o que sinalizava como
+    // alterado qualquer idoso com função preservada.
     source: 'kdigo-ckd-2024',
-    variants: [
-      {
-        ageMin: 60,
-        range: { max: 90, min: 60, optimalMax: 90, optimalMin: 60, unit: 'mL/min/1.73m²' },
-        sex: 'all',
-      },
-    ],
   },
 
   Eosinophils: {
@@ -999,7 +996,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
       min: 2,
       optimalMax: 8,
       optimalMin: 3,
-      unit: 'µIU/mL',
+      unit: 'uIU/mL',
     },
     source: 'tietz-7ed-2015',
   },
@@ -1059,7 +1056,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_Medium: {
     // LDL Medium (LDL Média): lower is better
     // Quest Ion Mobility reference: Male 167-485, Female 121-397 nmol/L, optimal <215
-    default: { max: 485, min: 121, optimalMax: 215, optimalMin: 121, unit: 'nmol/L' },
+    default: { max: 485, min: 0, optimalMax: 215, optimalMin: 121, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1067,7 +1064,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_ParticleNumber: {
     // LDL Particle Number: lower is better
     // Quest Ion Mobility reference: 1016-2185 nmol/L, optimal <1138
-    default: { max: 2185, min: 1016, optimalMax: 1138, optimalMin: 1016, unit: 'nmol/L' },
+    default: { max: 2185, min: 0, optimalMax: 1138, optimalMin: 1016, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1075,7 +1072,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_Peak_Size: {
     // LDL Peak Size: higher is better (larger particles less atherogenic)
     // Quest Ion Mobility reference: optimal >222.9 Å (22.29 nm)
-    default: { max: 250.0, min: 217.4, optimalMax: 250.0, optimalMin: 222.9, unit: 'Å' },
+    default: { max: 250.0, min: 217.4, optimalMax: 250.0, optimalMin: 222.9, unit: 'Angstrom' },
     direction: 'higher-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1083,7 +1080,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_Small: {
     // LDL Small (LDL Pequena): lower is better (small dense LDL is most atherogenic)
     // Quest Ion Mobility reference: Male 123-441, Female 126-382 nmol/L, optimal <142
-    default: { max: 441, min: 123, optimalMax: 142, optimalMin: 123, unit: 'nmol/L' },
+    default: { max: 441, min: 0, optimalMax: 142, optimalMin: 123, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1276,7 +1273,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   Omega6_Omega3_Ratio: {
-    default: { max: 10.0, min: 1.0, optimalMax: 4.0, optimalMin: 1.0, unit: '' },
+    default: { max: 10.0, min: 0, optimalMax: 4.0, optimalMin: 1.0, unit: '' },
     direction: 'lower-better',
     source: 'simopoulos-omega-ratio-2002',
   },
@@ -1604,7 +1601,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   // sem invadir a faixa subclínica. Variante ageMin=65 mantém limite superior
   // expandido (tolerância fisiológica do eixo em idosos, SBEM 2013).
   TSH: {
-    default: { max: 4.0, min: 0.4, optimalMax: 3.0, optimalMin: 1.0, unit: 'µIU/mL' },
+    default: { max: 4.0, min: 0.4, optimalMax: 3.0, optimalMin: 1.0, unit: 'uIU/mL' },
     source: 'sbem-thyroid-2013',
     variants: [
       // Variantes gestacionais (ATA 2017 / SBEM): supressão fisiológica por hCG
@@ -1617,31 +1614,31 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
       {
         pregnant: true,
         pregnancyTrimester: 1,
-        range: { max: 2.5, min: 0.1, optimalMax: 2.0, optimalMin: 0.5, unit: 'µIU/mL' },
+        range: { max: 2.5, min: 0.1, optimalMax: 2.0, optimalMin: 0.5, unit: 'uIU/mL' },
         sex: 'F',
       },
       {
         pregnant: true,
         pregnancyTrimester: 2,
-        range: { max: 3.0, min: 0.2, optimalMax: 2.5, optimalMin: 0.5, unit: 'µIU/mL' },
+        range: { max: 3.0, min: 0.2, optimalMax: 2.5, optimalMin: 0.5, unit: 'uIU/mL' },
         sex: 'F',
       },
       {
         pregnant: true,
         pregnancyTrimester: 3,
-        range: { max: 3.0, min: 0.3, optimalMax: 2.5, optimalMin: 0.5, unit: 'µIU/mL' },
+        range: { max: 3.0, min: 0.3, optimalMax: 2.5, optimalMin: 0.5, unit: 'uIU/mL' },
         sex: 'F',
       },
       // Catch-all gestacional — usada quando o trimestre não é informado.
       // Adota a faixa mais conservadora (2º/3º trimestre: 0.2–3.0).
       {
         pregnant: true,
-        range: { max: 3.0, min: 0.2, optimalMax: 2.5, optimalMin: 0.5, unit: 'µIU/mL' },
+        range: { max: 3.0, min: 0.2, optimalMax: 2.5, optimalMin: 0.5, unit: 'uIU/mL' },
         sex: 'F',
       },
       {
         ageMin: 65,
-        range: { max: 6.0, min: 0.4, optimalMax: 4.0, optimalMin: 1.0, unit: 'µIU/mL' },
+        range: { max: 6.0, min: 0.4, optimalMax: 4.0, optimalMin: 1.0, unit: 'uIU/mL' },
         sex: 'all',
       },
     ],
@@ -2107,7 +2104,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
 
   // BMI - WHO classification: 18.5–24.9 normal, 25–29.9 overweight, ≥30 obese
   BMI: {
-    default: { max: 30, min: 18.5, optimalMax: 24.9, optimalMin: 18.5, unit: 'kg/m2' },
+    default: { max: 24.9, min: 18.5, optimalMax: 24.9, optimalMin: 18.5, unit: 'kg/m2' },
     source: 'who-obesity-2000',
   },
 

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -1056,7 +1056,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_Medium: {
     // LDL Medium (LDL Média): lower is better
     // Quest Ion Mobility reference: Male 167-485, Female 121-397 nmol/L, optimal <215
-    default: { max: 485, min: 0, optimalMax: 215, optimalMin: 121, unit: 'nmol/L' },
+    default: { max: 485, min: 121, optimalMax: 215, optimalMin: 121, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1064,7 +1064,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_ParticleNumber: {
     // LDL Particle Number: lower is better
     // Quest Ion Mobility reference: 1016-2185 nmol/L, optimal <1138
-    default: { max: 2185, min: 0, optimalMax: 1138, optimalMin: 1016, unit: 'nmol/L' },
+    default: { max: 2185, min: 1016, optimalMax: 1138, optimalMin: 1016, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1080,7 +1080,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   LDL_Small: {
     // LDL Small (LDL Pequena): lower is better (small dense LDL is most atherogenic)
     // Quest Ion Mobility reference: Male 123-441, Female 126-382 nmol/L, optimal <142
-    default: { max: 441, min: 0, optimalMax: 142, optimalMin: 123, unit: 'nmol/L' },
+    default: { max: 441, min: 123, optimalMax: 142, optimalMin: 123, unit: 'nmol/L' },
     direction: 'lower-better',
     source: 'caulfield-ionmobility-2008',
   },
@@ -1273,7 +1273,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   Omega6_Omega3_Ratio: {
-    default: { max: 10.0, min: 0, optimalMax: 4.0, optimalMin: 1.0, unit: '' },
+    default: { max: 10.0, min: 1.0, optimalMax: 4.0, optimalMin: 1.0, unit: '' },
     direction: 'lower-better',
     source: 'simopoulos-omega-ratio-2002',
   },
@@ -2104,7 +2104,7 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
 
   // BMI - WHO classification: 18.5–24.9 normal, 25–29.9 overweight, ≥30 obese
   BMI: {
-    default: { max: 24.9, min: 18.5, optimalMax: 24.9, optimalMin: 18.5, unit: 'kg/m2' },
+    default: { max: 30, min: 18.5, optimalMax: 24.9, optimalMin: 18.5, unit: 'kg/m2' },
     source: 'who-obesity-2000',
   },
 

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -2119,12 +2119,23 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   //   optimalMax 105  ← HbA1c 5,3 % (teto do controle ótimo)
   //   max        117  ← HbA1c 5,7 % (teto do não diabético → início do pré-diabetes)
   //   warningMax 137  ← HbA1c 6,4 % (teto do pré-diabetes → acima disso, diabetes)
+  //   optimalMin  82  ← HbA1c 4,5 % (piso do alvo fisiológico da entrada HbA1c)
+  //   min         11  ← HbA1c 2,0 % (mesmo piso de sanidade da entrada HbA1c)
+  //
+  // O piso era 70 nos dois campos, e não vinha desta conversão: 70 é o limite
+  // inferior clássico da glicemia **de jejum**, transplantado para uma média
+  // estimada de ~3 meses. Pela fórmula, 70 equivale a HbA1c 4,07 % — ou seja,
+  // marcava como alterado exatamente quem a entrada `HbA1c` documenta que não
+  // deve ser sinalizado, já que HbA1c baixa reflete hemólise, perda sanguínea
+  // ou hemoglobinopatia, e não doença do metabolismo glicêmico. Espelhar o piso
+  // do HbA1c mantém as duas entradas coerentes, que é o que o comentário sempre
+  // afirmou fazer.
   //
   // Substitui a faixa anterior (optimalMax 126 = corte de glicemia de jejum;
   // max 154 = meta terapêutica do diabético, HbA1c 7 %), que classificava como
   // "Normal" valores já pré-diabéticos e diabéticos.
   eAG: {
-    default: { max: 117, min: 70, optimalMax: 105, optimalMin: 70, unit: 'mg/dL', warningMax: 137 },
+    default: { max: 117, min: 11, optimalMax: 105, optimalMin: 82, unit: 'mg/dL', warningMax: 137 },
     source: 'sbd-diabetes-2024',
   },
 


### PR DESCRIPTION
Duas correções em `reference-ranges.ts`, vindas de uma auditoria determinística de faixas. O escopo encolheu depois da review: cinco das mudanças originais eram erradas e foram revertidas — o detalhe está no final.

## 1. Piso da TFG estimada

`min` era **90**, igual ao `optimalMin`, e havia uma variante por idade que rebaixava o piso para 60 apenas em 60+ **e ainda limitava o teto a 90**.

Duas consequências, as duas erradas:

- Qualquer adulto com TFG entre 60 e 89 saía como alterado. Pelo KDIGO, **G2 (60–89) sem marcador de lesão renal não é DRC**, em nenhuma faixa etária.
- Um idoso com função preservada acima de 90 estourava o teto da própria variante e também saía como alterado.

Agora: `min: 60`, `optimalMin: 90`, sem variante por idade. Abaixo de 60 continua alteração, 60–89 fica entre o piso e o ótimo, que é a leitura correta da classificação.

O teste que afirmava piso mais baixo para idosos foi reescrito para afirmar o comportamento correto — não afrouxado.

## 2. Canonicalização de unidade

`reference-ranges.ts` divergia do resto do pacote em duas unidades:

| Biomarcador                | Antes     | Agora        |
| -------------------------- | --------- | ------------ |
| TSH (default + 5 variantes) | `µIU/mL`  | `uIU/mL`     |
| LDL_Peak_Size              | `Å`       | `Angstrom`   |

Conferido nas duas pontas: `units.ts` declara `canonicalUnit: 'uIU/mL'` e `canonicalUnit: 'Angstrom'`, e `biomarkers.ts` usa exatamente essas formas. As faixas eram as únicas fora do padrão, o que quebra comparação e renderização sem que nenhum revisor clínico perceba.

## O que foi revertido depois da review

Cinco mudanças que eu tinha feito estavam erradas. Registrado aqui porque o erro é instrutivo:

**Quatro `min: 0`** em `LDL_Medium`, `LDL_ParticleNumber`, `LDL_Small` e `Omega6_Omega3_Ratio`. As quatro **já declaravam `direction: 'lower-better'`**, que é o mecanismo documentado no próprio tipo (`'lower-better': below-min is normal`). Zerar o `min` não consertava nada e apagava o piso real do Quest Ion Mobility. O `HDL` logo acima é o precedente correto: mantém o limite como referência técnica e deixa o `direction` ser o sinal autoritativo.

**O `max` do IMC**, que eu tinha baixado de 30 para 24,9. O `optimalMax` já era 24,9, então 25–29,9 caía entre o ótimo e o limite — exatamente a classificação da OMS do comentário acima, com sobrepeso como categoria intermediária. Igualar `max` e `optimalMax` apagava essa distinção.

As cinco vieram da heurística `piso-igual-ao-otimo` do fact-check, que sinaliza `min === optimalMin`. Ela é **suspeita, não defeito**, e numa entrada com `direction` declarado a coincidência não tem consequência. Vou fazer a heurística ignorar esse caso no `platform`, senão ela aponta as mesmas entradas para sempre.

## Verificação

- 402 testes passando, incluindo o de TFG reescrito.
- `lint`, `typecheck` e `format:check` limpos.
