### PR TITLE
fix(core): corrige três códigos LOINC inválidos

### DIFF
--- a/ig/input/fsh/valuesets/BRLabTestVS.fsh
+++ b/ig/input/fsh/valuesets/BRLabTestVS.fsh
@@ -5,8 +5,8 @@ Description: "Códigos LOINC para exames laboratoriais suportados pelo fhir-bras
 
 // autoimunidade
 * $LOINC#8061-4 "Triagem de Anticorpos Antinucleares"
-* $LOINC#4485-3 "Complemento C3"
-* $LOINC#4498-6 "Complemento C4"
+* $LOINC#4485-9 "Complemento C3"
+* $LOINC#4498-2 "Complemento C4"
 * $LOINC#63453-5 "Anticorpos Anti-Gliadina Deamidada IgA"
 * $LOINC#63459-2 "Anticorpos Anti-Gliadina Deamidada IgG"
 * $LOINC#2472-9 "Imunoglobulina M"
@@ -97,7 +97,7 @@ Description: "Códigos LOINC para exames laboratoriais suportados pelo fhir-bras
 * $LOINC#75117-2 "Ômega-6: Ácido Linoleico"
 * $LOINC#90910-1 "Razão Ômega-6 / Ômega-3"
 * $LOINC#35177-5 "Ômega-6 Total"
-* $LOINC#5697-7 "Selênio"
+* $LOINC#5724-0 "Selênio"
 * $LOINC#2500-7 "Capacidade de Ligação do Ferro"
 * $LOINC#2502-3 "Saturação de Ferro"
 * $LOINC#2923-1 "Vitamina A"

--- a/packages/core/src/__tests__/biomarkers.test.ts
+++ b/packages/core/src/__tests__/biomarkers.test.ts
@@ -45,6 +45,45 @@ describe('BIOMARKER_DEFINITIONS', () => {
     expect(uniqueCodes.size).toBe(loincCodes.length);
   });
 
