### PR TITLE
fix(ci): quebra a mensagem de commit do snapshot em parágrafos

### DIFF
--- a/.github/workflows/loinc-check.yml
+++ b/.github/workflows/loinc-check.yml
@@ -98,7 +98,13 @@ jobs:
           fi
           branch="chore/loinc-snapshot-$(date -u +%Y%m%d%H%M)"
           git checkout -b "$branch"
-          git commit -m "chore(core): atualiza o snapshot de códigos LOINC" \
-            -m "Gerado por workflow_dispatch em modo update. Conferir cada mudança de nome ou status antes de aprovar: nome novo pode significar que o código deixou de servir para o analito."
+          # Cada -m vira um parágrafo. Precisam caber em menos de 100 colunas:
+          # o commit-msg roda commitlint aqui também, e `body-max-line-length`
+          # recusa parágrafo numa linha só — foi o que derrubou o bootstrap.
+          git commit \
+            -m "chore(core): atualiza o snapshot de códigos LOINC" \
+            -m "Gerado pelo workflow LOINC em modo update." \
+            -m "Conferir cada mudança de nome ou status antes de aprovar." \
+            -m "Nome novo pode significar que o código deixou de servir para o analito."
           git push -u origin "$branch"
           gh pr create --fill --base main --head "$branch"


### PR DESCRIPTION
Terceira falha do bootstrap do snapshot, e cada uma só apareceu rodando de verdade.

O run [31437770702](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/31437770702) passou da geração e do diff — a correção do #70 funcionou — e morreu no `commit-msg`:

```
✖   body's lines must not be longer than 100 characters [body-max-line-length]
husky - commit-msg script failed (code 1)
```

O corpo estava numa linha só de **193 caracteres**. Eu não tinha considerado que o hook do husky roda no runner igual roda na máquina de quem desenvolve.

## Correção

Cada `-m` vira um parágrafo curto, todos abaixo de 100 colunas.

Conferido de duas formas: rodando `git commit` real com esses argumentos (passa, e o corpo sai formatado como esperado) e passando a mensagem montada pelo `commitlint` direto (exit 0).

## Sequência das falhas, para registro

| Run | Onde parou | Causa |
| --- | --- | --- |
| 31412929190 | geração | 3 códigos LOINC inválidos (corrigidos no #69) |
| 31416442414 | geração | idem, agora com diagnóstico separando os casos (#66) |
| 31419302622 | diff | `git diff --quiet` ignora arquivo não rastreado (#70) |
| 31437770702 | commit | corpo acima de 100 colunas (este PR) |

Nenhuma dessas apareceria sem executar o workflow ponta a ponta — é o argumento para ter feito o bootstrap por dispatch em vez de assumir que funcionava.

Refs: PRE-254