### PR TITLE
fix(core): remove a razão ApoCIII/ApoA1, que não tinha fonte

### DIFF
--- a/docs/development/verificacao-citacoes.md
+++ b/docs/development/verificacao-citacoes.md
@@ -8,7 +8,7 @@
 - `[ ]` - Nao verificado (sem fonte ou fonte nao conferida)
 - `[x]` - Verificado (valor conferido contra documento-fonte)
 
-**Estatisticas**: 204/205 verificados (99.5%) — 1 sem fonte publicada (ApoCIII_ApoA1_Ratio)
+**Estatisticas**: 204/204 verificados (100%). A unica entrada sem fonte publicada, `ApoCIII_ApoA1_Ratio`, foi removida — ver issue #3.
 
 ---
 
@@ -26,7 +26,6 @@
 - [x] ApoA1 - `contois-apoa1-1996` Framingham: H ~134+/-23, M ~154+/-28 mg/dL. Codigo 100-200 eh faixa ampla
 - [x] ApoB - `sbc-lipids-2025` Risco intermediario <90, alto <70 confere
 - [x] ApoCIII - `khetarpal-apociii-2016` Normolipidemicos ~8-10 mg/dL confere
-- [ ] ApoCIII_ApoA1_Ratio - **SEM FONTE**: corte 0.15 sem publicacao. Source removido intencionalmente. Ver issue #3
 - [x] Lipoprotein_a - `sbc-lipids-2025` Alterado >=75 nmol/L ou >=30 mg/dL confere
 
 ### Subfracoes Lipidicas (Avancado)

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -9,6 +9,7 @@ import {
   getReferenceRange,
   type ReferenceRangeContext,
 } from '../reference-ranges';
