### PR TITLE
fix(ci): remove flag inválida que quebrava o publish de recuperação

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -54,7 +54,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -e
-          pnpm -r --filter "./packages/**" --if-present exec sh -c '
+          # Sem `--if-present`: essa flag existe em `pnpm run`, não em
+          # `pnpm exec`, e fazia o comando abortar com "Unknown option"
+          # antes de publicar qualquer coisa.
+          pnpm -r --filter "./packages/**" exec sh -c '
             pkg_name=$(node -p "require(\"./package.json\").name")
             pkg_version=$(node -p "require(\"./package.json\").version")
             pkg_private=$(node -p "Boolean(require(\"./package.json\").private)")


### PR DESCRIPTION
## O problema

**Cinco tags foram criadas e nenhuma publicada no npm**, sem ninguém notar:

```
tags:  v0.16.6  v0.17.0  v0.17.1  v0.17.2  v0.17.3
npm:   última publicada = 0.16.5
```

Essas tags carregam todo o trabalho de hoje — o ValueSet ligado ao CI (#64), o verificador de LOINC (#65), o teto de CK (#67), a remoção da razão ApoCIII/ApoA1 (#68) e a correção dos três códigos LOINC inválidos (#69). Nada disso chegou ao `platform`, que continua instalando 0.16.5.

## Por que passou despercebido

Porque **o caminho de recuperação também estava quebrado**. O `publish-tag.yml` existe exatamente para republicar uma tag quando o publish do release não acontece, e ele falha na primeira linha:

```
ERROR  Unknown option: 'if-present'
For help, run: pnpm help exec
```

`--if-present` é opção de `pnpm run`, não de `pnpm exec`. Reproduzido localmente:

```bash
$ pnpm -r --filter "./packages/core" --if-present exec sh -c 'echo x'
 ERROR  Unknown option: 'if-present'

$ pnpm -r --filter "./packages/core" exec sh -c 'echo ok'
ok
```

Com a flag, o comando aborta **antes de publicar qualquer pacote** — então a rede de segurança nunca funcionou.

## Correção

Remove a flag. O resto do script (pular pacote privado, pular versão já publicada, `pnpm publish --provenance`) já estava certo e continua igual — a idempotência que o cabeçalho promete depende só do `npm view`, não dessa flag.

## Fora deste PR

**A causa raiz do publish não rodar** ainda não está identificada. O job `publish` do `ci.yml` depende de `needs.release.outputs.released == 'true'`, e nas execuções que inspecionei ele aparece como `skipped`. As mais recentes pulam legitimamente (`No changes under packages/** — release skipped`, em merges que só tocaram workflow), mas as cinco que geraram tag são anteriores à janela que consegui inspecionar. Vale uma issue própria.

**Este arquivo é template sincronizado** — não está no `ignoreTemplates` do `.precisa.json`. Ou seja, a mesma correção precisa ir para o repo `tooling`, senão o próximo `precisa sync` traz a flag de volta. Sem isso, esta correção tem prazo de validade.

## Verificação

- `actionlint` limpo; o único `SC2016` é pré-existente e idêntico ao da `main` (aspas simples são intencionais: as variáveis são expandidas pelo `sh` interno, não pelo shell externo).
- `format:check` limpo.
- Flag testada nos dois sentidos localmente.

Refs: PRE-254