+  // Todo código LOINC termina em dígito verificador Mod 10 ("double-add-double").
+  // Conferir isso pega erro de digitação **sem rede e sem credencial**, em todo PR
+  // — enquanto o `pnpm loinc:check` contra o servidor oficial é mensal e precisa
+  // de conta.
+  //
+  // Não é hipotético: a primeira execução real do verificador encontrou três
+  // códigos inválidos publicados (C3 `4485-3`, C4 `4498-6`, Selênio `5697-7`), e
+  // os três falham exatamente neste teste. Teriam sido pegos na entrada.
+  it('should have a valid Mod 10 check digit on every LOINC code', () => {
+    const digitoEsperado = (numero: string): string => {
+      let soma = 0;
+      [...numero].reverse().forEach((ch, i) => {
+        let d = Number(ch);
+        if (i % 2 === 0) {
+          d *= 2;
+          if (d > 9) d -= 9;
+        }
+        soma += d;
+      });
+      return String((10 - (soma % 10)) % 10);
+    };
+
+    const invalidos = BIOMARKER_DEFINITIONS.filter((d) => d.loinc)
+      .map((d) => {
+        const loinc = String(d.loinc);
+        const [numero, digito] = loinc.split('-');
+        if (!numero || !digito || !/^\d+$/.test(numero) || !/^\d$/.test(digito)) {
+          return `${d.code} -> forma inválida: ${loinc}`;
+        }
+        const esperado = digitoEsperado(numero);
+        return esperado === digito
+          ? null
+          : `${d.code} -> ${loinc} (dígito verificador deveria ser ${esperado})`;
+      })
+      .filter((x): x is string => x !== null);
+
+    expect(invalidos).toEqual([]);
+  });
+
   it('should have unique internal codes', () => {
     const codes = BIOMARKER_DEFINITIONS.map((d) => d.code);
     const uniqueCodes = new Set(codes);

--- a/packages/core/src/__tests__/biomarkers.test.ts
+++ b/packages/core/src/__tests__/biomarkers.test.ts
@@ -82,7 +82,10 @@ describe('BIOMARKER_DEFINITIONS', () => {
         if (!FORMA_LOINC.test(loinc)) {
           return `${d.code} -> ${loinc} não tem a forma <número>-<dígito único>`;
         }
-        const [numero, digito] = loinc.split('-') as [string, string];
+        // Sem type assertion: os defaults do destructuring bastam para o
+        // compilador, e não dependem de raciocínio sobre o regex que um edit
+        // futuro poderia invalidar.
+        const [numero = '', digito = ''] = loinc.split('-');
         const esperado = digitoEsperado(numero);
         return esperado === digito
           ? null

--- a/packages/core/src/__tests__/biomarkers.test.ts
+++ b/packages/core/src/__tests__/biomarkers.test.ts
@@ -56,9 +56,13 @@ describe('BIOMARKER_DEFINITIONS', () => {
   it('should have a valid Mod 10 check digit on every LOINC code', () => {
     const digitoEsperado = (numero: string): string => {
       let soma = 0;
-      [...numero].reverse().forEach((ch, i) => {
+      // `posicaoDaDireita` é o índice depois do reverse, ou seja, conta da
+      // direita para a esquerda. O algoritmo dobra as posições pares nessa
+      // contagem — trocar isso por índice da esquerda quebra o cálculo em
+      // números de comprimento ímpar, sem quebrar nenhum teste óbvio.
+      [...numero].reverse().forEach((ch, posicaoDaDireita) => {
         let d = Number(ch);
-        if (i % 2 === 0) {
+        if (posicaoDaDireita % 2 === 0) {
           d *= 2;
           if (d > 9) d -= 9;
         }
@@ -67,13 +71,18 @@ describe('BIOMARKER_DEFINITIONS', () => {
       return String((10 - (soma % 10)) % 10);
     };
 
+    // A forma inteira é validada de uma vez. Validar só os dois primeiros
+    // segmentos deixaria passar `4485-9-1`, que tem número e dígito corretos e
+    // ainda assim não é código LOINC.
+    const FORMA_LOINC = /^\d+-\d$/;
+
     const invalidos = BIOMARKER_DEFINITIONS.filter((d) => d.loinc)
       .map((d) => {
         const loinc = String(d.loinc);
-        const [numero, digito] = loinc.split('-');
-        if (!numero || !digito || !/^\d+$/.test(numero) || !/^\d$/.test(digito)) {
-          return `${d.code} -> forma inválida: ${loinc}`;
+        if (!FORMA_LOINC.test(loinc)) {
+          return `${d.code} -> ${loinc} não tem a forma <número>-<dígito único>`;
         }
+        const [numero, digito] = loinc.split('-') as [string, string];
         const esperado = digitoEsperado(numero);
         return esperado === digito
           ? null

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -2573,7 +2573,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
   {
     category: 'autoimunidade',
     code: 'C3',
-    loinc: '4485-3',
+    loinc: '4485-9',
     names: {
       en: ['Complement C3', 'C3'],
       pt: ['Complemento C3', 'C3', 'Fração C3 do Complemento'],
@@ -2583,7 +2583,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
   {
     category: 'autoimunidade',
     code: 'C4',
-    loinc: '4498-6',
+    loinc: '4498-2',
     names: {
       en: ['Complement C4', 'C4'],
       pt: ['Complemento C4', 'C4', 'Fração C4 do Complemento'],
@@ -2652,7 +2652,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
   {
     category: 'nutrientes',
     code: 'Selenium',
-    loinc: '5697-7',
+    loinc: '5724-0',
     names: {
       en: ['Selenium', 'Se'],
       pt: ['Selênio', 'Se'],


### PR DESCRIPTION
A primeira execução real do verificador contra o servidor oficial ([run 31416442414](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/31416442414)) encontrou **três códigos que não existem no LOINC** — publicados no npm e no ValueSet do IG.

```
NÃO RESOLVEM no LOINC (3) — dado errado no catálogo:
  - 4485-3  (C3)
  - 4498-6  (C4)
  - 5697-7  (Selenium)
```

## As correções

| Biomarcador | Antes | Depois | Display oficial |
| --- | --- | --- | --- |
| C3 | `4485-3` | **`4485-9`** | Complement C3 [Mass/volume] in Serum or Plasma |
| C4 | `4498-6` | **`4498-2`** | Complement C4 [Mass/volume] in Serum or Plasma |
| Selenium | `5697-7` | **`5724-0`** | Selenium [Mass/volume] in Serum or Plasma |

**Conferido em duas pontas independentes**: o verificador com credencial do LOINC, e o `tx.fhir.org` público — este último com `2093-3` (Colesterol) como controle positivo, para garantir que o servidor responde. Os três novos resolvem nos dois; os três antigos, em nenhum.

A especificidade bate com a unidade de cada entrada: C3 e C4 em `mg/dL` e Selênio em `µg/L` são todos **Mass/volume em soro ou plasma**.

## O padrão: todos erravam o dígito verificador

Código LOINC termina em dígito verificador Mod 10 ("double-add-double"). Os três falham:

```
4485-3  -> dígito correto seria 9
4498-6  -> dígito correto seria 2
5697-7  -> dígito correto seria 8
```

(O Selênio errava duas coisas: dígito **e** número — o código certo é 5724-0, não 5697-8.)

Por isso entra também um **teste de dígito verificador** para todos os códigos do catálogo. Ele pega essa classe inteira **sem rede e sem credencial, em todo PR** — enquanto o `loinc:check` contra o servidor oficial é mensal e exige conta. Validei o algoritmo contra 8 códigos sabidamente bons antes de confiar nele, e conferi que reprova os três antigos nomeando cada um com o dígito correto:

```
C3 -> 4485-3 (dígito verificador deveria ser 9)
C4 -> 4498-6 (dígito verificador deveria ser 2)
Selenium -> 5697-7 (dígito verificador deveria ser 8)
```

## ValueSet regenerado

Carregava os códigos errados — C3 e C4 tinham entrado nele na regeneração do #64. `pnpm valueset:check` passa.

## Achado adjacente, fora deste PR

`units.ts` declara `µg/L` como canônico, mas **4 faixas usam `mcg/L`** (incluindo a do Selênio, cuja definição usa `µg/L`). Mesma classe do que o #63 corrigiu para TSH e Insulina. Deixei de fora para não misturar com correção de código LOINC.

## Verificação

- 405 testes passando (404 + o novo).
- `lint`, `typecheck`, `format:check` e `valueset:check` limpos.

Refs: PRE-254