### PR TITLE
fix(ci): o primeiro snapshot de LOINC era gerado e descartado

### DIFF
--- a/.github/workflows/loinc-check.yml
+++ b/.github/workflows/loinc-check.yml
@@ -83,15 +83,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if git diff --quiet -- scripts/loinc-snapshot.json; then
+          set -euo pipefail
+          SNAP=scripts/loinc-snapshot.json
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # `git add` antes de comparar, e comparar contra o índice.
+          # `git diff --quiet -- <arquivo>` ignora arquivo não rastreado e sai 0,
+          # então o primeiro snapshot de todos — que é justamente o caso do
+          # bootstrap — era gerado, dado como "sem mudança" e descartado.
+          git add "$SNAP"
+          if git diff --cached --quiet -- "$SNAP"; then
             echo "::notice::Snapshot já estava atualizado; nada a propor."
             exit 0
           fi
           branch="chore/loinc-snapshot-$(date -u +%Y%m%d%H%M)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
-          git add scripts/loinc-snapshot.json
           git commit -m "chore(core): atualiza o snapshot de códigos LOINC" \
             -m "Gerado por workflow_dispatch em modo update. Conferir cada mudança de nome ou status antes de aprovar: nome novo pode significar que o código deixou de servir para o analito."
           git push -u origin "$branch"


### PR DESCRIPTION
O bootstrap do snapshot ([run 31419302622](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/31419302622)) **funcionou** — e o resultado foi jogado fora.

```
Consultando 177 códigos LOINC únicos (177 biomarcadores)…
Snapshot gravado: 177 códigos
::notice::Snapshot já estava atualizado; nada a propor.
```

Os 177 códigos resolveram (depois do #69 corrigir os três inválidos), o arquivo foi gravado no runner, e aí o passo seguinte decidiu que não havia mudança.

## Causa

`git diff --quiet -- <arquivo>` **ignora arquivo não rastreado e sai com 0**. O snapshot ainda não existia no repositório, então o primeiro de todos caía exatamente nesse caso — o caminho quebrado era o único que importava para começar.

Reproduzido num repositório de teste:

```
git diff --quiet -- untracked.json           -> exit 0   ("sem mudança")
git add + git diff --cached --quiet -- ...   -> exit 1   (detecta)
```

## Correção

`git add` antes de comparar, e comparação contra o índice — funciona para arquivo novo e para arquivo alterado. O `git config` subiu para antes do `add`, já que agora é usado mais cedo.

Conferido nos três estados:

```
snapshot novo (não rastreado) -> abriria PR
snapshot igual                -> nada a propor
snapshot alterado             -> abriria PR
```

## Nota

O log traz `LOINC ?` no lugar da versão: o $lookup do servidor não devolveu parâmetro `version` na forma que eu esperava. A licença trata versão como *strongly encouraged, but not required* (10.4), então não bloqueia — mas fica anotado para olhar quando o snapshot entrar e der para inspecionar a resposta real.

Refs: PRE-254