### PR TITLE
fix(ci): separa código inexistente de resposta sem display name

### DIFF
--- a/scripts/verify-loinc.ts
+++ b/scripts/verify-loinc.ts
@@ -212,6 +212,14 @@ async function main() {
 
   const unicosDoCatalogo = new Set(comLoinc.map((b) => String(b.loinc)));
 
+  // Código sozinho não diz nada a quem for consertar: o catálogo é indexado por
+  // biomarcador, não por LOINC.
+  const biomarcadoresDe = (loinc: string) =>
+    comLoinc
+      .filter((b) => String(b.loinc) === loinc)
+      .map((b) => b.code)
+      .join(', ') || '?';
+
   console.error(
     `Consultando ${unicosDoCatalogo.size} códigos LOINC únicos (${comLoinc.length} biomarcadores)…`,
   );
@@ -241,18 +249,39 @@ async function main() {
 
   if (UPDATE) {
     const codes: Snapshot['codes'] = {};
-    const semNome: string[] = [];
+    // Os dois casos pedem ações opostas e não podem sair no mesmo balde:
+    // código que não resolve é dado errado nosso, e vai para PR corrigindo o
+    // catálogo. Código que resolve sem display é resposta inesperada do
+    // servidor, e vai para investigação do lado deles.
+    const naoResolvem: string[] = [];
+    const semDisplay: string[] = [];
     for (const [code, r] of [...vivos].sort((a, b) => a[0].localeCompare(b[0]))) {
-      if (r.ausente || !r.display) {
-        semNome.push(code);
+      if (r.ausente) {
+        naoResolvem.push(code);
+        continue;
+      }
+      if (!r.display) {
+        semDisplay.push(code);
         continue;
       }
       codes[code] = { display: r.display, status: r.status ?? null };
     }
+    const semNome = [...naoResolvem, ...semDisplay];
     if (semNome.length) {
       console.error(`\nNão dá para gravar snapshot: ${semNome.length} código(s) sem nome oficial.`);
-      for (const c of semNome) console.error(`  - ${c}`);
-      console.error('A licença (10.3) exige o display name junto do código.');
+      if (naoResolvem.length) {
+        console.error(`\nNÃO RESOLVEM no LOINC (${naoResolvem.length}) — dado errado no catálogo:`);
+        for (const c of naoResolvem) console.error(`  - ${c}  (${biomarcadoresDe(c)})`);
+        console.error('  Conferir o código na fonte e corrigir o catálogo.');
+      }
+      if (semDisplay.length) {
+        console.error(
+          `\nRESOLVEM mas sem display name (${semDisplay.length}) — resposta inesperada:`,
+        );
+        for (const c of semDisplay) console.error(`  - ${c}  (${biomarcadoresDe(c)})`);
+        console.error('  O código existe; o servidor é que não devolveu nome.');
+      }
+      console.error('\nA licença (10.3) exige o display name junto do código.');
       process.exitCode = EXIT_FINDINGS;
       return;
     }


### PR DESCRIPTION
A primeira execução real do verificador contra o LOINC ([run 31412929190](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/31412929190)) parou em três códigos:

```
Não dá para gravar snapshot: 3 código(s) sem nome oficial.
  - 4485-3   (C3)
  - 4498-6   (C4)
  - 5697-7   (Selenium)
```

O script se comportou como projetado — recusou gravar um snapshot que descumpriria a seção 10.3 da licença. Mas a mensagem junta **dois casos de naturezas opostas**:

| Caso | O que significa | Quem conserta |
| --- | --- | --- |
| Não resolve | dado errado no nosso catálogo | PR corrigindo o código |
| Resolve sem display name | resposta inesperada do servidor | investigação do lado do LOINC |

Sair no mesmo balde manda quem for investigar para o lugar errado — e neste caso a diferença decide se temos três códigos inválidos publicados no npm e no IG, ou três respostas estranhas da API.

## O que muda

Blocos separados, cada um com a ação correspondente, e o **biomarcador ao lado do código** — o catálogo é indexado por biomarcador, então o número sozinho não ajuda quem for procurar.

## Próximo passo

Com isto no lugar, rodar o workflow em modo update de novo diz qual dos dois casos são os três. Só então dá para saber se é PR de correção de catálogo ou questão para o LOINC.

Refs: PRE-254