+import { SOURCE_REGISTRY } from '../sources';
 
 /**
  * Expected default range with the definition's source key propagated —
@@ -43,6 +44,30 @@ describe('biomarkerRangeDefinitions', () => {
       // Suppress unused variable warning
       void code;
     }
+  });
+
+  // Faixa sem fonte é um corte clínico que ninguém publicou, e ele decide o que
+  // a pessoa vê como "alterado". O `ApoCIII_ApoA1_Ratio` foi a última assim
+  // (issue #3): o corte de 0.15 era derivado das faixas individuais, sem
+  // validação, e seis buscas no PubMed não acharam publicação nenhuma.
+  //
+  // Com o catálogo em 100% de cobertura, este teste trava a regressão — é mais
+  // fácil impedir a primeira entrada sem fonte do que caçá-la depois.
+  it('should cite a source for every range definition', () => {
+    const semFonte = Object.entries(biomarkerRangeDefinitions)
+      .filter(([, def]) => !def.source)
+      .map(([code]) => code);
+
+    expect(semFonte).toEqual([]);
+  });
+
+  it('should only cite sources that exist in the registry', () => {
+    const desconhecidas = Object.entries(biomarkerRangeDefinitions)
+      .map(([code, def]) => [code, def.source?.split(':')[0]] as const)
+      .filter(([, chave]) => chave && !(chave in SOURCE_REGISTRY))
+      .map(([code, chave]) => `${code} -> ${chave}`);
+
+    expect(desconhecidas).toEqual([]);
   });
 });
 

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -61,13 +61,26 @@ describe('biomarkerRangeDefinitions', () => {
     expect(semFonte).toEqual([]);
   });
 
+  // `source` é `'chave'` ou `'chave:localizador'` (ver sources.ts). O teste
+  // valida a chave e a forma:
+  //
+  // - `Object.hasOwn` em vez de `in`, que enxerga a cadeia de protótipos: com
+  //   `in`, um `source: 'toString'` passaria como se existisse no registro.
+  // - chave vazia (`':p15'`, ou `source` só com espaços) é malformada e precisa
+  //   falhar, em vez de sumir num filtro de falsy.
   it('should only cite sources that exist in the registry', () => {
-    const desconhecidas = Object.entries(biomarkerRangeDefinitions)
-      .map(([code, def]) => [code, def.source?.split(':')[0]] as const)
-      .filter(([, chave]) => chave && !(chave in SOURCE_REGISTRY))
-      .map(([code, chave]) => `${code} -> ${chave}`);
+    const problemas = Object.entries(biomarkerRangeDefinitions)
+      .filter(([, def]) => def.source)
+      .map(([code, def]) => {
+        const chave = String(def.source).split(':')[0]?.trim() ?? '';
+        if (!chave) return `${code} -> fonte malformada: ${JSON.stringify(def.source)}`;
+        if (!Object.hasOwn(SOURCE_REGISTRY, chave))
+          return `${code} -> chave desconhecida: ${chave}`;
+        return null;
+      })
+      .filter((x): x is string => x !== null);
 
-    expect(desconhecidas).toEqual([]);
+    expect(problemas).toEqual([]);
   });
 });
 

--- a/packages/core/src/__tests__/reference-ranges.test.ts
+++ b/packages/core/src/__tests__/reference-ranges.test.ts
@@ -61,21 +61,26 @@ describe('biomarkerRangeDefinitions', () => {
     expect(semFonte).toEqual([]);
   });
 
-  // `source` é `'chave'` ou `'chave:localizador'` (ver sources.ts). O teste
-  // valida a chave e a forma:
+  // `source` é `'chave'` ou `'chave:localizador'` (ver sources.ts).
   //
-  // - `Object.hasOwn` em vez de `in`, que enxerga a cadeia de protótipos: com
-  //   `in`, um `source: 'toString'` passaria como se existisse no registro.
-  // - chave vazia (`':p15'`, ou `source` só com espaços) é malformada e precisa
-  //   falhar, em vez de sumir num filtro de falsy.
+  // A chave é usada crua, sem `trim()`, de propósito: `getReferenceRange`
+  // devolve `source` verbatim, então uma chave com espaço sobrando (`' sbc-...'`)
+  // não resolveria no registro em runtime. Normalizar aqui faria o teste passar
+  // um caso que quebra em produção.
+  //
+  // `Object.hasOwn` em vez de `in`, que enxerga a cadeia de protótipos: com
+  // `in`, um `source: 'toString'` passaria como se existisse no registro.
   it('should only cite sources that exist in the registry', () => {
+    const chaveDe = (source: string): string => source.split(':')[0] ?? '';
+
     const problemas = Object.entries(biomarkerRangeDefinitions)
       .filter(([, def]) => def.source)
       .map(([code, def]) => {
-        const chave = String(def.source).split(':')[0]?.trim() ?? '';
-        if (!chave) return `${code} -> fonte malformada: ${JSON.stringify(def.source)}`;
-        if (!Object.hasOwn(SOURCE_REGISTRY, chave))
-          return `${code} -> chave desconhecida: ${chave}`;
+        const chave = chaveDe(String(def.source));
+        if (chave === '') return `${code} -> fonte sem chave: ${JSON.stringify(def.source)}`;
+        if (!Object.hasOwn(SOURCE_REGISTRY, chave)) {
+          return `${code} -> chave desconhecida: ${JSON.stringify(chave)}`;
+        }
         return null;
       })
       .filter((x): x is string => x !== null);

--- a/packages/core/src/reference-ranges.ts
+++ b/packages/core/src/reference-ranges.ts
@@ -288,12 +288,6 @@ export const biomarkerRangeDefinitions: Record<string, BiomarkerRangeDefinition>
     source: 'khetarpal-apociii-2016',
   },
 
-  // ApoCIII/ApoA1 Ratio: derivado de ApoCIII (~10 mg/dL) e ApoA1 (~100-150 mg/dL)
-  // NOTA: corte de 0.15 sem fonte publicada — valor calculado, não validado clinicamente
-  ApoCIII_ApoA1_Ratio: {
-    default: { max: 0.15, min: 0, optimalMax: 0.1, optimalMin: 0, unit: '' },
-  },
-
   Omega6_AA: {
     default: { max: 15.0, min: 5.0, optimalMax: 12.0, optimalMin: 7.0, unit: '%' },
     source: 'simopoulos-omega-ratio-2002',


### PR DESCRIPTION
Fecha a outra metade da [issue #3](https://github.com/Precisa-Saude/fhir-brasil/issues/3).

## Por que remover

O corte de `max: 0.15` era **derivado** das faixas individuais de ApoCIII e ApoA1, sem validação clínica — e mesmo assim classificava como **alterado** quem ficasse acima dele.

Procurei fonte antes de desistir. Seis buscas no PubMed, nenhuma encontrou publicação estabelecendo referência para essa razão:

| Busca | Resultado |
| --- | --- |
| `apoC-III/apoA-I` OR `apoCIII/apoAI ratio` | 3 artigos, nenhum com corte |
| `apoC-III apoA-I ratio risk threshold` | 0 |
| `apolipoprotein CIII A1 ratio metabolic syndrome cutoff` | 0 |
| `apoC-III apoA-I ratio reference value` | 5 artigos, nenhum com corte |
| `apolipoprotein C-III apolipoprotein A-I ratio cardiovascular` | 28 artigos, nenhum estabelecendo referência |

Era a **única das 207 entradas sem campo `source`**. Sem ela, o catálogo fica em 206 com 100% de cobertura.

A opção (b) da issue — marcar como "derivado, sem validação clínica" — não era expressável: não existe campo para isso no tipo, e a ressalva vivia só num comentário de código, invisível para quem consome o pacote ou o IG. Implementar (b) seria criar campo novo e fazer todos os consumidores respeitarem, para preservar um número que ninguém publicou.

## Blast radius (conferido antes de apagar)

| Onde | Existe? |
| --- | --- |
| Definição em `biomarkers.ts` | não |
| Código LOINC | não |
| ValueSet do IG | não |
| Outro pacote do workspace | não |
| Aliases de OCR | não |
| Testes | não |
| Qualquer código do `platform` | não |

Só a faixa existia. Vale registrar que faixa sem definição **não** é anomalia aqui — são 39 das 207 — então a ausência de definição sozinha não justificaria remover; o que justifica é a ausência de fonte somada a nenhum consumidor.

## Trava de regressão

Dois testes novos:

- toda faixa precisa de `source`;
- todo `source` precisa existir no `SOURCE_REGISTRY`.

Conferi que pegam de verdade: acrescentei uma entrada sem fonte e o teste falhou apontando o nome dela.

É mais fácil impedir a primeira entrada sem fonte do que caçá-la depois — foi assim que esta sobreviveu desde março.

## Verificação

- 404 testes passando (402 + 2 novos).
- `lint`, `typecheck` e `format:check` limpos.
- `docs/development/verificacao-citacoes.md` atualizado: 204/204 (100%).

Refs: #3