### PR TITLE
fix(core): sobe o teto masculino de CK para o limite populacional

### DIFF
--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -458,9 +458,28 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
   },
 
   // CK: valores conservadores baseados em faixas laboratoriais típicas
+  // CK — o teto masculino era 190 U/L, bem abaixo de qualquer limite superior
+  // derivado de população: 314 no Kalaria 2026 (homens brancos) e 382 no McLeod
+  // 2016 (NHANES, brancos, p97.5). Sinalizava como alterado um monte de gente
+  // com músculo, exercício recente ou simplesmente CK alto normal.
+  //
+  // Passa a 314, que é o mais baixo entre os limites populacionais disponíveis
+  // — a escolha que menos deixa passar elevação real. O `optimalMax` fica em
+  // 170, então a faixa 170–314 lê como "acima do ótimo, dentro da referência",
+  // e não como alteração.
+  //
+  // O teto feminino de 170 já coincide com o limite de mulheres brancas do
+  // mesmo estudo, e fica como está.
+  //
+  // Estratificação por ancestralidade NÃO foi adotada, apesar de o estudo
+  // mostrar limites bem maiores em pessoas negras (389 ♀ / 757 ♂). As
+  // categorias do estudo são britânicas e não mapeiam na população brasileira:
+  // SUAREZ-KURTZ et al. (Front Pharmacol, 2012, PMID 23133420) mostram que a
+  // variação relevante é contínua entre brasileiros e "não é capturada pela
+  // autodeclaração de raça/Cor". Ver a issue #3 para a decisão registrada.
   CK: {
-    default: { max: 190, min: 30, optimalMax: 170, optimalMin: 40, unit: 'U/L' },
-    source: 'tietz-7ed-2015',
+    default: { max: 314, min: 30, optimalMax: 170, optimalMin: 40, unit: 'U/L' },
+    source: 'kalaria-ck-ri-2026',
     variants: [
       { sex: 'F', range: { max: 170, min: 30, optimalMax: 150, optimalMin: 40, unit: 'U/L' } },
     ],

--- a/packages/core/src/sources.ts
+++ b/packages/core/src/sources.ts
@@ -118,6 +118,16 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
   },
 
   // ---------------------------------------------------------------------------
+  // Referência laboratorial geral
+  // ---------------------------------------------------------------------------
+  'kalaria-ck-ri-2026': {
+    abnt: 'KALARIA, T. et al. Age, sex and ethnicity changes in creatine kinase and sex- and ethnicity-specific reference intervals of creatine kinase. Clinical Medicine, v. 26, n. 4, p. 100596, 2026.',
+    doi: '10.1016/j.clinme.2026.100596',
+    key: 'kalaria-ck-ri-2026',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/42142664/',
+  },
+
+  // ---------------------------------------------------------------------------
   // Fontes internacionais — Nefrologia
   // ---------------------------------------------------------------------------
   'kdigo-ckd-2024': {
@@ -273,13 +283,13 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     key: 'sbem-thyroid-2013',
     url: 'https://pubmed.ncbi.nlm.nih.gov/23681263/',
   },
-
   'sbem-vitamind-2014': {
     abnt: 'MAEDA, S. S. et al. Recomendações da Sociedade Brasileira de Endocrinologia e Metabologia (SBEM) para o diagnóstico e tratamento da hipovitaminose D. Arquivos Brasileiros de Endocrinologia & Metabologia, v. 58, n. 5, p. 411-433, 2014.',
     doi: '10.1590/0004-2730000003388',
     key: 'sbem-vitamind-2014',
     url: 'https://pubmed.ncbi.nlm.nih.gov/25166032/',
   },
+
   // ---------------------------------------------------------------------------
   // Sociedade Brasileira de Patologia Clínica / Medicina Laboratorial
   // ---------------------------------------------------------------------------
@@ -330,9 +340,6 @@ export const SOURCE_REGISTRY: Record<string, SourceReference> = {
     url: 'https://pubmed.ncbi.nlm.nih.gov/19042984/',
   },
 
