### PR TITLE
feat(ci): confere os códigos LOINC contra a fonte oficial

### DIFF
--- a/.github/workflows/loinc-check.yml
+++ b/.github/workflows/loinc-check.yml
@@ -1,0 +1,91 @@
+name: LOINC
+
+# Agendado, e não por PR. O check precisa de credencial e de rede: em todo PR
+# ficaria lento e instável, e secret não é exposto a PR de fork em repo público.
+# O LOINC está migrando para release mensal, então o cron acompanha a cadência
+# do que está sendo observado.
+on:
+  schedule:
+    # Dia 5, 06:00 UTC — depois da virada do mês, sem cair no pico da meia-noite.
+    - cron: '0 6 5 * *'
+  workflow_dispatch:
+    inputs:
+      update:
+        description: 'Regravar o snapshot e abrir PR com a mudança'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Códigos LOINC
+    if: ${{ !inputs.update }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Conferir códigos contra o fhir.loinc.org
+        env:
+          LOINC_USER: ${{ secrets.LOINC_USER }}
+          LOINC_PASSWORD: ${{ secrets.LOINC_PASSWORD }}
+        run: |
+          code=0
+          pnpm loinc:check || code=$?
+          # 2 é "não deu para conferir" — LOINC fora do ar, rede bloqueada,
+          # credencial recusada. Indisponibilidade de terceiro não pode virar
+          # falha nossa, mas também não pode passar por sucesso silencioso.
+          if [ "$code" = "2" ]; then
+            echo "::warning::LOINC indisponível; códigos não verificados nesta execução"
+            exit 0
+          fi
+          exit "$code"
+
+  update:
+    name: Regravar snapshot
+    if: ${{ inputs.update }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Regravar o snapshot
+        env:
+          LOINC_USER: ${{ secrets.LOINC_USER }}
+          LOINC_PASSWORD: ${{ secrets.LOINC_PASSWORD }}
+        run: pnpm loinc:update
+      # Aceitar deriva é PR revisado, nunca commit automático na main: uma
+      # mudança de nome upstream pode significar que o código deixou de servir
+      # para o analito, e isso precisa de olho humano.
+      - name: Abrir PR com o snapshot novo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- scripts/loinc-snapshot.json; then
+            echo "::notice::Snapshot já estava atualizado; nada a propor."
+            exit 0
+          fi
+          branch="chore/loinc-snapshot-$(date -u +%Y%m%d%H%M)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add scripts/loinc-snapshot.json
+          git commit -m "chore(core): atualiza o snapshot de códigos LOINC" \
+            -m "Gerado por workflow_dispatch em modo update. Conferir cada mudança de nome ou status antes de aprovar: nome novo pode significar que o código deixou de servir para o analito."
+          git push -u origin "$branch"
+          gh pr create --fill --base main --head "$branch"

--- a/.github/workflows/loinc-check.yml
+++ b/.github/workflows/loinc-check.yml
@@ -18,6 +18,13 @@ on:
 permissions:
   contents: read
 
+# Uma execução por vez. O modo update não escreve na main — abre PR — então
+# duas execuções simultâneas não corrompem nada, mas abririam dois PRs com o
+# mesmo conteúdo e gastariam o dobro de chamadas ao LOINC à toa.
+concurrency:
+  group: loinc-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check:
     name: Códigos LOINC

--- a/README.md
+++ b/README.md
@@ -197,6 +197,22 @@ Este software é fornecido para fins informativos e educacionais. **Não substit
 
 [Apache License 2.0](LICENSE)
 
+O código deste repositório é Apache-2.0. O catálogo de biomarcadores incorpora
+códigos LOINC, que têm licença própria — permissiva e sem custo, mas com aviso
+exigido:
+
+> This material contains content from LOINC (http://loinc.org). LOINC is
+> copyright © Regenstrief Institute, Inc. and the Logical Observation
+> Identifiers Names and Codes (LOINC) Committee and is available at no cost
+> under the license at http://loinc.org/license. LOINC® is a registered United
+> States trademark of Regenstrief Institute, Inc.
+
+O nome oficial de cada código fica em
+[`scripts/loinc-snapshot.json`](scripts/loinc-snapshot.json), que a seção 10.3
+da licença exige acompanhar o código sempre que ele é redistribuído. O
+`pnpm loinc:check` confere esse arquivo contra o servidor oficial — veja
+[`scripts/README.md`](scripts/README.md).
+
 ---
 
 Mantido por [Precisa Saúde](https://precisa-saude.com.br)

--- a/ig/sushi-config.yaml
+++ b/ig/sushi-config.yaml
@@ -19,6 +19,15 @@ contact:
         value: contato@precisa-saude.com.br
 jurisdiction: urn:iso:std:iso:3166#BR "Brazil"
 license: Apache-2.0
+# Exigido pela seção 10.1 da licença do LOINC: onde o produto é publicado como
+# recurso online, o aviso precisa estar disponível na licença ou nos termos de
+# uso. O IG publica códigos LOINC no BRLabTestVS.
+copyright: >-
+  This material contains content from LOINC (http://loinc.org). LOINC is
+  copyright © Regenstrief Institute, Inc. and the Logical Observation
+  Identifiers Names and Codes (LOINC) Committee and is available at no cost
+  under the license at http://loinc.org/license. LOINC® is a registered United
+  States trademark of Regenstrief Institute, Inc.
 description: >-
   Implementation Guide brasileiro com perfis FHIR R4 para resultados
   laboratoriais, incluindo definições de biomarcadores, faixas de

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "turbo run lint",
+    "loinc:check": "node --experimental-strip-types scripts/verify-loinc.ts",
+    "loinc:update": "node --experimental-strip-types scripts/verify-loinc.ts --update",
     "prepare": "husky",
     "release": "semantic-release",
     "test": "turbo run test",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -101,3 +101,14 @@ Este pacote fornece ferramentas de software para padronização de dados clínic
 ## Licença
 
 [Apache-2.0](../../LICENSE)
+
+### Conteúdo LOINC
+
+Este pacote incorpora códigos LOINC, que têm licença própria — permissiva e sem
+custo, mas com aviso exigido:
+
+> This material contains content from LOINC (http://loinc.org). LOINC is
+> copyright © Regenstrief Institute, Inc. and the Logical Observation
+> Identifiers Names and Codes (LOINC) Committee and is available at no cost
+> under the license at http://loinc.org/license. LOINC® is a registered United
+> States trademark of Regenstrief Institute, Inc.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,100 @@
+# Scripts
+
+Ferramentas de manutenção do catálogo. Nenhuma faz parte do pacote publicado.
+
+## verify-loinc.ts
+
+Confere os códigos LOINC do catálogo contra o servidor oficial
+(`https://fhir.loinc.org`).
+
+```bash
+pnpm loinc:check     # compara o vivo com o snapshot versionado
+pnpm loinc:update    # regrava o snapshot a partir do vivo
+```
+
+Precisa de `LOINC_USER` e `LOINC_PASSWORD` (conta gratuita em
+[loinc.org/get-started](https://loinc.org/get-started/)). No CI vêm dos secrets
+do repositório.
+
+### O que o check garante
+
+1. **Existência** — o código resolve no servidor oficial. Pega erro de digitação
+   e código que o LOINC aposentou.
+2. **Deriva** — o nome oficial ou o status mudaram no LOINC desde que mapeamos.
+   É o que realmente paga: transforma uma edição silenciosa de terceiro em check
+   vermelho, em vez de descobrir meses depois.
+
+Status `DEPRECATED` ou `DISCOURAGED` falha alto.
+
+### O que o check NÃO garante
+
+**Adequação semântica.** Se `43583-4` é o código _certo_ para Lipoproteína (a) —
+property, timing, system, scale, method conferindo com o que medimos — é revisão
+humana, e nenhum check verde diz que os mapeamentos estão corretos.
+
+Não confunda uma coisa com a outra. O check passar significa que os códigos
+existem e não mudaram, não que estão certos.
+
+### Códigos de saída
+
+| Código | Significado                                                                   |
+| ------ | ----------------------------------------------------------------------------- |
+| `0`    | Tudo confere com o snapshot                                                   |
+| `1`    | Achado real: código não resolve, status proibido, deriva, ou fora do snapshot |
+| `2`    | Não deu para conferir (LOINC fora do ar, rede, credencial recusada)           |
+
+O `2` existe para o CI não confundir "não consegui perguntar" com "está tudo
+certo". Indisponibilidade de terceiro vira `::warning::` e não derruba o build.
+
+### Como aceitar uma mudança
+
+Deriva **não** é corrigida automaticamente. Rode o workflow `LOINC` em
+`workflow_dispatch` com `update: true`: ele regrava o snapshot e abre um PR.
+
+Isso é de propósito. Um nome que mudou upstream pode significar que o código
+deixou de servir para o analito que a gente mede, e isso precisa de olho humano
+antes de entrar.
+
+### Sobre o snapshot
+
+`loinc-snapshot.json` guarda, por código, o nome oficial e o status, mais a
+versão do LOINC e a data da conferência.
+
+Guardar o nome não é só diagnóstico. A **seção 10.3 da licença do LOINC** exige
+que informação extraída venha sempre acompanhada do identificador **e do display
+name correspondente**. Um snapshot só com hash do nome seria menor e detectaria
+deriva igual, mas descumpriria essa cláusula. O arquivo carrega o aviso da seção
+10.1 junto dos dados, para viajar com eles.
+
+### Agendamento
+
+Cron mensal (dia 5) mais `workflow_dispatch`. Não roda por PR: precisa de
+credencial e rede, o que em todo PR fica lento e instável — e secret não é
+exposto a PR de fork em repositório público.
+
+A cadência acompanha a do LOINC, que está migrando para release mensal.
+
+## generate-valueset.ts
+
+Gera `ig/input/fsh/valuesets/BRLabTestVS.fsh` a partir dos biomarcadores com
+código LOINC no `packages/core`.
+
+```bash
+pnpm valueset:generate   # regenera
+pnpm valueset:check      # regenera e falha se o versionado divergir
+```
+
+O `valueset:check` roda em todo PR — não usa rede nem credencial. Existe porque
+o gerador ficou anos sem ser chamado por nada: o ValueSet congelou em 160 códigos
+enquanto o catálogo chegava a 177, e manteve um código LOINC antigo da
+Lipoproteína (a) depois da troca.
+
+## sync-versions.js
+
+Sincroniza a versão entre os pacotes do workspace. Chamado pelo
+`semantic-release`.
+
+## worktree.sh
+
+Atalho para `pnpm exec precisa-worktree`. A implementação está no
+[`worktree-cli`](https://github.com/Precisa-Saude/tooling/tree/main/packages/worktree-cli).

--- a/scripts/verify-loinc.ts
+++ b/scripts/verify-loinc.ts
@@ -80,6 +80,31 @@ interface LookupResult {
   version?: string;
 }
 
+/**
+ * `Retry-After` tem duas formas na RFC 9110: segundos, ou HTTP-date. Só tratar
+ * a primeira faz o servidor mandar a data e a gente cair no backoff genérico
+ * sem perceber.
+ *
+ * Devolve `null` para valor ausente, malformado, ou data já passada — nesses
+ * casos quem chama volta para o backoff exponencial, que é o comportamento
+ * seguro.
+ */
+function segundosDeRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const bruto = header.trim();
+
+  const segundos = Number(bruto);
+  if (Number.isFinite(segundos)) return segundos > 0 ? segundos : null;
+
+  const quando = Date.parse(bruto);
+  if (Number.isNaN(quando)) {
+    console.error(`  (Retry-After em formato inesperado: ${JSON.stringify(bruto)})`);
+    return null;
+  }
+  const delta = Math.ceil((quando - Date.now()) / 1000);
+  return delta > 0 ? delta : null;
+}
+
 /** Parâmetro `property` do $lookup vem como par code/value dentro de `part`. */
 function lerPropriedade(parameters: unknown[], nome: string): string | undefined {
   for (const p of parameters) {
@@ -117,9 +142,9 @@ async function lookup(code: string): Promise<LookupResult> {
       if (res.status === 429 || res.status >= 500) {
         // Se o servidor disser quanto esperar, obedecer é melhor que chutar
         // backoff: evita tanto voltar cedo demais quanto dormir à toa.
-        const retryAfter = Number(res.headers.get('retry-after'));
-        if (Number.isFinite(retryAfter) && retryAfter > 0 && attempt < ATTEMPTS) {
-          await sleep(Math.min(retryAfter, 60) * 1000);
+        const espera = segundosDeRetryAfter(res.headers.get('retry-after'));
+        if (espera != null && attempt < ATTEMPTS) {
+          await sleep(Math.min(espera, 60) * 1000);
           continue;
         }
         throw new Error(`LOINC respondeu ${res.status}`);
@@ -185,7 +210,11 @@ async function main() {
     String(a.loinc).localeCompare(String(b.loinc)),
   );
 
-  console.error(`Consultando ${comLoinc.length} códigos LOINC…`);
+  const unicosDoCatalogo = new Set(comLoinc.map((b) => String(b.loinc)));
+
+  console.error(
+    `Consultando ${unicosDoCatalogo.size} códigos LOINC únicos (${comLoinc.length} biomarcadores)…`,
+  );
 
   const vivos = new Map<string, LookupResult>();
   let indisponibilidade: string | null = null;
@@ -227,12 +256,16 @@ async function main() {
       process.exitCode = EXIT_FINDINGS;
       return;
     }
-    // Snapshot com menos códigos do que foi consultado significa que alguma
-    // coisa se perdeu no caminho. Gravar assim seria pior que não gravar: o
-    // check seguinte passaria sem conferir o que sumiu.
-    if (Object.keys(codes).length !== vivos.size) {
+    // A invariante que importa é contra o catálogo, não contra `vivos`: toda
+    // entrada de `vivos` já cai em `codes` ou em `semNome`, e `semNome` sai
+    // antes daqui, então comparar com `vivos.size` seria sempre verdadeiro.
+    //
+    // Snapshot cobrindo menos códigos do que o catálogo declara é pior que
+    // snapshot nenhum: o check seguinte passaria verde sem conferir o que ficou
+    // de fora.
+    if (Object.keys(codes).length !== unicosDoCatalogo.size) {
       console.error(
-        `\nNão dá para gravar snapshot: consultei ${vivos.size} códigos e montei ${Object.keys(codes).length}.`,
+        `\nNão dá para gravar snapshot: o catálogo declara ${unicosDoCatalogo.size} códigos únicos e eu montei ${Object.keys(codes).length}.`,
       );
       process.exitCode = EXIT_FINDINGS;
       return;
@@ -305,15 +338,15 @@ async function main() {
     console.error(`DERIVA        ${d.code} ${d.campo}: "${d.de}" → "${d.para}"`);
   }
   for (const c of novos) {
-    console.error(`FORA DO SNAP  ${c} — código novo no catálogo, ainda não conferido`);
+    console.error(`FORA DO SNAP  ${c} — resolveu agora, mas não está no snapshot`);
   }
   console.error(
     '\nAceitar qualquer uma destas mudanças é PR revisado: rode o workflow LOINC em' +
       '\nworkflow_dispatch com update: true.' +
-      '\n\nCódigo novo aparece aqui de propósito. Ele entrou no catálogo sem nunca ter' +
-      '\nsido conferido contra o LOINC, e é justamente aí que erro de digitação ou' +
-      '\ncódigo aposentado passa batido — a revisão do PR do snapshot é o momento de' +
-      '\nolhar se o código serve para o analito.',
+      '\n\nCódigo fora do snapshot aparece aqui de propósito. Ele resolveu nesta execução,' +
+      '\nentão existe — o que falta é ter passado por revisão humana: entrou no catálogo' +
+      '\nsem ninguém conferir se serve para o analito que medimos, e existir no LOINC não' +
+      '\nquer dizer ser o código certo. O PR do snapshot é onde esse olhar acontece.',
   );
   process.exitCode = EXIT_FINDINGS;
 }

--- a/scripts/verify-loinc.ts
+++ b/scripts/verify-loinc.ts
@@ -115,6 +115,13 @@ async function lookup(code: string): Promise<LookupResult> {
         return { indisponivel: `autenticação recusada (HTTP ${res.status})` };
       }
       if (res.status === 429 || res.status >= 500) {
+        // Se o servidor disser quanto esperar, obedecer é melhor que chutar
+        // backoff: evita tanto voltar cedo demais quanto dormir à toa.
+        const retryAfter = Number(res.headers.get('retry-after'));
+        if (Number.isFinite(retryAfter) && retryAfter > 0 && attempt < ATTEMPTS) {
+          await sleep(Math.min(retryAfter, 60) * 1000);
+          continue;
+        }
         throw new Error(`LOINC respondeu ${res.status}`);
       }
 
@@ -125,10 +132,16 @@ async function lookup(code: string): Promise<LookupResult> {
       };
 
       if (data.resourceType === 'OperationOutcome') {
-        const erro = data.issue?.some((i) => i.severity === 'error');
+        // FHIR define fatal | error | warning | information. As duas primeiras
+        // são o servidor dizendo que a consulta não resolveu.
+        const erro = data.issue?.some((i) => i.severity === 'error' || i.severity === 'fatal');
         // Resposta legítima do servidor: o código não existe.
         if (erro) return { ausente: true };
-        return { indisponivel: 'OperationOutcome sem issue de erro' };
+        // OperationOutcome só com warning/information é forma inesperada.
+        // Tratar como ausente acusaria o código de inexistente e derrubaria o
+        // build sobre um dado que talvez esteja certo; "não deu para conferir"
+        // é a leitura honesta.
+        return { indisponivel: 'OperationOutcome sem issue de erro nem fatal' };
       }
 
       if (!Array.isArray(data.parameter)) {
@@ -214,6 +227,16 @@ async function main() {
       process.exitCode = EXIT_FINDINGS;
       return;
     }
+    // Snapshot com menos códigos do que foi consultado significa que alguma
+    // coisa se perdeu no caminho. Gravar assim seria pior que não gravar: o
+    // check seguinte passaria sem conferir o que sumiu.
+    if (Object.keys(codes).length !== vivos.size) {
+      console.error(
+        `\nNão dá para gravar snapshot: consultei ${vivos.size} códigos e montei ${Object.keys(codes).length}.`,
+      );
+      process.exitCode = EXIT_FINDINGS;
+      return;
+    }
     const versao = [...vivos.values()].find((r) => r.version)?.version ?? null;
     const snapshot: Snapshot = {
       _checkedAt: new Date().toISOString().slice(0, 10),
@@ -281,9 +304,16 @@ async function main() {
   for (const d of derivas) {
     console.error(`DERIVA        ${d.code} ${d.campo}: "${d.de}" → "${d.para}"`);
   }
-  for (const c of novos) console.error(`FORA DO SNAP  ${c} — rode o modo update`);
+  for (const c of novos) {
+    console.error(`FORA DO SNAP  ${c} — código novo no catálogo, ainda não conferido`);
+  }
   console.error(
-    '\nAceitar mudança de nome ou status é PR revisado: rode o workflow em modo update.',
+    '\nAceitar qualquer uma destas mudanças é PR revisado: rode o workflow LOINC em' +
+      '\nworkflow_dispatch com update: true.' +
+      '\n\nCódigo novo aparece aqui de propósito. Ele entrou no catálogo sem nunca ter' +
+      '\nsido conferido contra o LOINC, e é justamente aí que erro de digitação ou' +
+      '\ncódigo aposentado passa batido — a revisão do PR do snapshot é o momento de' +
+      '\nolhar se o código serve para o analito.',
   );
   process.exitCode = EXIT_FINDINGS;
 }

--- a/scripts/verify-loinc.ts
+++ b/scripts/verify-loinc.ts
@@ -1,0 +1,291 @@
+/* eslint-disable no-console -- script de CLI: a saída é o produto */
+/**
+ * Confere os códigos LOINC do catálogo contra o servidor oficial.
+ *
+ * Uso:
+ *   pnpm loinc:check     — compara o vivo com o snapshot versionado
+ *   pnpm loinc:update    — regrava o snapshot a partir do vivo
+ *
+ * Precisa de LOINC_USER e LOINC_PASSWORD (conta gratuita em
+ * https://loinc.org/get-started/). No CI vêm dos secrets do repo.
+ *
+ * ## O que este check garante, e o que não garante
+ *
+ * Garante duas coisas:
+ *
+ *   1. **Existência** — o código resolve no servidor oficial. Pega erro de
+ *      digitação e código aposentado.
+ *   2. **Deriva** — o nome oficial ou o status mudaram no LOINC desde que
+ *      mapeamos. Transforma uma edição silenciosa de terceiro em check
+ *      vermelho.
+ *
+ * **Não** garante adequação semântica: se `43583-4` é o código *certo* para
+ * Lipoproteína (a) é revisão humana, e nenhum check verde diz que os
+ * mapeamentos estão corretos.
+ *
+ * ## Por que o snapshot guarda o nome oficial
+ *
+ * Não é só para diagnosticar deriva. A licença do LOINC, seção 10.3, exige que
+ * informação extraída do material licenciado venha sempre acompanhada do
+ * identificador LOINC **e do display name correspondente** — um entre nome
+ * totalmente especificado, SHORTNAME, LONG_COMMON_NAME ou DisplayName.
+ *
+ * Guardar só um hash do nome seria menor e suficiente para detectar mudança,
+ * mas descumpriria essa cláusula. O snapshot carrega o aviso exigido pela
+ * seção 10.1 junto dos dados, para viajar com eles.
+ *
+ * @see https://loinc.org/kb/license
+ * @see https://fhir.loinc.org/
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { BIOMARKER_DEFINITIONS } from '../packages/core/src/biomarkers.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT_PATH = resolve(__dirname, 'loinc-snapshot.json');
+
+const LOINC_USER = process.env.LOINC_USER;
+const LOINC_PASSWORD = process.env.LOINC_PASSWORD;
+const LOOKUP_URL = 'https://fhir.loinc.org/CodeSystem/$lookup';
+
+const UPDATE = process.argv.includes('--update');
+
+// Exigido pela seção 10.1 da licença. Texto verbatim — não reescrever.
+const LOINC_NOTICE =
+  'This material contains content from LOINC (http://loinc.org). LOINC is ' +
+  'copyright © Regenstrief Institute, Inc. and the Logical Observation ' +
+  'Identifiers Names and Codes (LOINC) Committee and is available at no cost ' +
+  'under the license at http://loinc.org/license. LOINC® is a registered ' +
+  'United States trademark of Regenstrief Institute, Inc.';
+
+// Status que o LOINC usa para código que não deve mais ser adotado.
+const STATUS_PROIBIDOS = new Set(['DEPRECATED', 'DISCOURAGED']);
+
+const EXIT_OK = 0;
+const EXIT_FINDINGS = 1;
+const EXIT_UNVERIFIABLE = 2;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface LookupResult {
+  /** Código respondeu que não existe. Diferente de não ter dado para perguntar. */
+  ausente?: boolean;
+  display?: string;
+  /** Falha de rede, auth ou 5xx: não dá para concluir nada sobre o código. */
+  indisponivel?: string;
+  status?: string;
+  version?: string;
+}
+
+/** Parâmetro `property` do $lookup vem como par code/value dentro de `part`. */
+function lerPropriedade(parameters: unknown[], nome: string): string | undefined {
+  for (const p of parameters) {
+    const param = p as { name?: string; part?: { name?: string; [k: string]: unknown }[] };
+    if (param.name !== 'property' || !Array.isArray(param.part)) continue;
+    const code = param.part.find((x) => x.name === 'code');
+    if ((code?.valueCode ?? code?.valueString) !== nome) continue;
+    const value = param.part.find((x) => x.name === 'value');
+    const v = value?.valueString ?? value?.valueCode ?? value?.valueBoolean;
+    if (v != null) return String(v);
+  }
+  return undefined;
+}
+
+async function lookup(code: string): Promise<LookupResult> {
+  if (!LOINC_USER || !LOINC_PASSWORD) {
+    return { indisponivel: 'LOINC_USER/LOINC_PASSWORD ausentes no ambiente' };
+  }
+  const auth = Buffer.from(`${LOINC_USER}:${LOINC_PASSWORD}`).toString('base64');
+  const url = `${LOOKUP_URL}?system=http://loinc.org&code=${encodeURIComponent(code)}`;
+
+  const ATTEMPTS = 4;
+  let ultimoErro = '';
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: { Accept: 'application/fhir+json', Authorization: `Basic ${auth}` },
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      // 401/403 é configuração errada, não código inexistente. Não adianta repetir.
+      if (res.status === 401 || res.status === 403) {
+        return { indisponivel: `autenticação recusada (HTTP ${res.status})` };
+      }
+      if (res.status === 429 || res.status >= 500) {
+        throw new Error(`LOINC respondeu ${res.status}`);
+      }
+
+      const data = (await res.json()) as {
+        resourceType?: string;
+        issue?: { severity?: string }[];
+        parameter?: unknown[];
+      };
+
+      if (data.resourceType === 'OperationOutcome') {
+        const erro = data.issue?.some((i) => i.severity === 'error');
+        // Resposta legítima do servidor: o código não existe.
+        if (erro) return { ausente: true };
+        return { indisponivel: 'OperationOutcome sem issue de erro' };
+      }
+
+      if (!Array.isArray(data.parameter)) {
+        return { indisponivel: 'resposta sem `parameter`' };
+      }
+
+      const displayParam = data.parameter.find(
+        (p) => (p as { name?: string }).name === 'display',
+      ) as { valueString?: string } | undefined;
+      const versionParam = data.parameter.find(
+        (p) => (p as { name?: string }).name === 'version',
+      ) as { valueString?: string } | undefined;
+
+      return {
+        display: displayParam?.valueString,
+        status: lerPropriedade(data.parameter, 'STATUS'),
+        version: versionParam?.valueString,
+      };
+    } catch (err) {
+      ultimoErro = err instanceof Error ? err.message : String(err);
+      if (attempt < ATTEMPTS) await sleep(500 * 2 ** (attempt - 1));
+    }
+  }
+  return { indisponivel: ultimoErro || 'tentativas esgotadas' };
+}
+
+interface Snapshot {
+  _checkedAt: string;
+  _loincVersion: string | null;
+  _notice: string;
+  codes: Record<string, { display: string; status: string | null }>;
+}
+
+function lerSnapshot(): Snapshot | null {
+  if (!existsSync(SNAPSHOT_PATH)) return null;
+  return JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8')) as Snapshot;
+}
+
+async function main() {
+  const comLoinc = BIOMARKER_DEFINITIONS.filter((b) => b.loinc).sort((a, b) =>
+    String(a.loinc).localeCompare(String(b.loinc)),
+  );
+
+  console.error(`Consultando ${comLoinc.length} códigos LOINC…`);
+
+  const vivos = new Map<string, LookupResult>();
+  let indisponibilidade: string | null = null;
+
+  for (const b of comLoinc) {
+    const code = String(b.loinc);
+    if (vivos.has(code)) continue;
+    const r = await lookup(code);
+    if (r.indisponivel) {
+      // Não dá para distinguir "mudou" de "não perguntei". Para tudo.
+      indisponibilidade = `${code}: ${r.indisponivel}`;
+      break;
+    }
+    vivos.set(code, r);
+    await sleep(120);
+  }
+
+  if (indisponibilidade) {
+    console.error(`\nNÃO VERIFICADO — ${indisponibilidade}`);
+    console.error('Nenhuma conclusão sobre os códigos nesta execução.');
+    process.exitCode = EXIT_UNVERIFIABLE;
+    return;
+  }
+
+  if (UPDATE) {
+    const codes: Snapshot['codes'] = {};
+    const semNome: string[] = [];
+    for (const [code, r] of [...vivos].sort((a, b) => a[0].localeCompare(b[0]))) {
+      if (r.ausente || !r.display) {
+        semNome.push(code);
+        continue;
+      }
+      codes[code] = { display: r.display, status: r.status ?? null };
+    }
+    if (semNome.length) {
+      console.error(`\nNão dá para gravar snapshot: ${semNome.length} código(s) sem nome oficial.`);
+      for (const c of semNome) console.error(`  - ${c}`);
+      console.error('A licença (10.3) exige o display name junto do código.');
+      process.exitCode = EXIT_FINDINGS;
+      return;
+    }
+    const versao = [...vivos.values()].find((r) => r.version)?.version ?? null;
+    const snapshot: Snapshot = {
+      _checkedAt: new Date().toISOString().slice(0, 10),
+      _loincVersion: versao,
+      _notice: LOINC_NOTICE,
+      codes,
+    };
+    writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+    console.error(
+      `\nSnapshot gravado: ${Object.keys(codes).length} códigos, LOINC ${versao ?? '?'}`,
+    );
+    process.exitCode = EXIT_OK;
+    return;
+  }
+
+  const snapshot = lerSnapshot();
+  if (!snapshot) {
+    console.error(`\nSnapshot ausente em ${SNAPSHOT_PATH}. Rode o workflow em modo update.`);
+    process.exitCode = EXIT_FINDINGS;
+    return;
+  }
+
+  const ausentes: string[] = [];
+  const proibidos: { code: string; status: string }[] = [];
+  const derivas: { code: string; de: string; para: string; campo: string }[] = [];
+  const novos: string[] = [];
+
+  for (const [code, r] of vivos) {
+    if (r.ausente) {
+      ausentes.push(code);
+      continue;
+    }
+    if (r.status && STATUS_PROIBIDOS.has(r.status.toUpperCase())) {
+      proibidos.push({ code, status: r.status });
+    }
+    const antigo = snapshot.codes[code];
+    if (!antigo) {
+      novos.push(code);
+      continue;
+    }
+    if (r.display && r.display !== antigo.display) {
+      derivas.push({ campo: 'display', code, de: antigo.display, para: r.display });
+    }
+    const statusVivo = r.status ?? null;
+    if (statusVivo !== antigo.status) {
+      derivas.push({
+        campo: 'status',
+        code,
+        de: String(antigo.status),
+        para: String(statusVivo),
+      });
+    }
+  }
+
+  const problemas = ausentes.length + proibidos.length + derivas.length + novos.length;
+  if (!problemas) {
+    console.error(`\nOK — ${vivos.size} códigos conferem com o snapshot.`);
+    process.exitCode = EXIT_OK;
+    return;
+  }
+
+  console.error('');
+  for (const c of ausentes) console.error(`NÃO RESOLVE   ${c} — não existe no LOINC`);
+  for (const p of proibidos) console.error(`STATUS        ${p.code} — ${p.status}`);
+  for (const d of derivas) {
+    console.error(`DERIVA        ${d.code} ${d.campo}: "${d.de}" → "${d.para}"`);
+  }
+  for (const c of novos) console.error(`FORA DO SNAP  ${c} — rode o modo update`);
+  console.error(
+    '\nAceitar mudança de nome ou status é PR revisado: rode o workflow em modo update.',
+  );
+  process.exitCode = EXIT_FINDINGS;
+}
+
+await main();


### PR DESCRIPTION
Item **A** do PRE-254, mais a lacuna de licença que ele destapou.

## O problema

Nada conferia os **177 códigos LOINC** do catálogo contra o LOINC. O único script que fazia isso vivia no `platform`, lia os biomarcadores por **regex num arquivo `.ts`**, e quebrou quando eles migraram para cá — sem ninguém perceber, porque não era chamado por nada.

## O verificador

Mora onde o catálogo mora, e **importa `BIOMARKER_DEFINITIONS` direto do source** em vez de parsear arquivo. Essa troca sozinha é o que impede o script de quebrar em silêncio na próxima vez que algo se mover.

```bash
pnpm loinc:check     # compara o vivo com o snapshot versionado
pnpm loinc:update    # regrava o snapshot
```

**Garante** existência (pega erro de digitação e código aposentado) e **deriva** de nome ou status desde a última conferência — que é o que realmente paga, porque transforma edição silenciosa de terceiro em check vermelho. `DEPRECATED` e `DISCOURAGED` falham alto.

**Não garante adequação semântica**, e o README diz isso com todas as letras. Se `43583-4` é o código *certo* para Lipoproteína (a) continua sendo revisão humana. Check verde não significa mapeamento correto — é a distinção que o ticket pede para não confundir.

Deriva **não** vira commit automático: o modo update abre PR, porque nome que mudou upstream pode significar que o código deixou de servir para o analito.

Agendado **mensal + `workflow_dispatch`**, não por PR — precisa de credencial e rede, e secret não é exposto a PR de fork em repo público. Três códigos de saída, com `2` reservado para "não deu para conferir": indisponibilidade do LOINC vira `::warning::`, não falha nossa.

## Conformidade com a licença

Li a licença antes de desenhar o snapshot, e ela inverteu o desenho.

Eu tinha proposto guardar só um **hash** do nome oficial — menor, e suficiente para detectar deriva. A **seção 10.3** proíbe: informação extraída do material licenciado deve vir sempre acompanhada do identificador LOINC **e do display name correspondente** (nome totalmente especificado, `SHORTNAME`, `LONG_COMMON_NAME` ou `DisplayName`). Hash-only seria não conforme. O snapshot guarda o nome oficial.

**E isso destapou uma lacuna que já existia.** O aviso exigido pela **seção 10.1** não aparecia em lugar nenhum deste repositório — que é **público** e redistribui os 177 códigos pelo npm e pelo IG. `sushi-config.yaml` declarava só `Apache-2.0`.

O aviso entra agora, **verbatim** (conferido caractere a caractere contra o PDF da licença), em quatro lugares:

| Onde                     | Por quê                                        |
| ------------------------ | ---------------------------------------------- |
| `README.md`              | repositório público                            |
| `packages/core/README.md`| vai para o npm junto do pacote                 |
| `ig/sushi-config.yaml`   | 10.1 exige nos termos de recurso online        |
| `scripts/loinc-snapshot.json` | viaja junto dos dados                     |

Não sou advogado e não estou dando parecer: estou aplicando o texto da cláusula ao que o repositório faz hoje.

## O snapshot ainda não está aqui — e por quê

`workflow_dispatch` só fica disponível depois que o workflow existe na branch padrão, então **não dá para gerar o snapshot antes do merge**. A sequência é:

1. Este PR entra.
2. Rodar o workflow **LOINC** em `workflow_dispatch` com `update: true`.
3. Ele consulta os 177 códigos e **abre um PR com o snapshot** — que já é o fluxo normal de aceitar mudança, e serve de teste de ponta a ponta contra a API real.

Até lá o `loinc:check` sai com `1` e mensagem explícita (`Snapshot ausente… rode o workflow em modo update`). Nada quebra no meio tempo: o job de check só roda em cron (dia 5) e por dispatch, nunca em PR.

## Verificação

- Contrato da API **reaproveitado do script morto** (endpoint, Basic auth, `Accept: application/fhir+json`, `parameter[name=display]`, `OperationOutcome` para código inexistente), como o ticket previa — não foi adivinhado.
- Sem credencial, sai `2` com a mensagem certa. Conferido.
- `actionlint` limpo no workflow; ambos os YAML parseiam; `eslint`, `tsc` e `format:check` limpos.
- Aviso conferido **caractere a caractere** contra o texto extraído do PDF.

## Fora deste PR

Item **B** em #64. Item **C** em [platform#591](https://github.com/Precisa-Saude/platform/pull/591).
