### PR TITLE
fix(core): troca o código LOINC da LDH, que está desencorajado

### DIFF
--- a/ig/input/fsh/valuesets/BRLabTestVS.fsh
+++ b/ig/input/fsh/valuesets/BRLabTestVS.fsh
@@ -58,7 +58,7 @@ Description: "Códigos LOINC para exames laboratoriais suportados pelo fhir-bras
 * $LOINC#1975-2 "Bilirrubina Total"
 * $LOINC#2324-2 "Gama-Glutamil Transferase"
 * $LOINC#2336-6 "Globulina"
-* $LOINC#2532-0 "Desidrogenase Lática"
+* $LOINC#14804-9 "Desidrogenase Lática"
 * $LOINC#2885-2 "Proteína Total"
 // hormonios
 * $LOINC#1848-1 "Diidrotestosterona"

--- a/packages/core/src/__tests__/biomarkers.test.ts
+++ b/packages/core/src/__tests__/biomarkers.test.ts
@@ -289,6 +289,16 @@ describe('getDefinitionByCode', () => {
     expect(def?.unit).toBe('nmol/L');
   });
 
+  // O 2532-0 saiu de código canônico por estar DISCOURAGED no LOINC, mas
+  // continua chegando em laudo antigo e em dado já armazenado. Trocar o
+  // canônico sem manter o alias quebraria a leitura desse histórico.
+  it('LDH aceita o código antigo 2532-0 como alias', () => {
+    const def = getDefinitionByCode('LDH');
+    expect(def?.loinc).toBe('14804-9');
+    expect(loincToCode('14804-9')).toBe('LDH');
+    expect(loincToCode('2532-0')).toBe('LDH');
+  });
+
   it('Omega3_Total usa LOINC 99620-7 (RBC, não 35178-3 Ser/Plas)', () => {
     // Revisão clínica (issue #41): Índice Ômega-3 (Harris 2004) é medido
     // em hemácias; 99620-7 alinha à matriz dos sibling EPA (75097-6) e

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -2536,6 +2536,11 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
     category: 'figado',
     code: 'LDH',
     loinc: '14804-9',
+    // 2532-0 é o código genérico anterior, que o LOINC marca como DISCOURAGED.
+    // Fica como alias para que laudo antigo e dado já armazenado continuem
+    // resolvendo em LDH — a troca do código canônico não pode quebrar leitura
+    // de histórico.
+    loincAliases: ['2532-0'],
     names: {
       en: ['Lactate Dehydrogenase', 'LDH', 'LD'],
       pt: ['Desidrogenase Lática', 'DHL', 'LDH', 'Lactato Desidrogenase'],

--- a/packages/core/src/biomarkers.ts
+++ b/packages/core/src/biomarkers.ts
@@ -2535,7 +2535,7 @@ export const BIOMARKER_DEFINITIONS: BiomarkerDefinition[] = [
   {
     category: 'figado',
     code: 'LDH',
-    loinc: '2532-0',
+    loinc: '14804-9',
     names: {
       en: ['Lactate Dehydrogenase', 'LDH', 'LD'],
       pt: ['Desidrogenase Lática', 'DHL', 'LDH', 'Lactato Desidrogenase'],


### PR DESCRIPTION
Achado do primeiro snapshot bem-sucedido: **176 códigos ACTIVE e um DISCOURAGED**.

```
código: 2532-0 | status: DISCOURAGED
display: Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma
biomarcador: LDH ('Desidrogenase Lática', 'DHL', 'LDH')
```

`DISCOURAGED` não é o mesmo que aposentado — o código resolve e continua válido — mas o LOINC está sinalizando que existe termo preferível. O `2532-0` é o genérico sem método; o **`14804-9`** especifica *by Lactate to pyruvate reaction*, que é como o ensaio é feito na prática.

Conferido no `tx.fhir.org`:

```
2532-0    status=DISCOURAGED
14804-9   status=ACTIVE   Lactate dehydrogenase [Enzymatic activity/volume]
                          in Serum or Plasma by Lactate to pyruvate reaction
```

Dígito verificador dos dois confere, então o teste offline não pegaria este caso — foi preciso perguntar ao servidor. É a diferença entre as duas camadas que o PRE-254 separa: dígito é forma, status é deriva.

## Por que agora

Status desencorajado é **falha alta por desenho** no `loinc:check`. Sem esta troca, o check mensal falharia em toda execução, e um check que sempre falha é um check que ninguém olha.

ValueSet regenerado.

## Verificação

- 405 testes passando; `lint`, `typecheck`, `format:check` limpos.
- `valueset:check` limpo após regenerar.

Refs: PRE-254