-  // ---------------------------------------------------------------------------
-  // Referência laboratorial geral
-  // ---------------------------------------------------------------------------
   'tietz-7ed-2015': {
     abnt: 'BURTIS, C. A.; BRUNS, D. E. Tietz Fundamentals of Clinical Chemistry and Molecular Diagnostics. 7. ed. St. Louis: Elsevier Saunders, 2015.',
     isbn: '978-1-4557-4165-6',


### PR DESCRIPTION
Fecha metade da [issue #3](https://github.com/Precisa-Saude/fhir-brasil/issues/3) — o item da CK.

## O problema

O teto masculino era **190 U/L**, abaixo de qualquer limite superior derivado de população:

| Fonte | ♂ | ♀ |
| --- | --- | --- |
| Código (antes) | 190 | 170 |
| Kalaria 2026, brancos | 314 | 170 |
| McLeod 2016 (NHANES, brancos, p97.5) | 382 | 295 |

Com 190, homem com massa muscular, exercício recente ou simplesmente CK alto normal saía como **alterado**.

Repare que o teto **feminino de 170 coincide exatamente** com o limite de mulheres brancas do Kalaria — o masculino é que era o destoante.

## O que muda

`max` masculino passa a **314**, o mais baixo entre os limites populacionais disponíveis — a escolha que menos deixa passar elevação real, e ainda assim bem menos sensível que 190.

O `optimalMax` fica em **170**, então a faixa 170–314 lê como "acima do ótimo, dentro da referência", e não como alteração. É o mesmo uso dos dois campos que o IMC já fazia e que eu tinha quebrado no #63.

```
CK homem 150  -> ótimo
CK homem 200  -> acima do ótimo   (antes: ANORMAL)
CK homem 300  -> acima do ótimo   (antes: ANORMAL)
CK homem 350  -> ANORMAL
```

## Por que NÃO estratificamos por ancestralidade

O mesmo estudo mostra limites muito maiores em pessoas negras (389 ♀ / 757 ♂), e aplicar limite só por sexo classifica como alto **22,6–30,3%** dos resultados de pessoas negras contra 5,1–7,7% das brancas. É um problema real.

Ainda assim, não adotamos — e a razão é que **as categorias não transferem**. SUAREZ-KURTZ et al. ([PMID 23133420](https://pubmed.ncbi.nlm.nih.gov/23133420/)), sobre 1.034 adultos nas categorias de Cor do Censo brasileiro, concluem que extrapolar de grupos étnicos bem definidos "não é aplicável à maioria dos brasileiros", e que a variação clinicamente relevante é **contínua e não capturada pela autodeclaração de raça/Cor**. "Parda" é a maior categoria do Censo e não tem linha na tabela britânica.

Somando: perguntar a Cor daria resposta que não seleciona a faixa certa, e Cor é dado sensível pela LGPD (art. 5º II, mesmo grau de dado de saúde). Custo alto, sinal ruim.

**Subir o teto reduz falso "alterado" para todo mundo** — inclusive para o grupo que a estratificação protegeria — sem coletar nada.

Fica um resíduo honesto: homem negro com CK alto normal ainda pode ver "alterado" mais do que deveria. Resolver isso direito exige dado brasileiro estratificado, que não existe hoje (`ELSA-Brasil + creatine kinase` = zero resultados no PubMed).

## Fonte

KALARIA, T. et al. *Age, sex and ethnicity changes in creatine kinase and sex- and ethnicity-specific reference intervals of creatine kinase.* Clinical Medicine, v. 26, n. 4, p. 100596, 2026. DOI [10.1016/j.clinme.2026.100596](https://doi.org/10.1016/j.clinme.2026.100596) · [PMID 42142664](https://pubmed.ncbi.nlm.nih.gov/42142664/)

Campos da citação conferidos um a um no PubMed. Intervalos indiretos de 58.096 indivíduos pelo algoritmo refineR, verificados em dois conjuntos independentes.

## Verificação

- 402 testes passando; `lint`, `typecheck` e `format:check` limpos.
- Faixas conferidas no pacote compilado, não só na leitura do source.

Refs: #3