### PR TITLE
fix(ci): não falha quando o Actions não pode abrir PR

### DIFF
--- a/.github/workflows/loinc-check.yml
+++ b/.github/workflows/loinc-check.yml
@@ -121,6 +121,8 @@ jobs:
           url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1"
           echo "::notice::Branch publicada: $branch"
           echo "::notice::Abrir PR manualmente: $url"
-          echo "### Snapshot de LOINC pronto para revisão" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Branch \`$branch\` publicada. [Abrir PR]($url)" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Snapshot de LOINC pronto para revisão"
+            echo ""
+            echo "Branch \`$branch\` publicada. [Abrir PR]($url)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/loinc-check.yml
+++ b/.github/workflows/loinc-check.yml
@@ -107,4 +107,20 @@ jobs:
             -m "Conferir cada mudança de nome ou status antes de aprovar." \
             -m "Nome novo pode significar que o código deixou de servir para o analito."
           git push -u origin "$branch"
-          gh pr create --fill --base main --head "$branch"
+          # A branch com o snapshot já está publicada aqui — o trabalho não se
+          # perde a partir deste ponto.
+          #
+          # Abrir o PR pode não ser permitido: o repositório mantém
+          # `can_approve_pull_request_reviews: false`, que também bloqueia
+          # criação de PR pelo GITHUB_TOKEN. Isso é postura de segurança
+          # deliberada, então o workflow se adapta a ela em vez de exigir que
+          # ela mude — cai para imprimir o link pronto.
+          if gh pr create --fill --base main --head "$branch"; then
+            exit 0
+          fi
+          url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1"
+          echo "::notice::Branch publicada: $branch"
+          echo "::notice::Abrir PR manualmente: $url"
+          echo "### Snapshot de LOINC pronto para revisão" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Branch \`$branch\` publicada. [Abrir PR]($url)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Quarta falha do bootstrap — e a primeira em que **o trabalho não se perdeu**.

O run [31438181796](https://github.com/Precisa-Saude/fhir-brasil/actions/runs/31438181796) gerou o snapshot, passou no commit-msg (correção do #71), commitou e **publicou a branch** `chore/loinc-snapshot-202608102225`. Aí:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

## Por que não vou mexer na configuração

O repositório tem `can_approve_pull_request_reviews: false`, que também bloqueia criação de PR pelo `GITHUB_TOKEN`. Dá para inverter isso pela API, mas é **postura de segurança deliberada** — não é o tipo de coisa que um workflow deve exigir que mude para funcionar.

Então o workflow se adapta: tenta abrir o PR e, se não puder, imprime o link pronto como `::notice::` e no resumo do job.

A branch já está publicada nesse ponto, então o snapshot está a salvo — é só clicar. Falhar o job aqui só criava alarme sobre algo que já tinha dado certo.

## Estado do bootstrap

A branch daquele run existe e o snapshot está íntegro:

```
códigos:      177
conferido em: 2026-08-10
aviso da licença presente: sim
status:       176 ACTIVE, 1 DISCOURAGED
```

O DISCOURAGED é a LDH, tratado no #72. Depois que ele entrar, regenero o snapshot para nascer com tudo ACTIVE.

Refs: PRE-254