### PR TITLE
chore(ci): sincroniza templates do cli 1.13.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,21 @@ permissions:
   # via GITHUB_TOKEN no fallback de providers.
   models: read
 
+# Cancela só em PR. O `push` deste workflow só dispara na branch padrão, e lá
+# o run publica no npm: cancelar no meio deixa a tag criada sem a versão
+# publicada. Foi o que aconteceu no fhir-brasil, onde cinco tags (v0.16.6 a
+# v0.17.3) ficaram sem publicar porque cada merge cancelava o publish do merge
+# anterior — e o commit `chore(release)` do semantic-release dispara mais um
+# run, que cancela o próprio publish que o criou.
+#
+# Chavear por `event_name` em vez de comparar a branch evita depender de
+# `github.event.repository.default_branch`, que nem todo contexto de gatilho
+# popula — e, se viesse vazio, a comparação daria `true` e voltaria a cancelar
+# na branch padrão, justamente o que este comentário existe para impedir.
+# Assim, qualquer evento inesperado cai no lado seguro (não cancela).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ── CI checks (every PR and push) ──────────────────────────────

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -56,7 +56,7 @@ jobs:
           set -e
           # Sem `--if-present`: essa flag existe em `pnpm run`, não em
           # `pnpm exec`, e fazia o comando abortar com "Unknown option"
-          # antes de publicar qualquer coisa.
+          # antes de publicar qualquer pacote.
           pnpm -r --filter "./packages/**" exec sh -c '
             pkg_name=$(node -p "require(\"./package.json\").name")
             pkg_version=$(node -p "require(\"./package.json\").version")

--- a/.github/workflows/publish-watch.yml
+++ b/.github/workflows/publish-watch.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           node-version: 22
 
+      # O job NÃO falha em divergência, de propósito: cron diário vermelho
+      # vira ruído que se aprende a ignorar. O alerta é a issue aberta no
+      # passo final, que persiste até alguém fechar e não duplica.
       - name: Compare npm latest vs git tags
         id: check
         run: |
@@ -76,6 +79,23 @@ jobs:
             else
               echo "::warning::$name@$npm_version published on npm but no matching git tag in this repo"
               mismatches="${mismatches}- \`${name}@${npm_version}\` (no matching tag)\n"
+            fi
+
+            # Direção inversa: existe versão com tag que nunca foi publicada?
+            # O laço acima parte do npm, então só enxerga "publicado sem tag".
+            # O modo de falha caro é o oposto — release cortada que não chegou
+            # ao consumidor —, e foi o que aconteceu no fhir-brasil: as tags
+            # v0.16.6 a v0.17.3 existiam com o npm parado na 0.16.5, e este
+            # check passava verde porque a tag da 0.16.5 estava lá.
+            latest_tag=$(git tag --sort=-v:refname --list 'v*' | head -1)
+            latest_ver="${latest_tag#v}"
+            if [ -n "$latest_ver" ] && [ "$latest_ver" != "$npm_version" ]; then
+              if npm view "$name@$latest_ver" version >/dev/null 2>&1; then
+                echo "$name@$latest_ver: tag mais recente publicada"
+              else
+                echo "::warning::$name: tag $latest_tag existe mas $latest_ver não está no npm"
+                mismatches="${mismatches}- \`${name}@${latest_ver}\` (tag sem publicação)\n"
+              fi
             fi
           done
           if [ -n "$mismatches" ]; then

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -50,7 +50,16 @@ jobs:
               per_page: 100,
             });
             const ignore = [/\.md$/, /^docs\//, /^\.github\//, /\.json$/, /\.ya?ml$/, /\.cff$/];
-            const hasCode = files.some(f => !ignore.some(p => p.test(f.filename)));
+            // Workflow é código: roda shell com as credenciais do repo. Ficava
+            // de fora por casar com `^.github/` e com `.yml`, e o efeito é o
+            // inverso do risco — mudança em pipeline passava sem revisão
+            // nenhuma. Dois bugs de shell chegaram à main assim (fhir-brasil
+            // #70 e #75).
+            const isWorkflow = (filename) =>
+              /^\.github\/workflows\/.+\.ya?ml$/.test(filename);
+            const hasCode = files.some(
+              f => isWorkflow(f.filename) || !ignore.some(p => p.test(f.filename)),
+            );
             if (!hasCode) {
               core.setOutput('should_run', 'false');
               core.setOutput('review_round', 'skip');

--- a/.precisa.json
+++ b/.precisa.json
@@ -21,5 +21,5 @@
   ],
   "siteFilter": "@fhir-brasil/site",
   "siteProjectName": "fhir-brasil",
-  "ignoreTemplates": [".commitlintrc.cjs", "eslint.config.js"]
+  "ignoreTemplates": [".commitlintrc.cjs", ".github/workflows/_checks.yml", "eslint.config.js"]
 }


### PR DESCRIPTION
Primeiro sync depois do `@precisa-saude/cli@1.13.1`, que carrega as correções do pipeline de release.

## O que chega

| Arquivo | Correção |
| --- | --- |
| `ci.yml` | `cancel-in-progress` só em PR ([tooling#47](https://github.com/Precisa-Saude/tooling/pull/47)) |
| `publish-tag.yml` | sem `--if-present`, que abortava o publish de recuperação (tooling#47) |
| `review.yml` | workflow passa a contar como código ([tooling#48](https://github.com/Precisa-Saude/tooling/pull/48)) |
| `publish-watch.yml` | conferência inversa: tag sem publicação ([tooling#50](https://github.com/Precisa-Saude/tooling/pull/50)) |

As duas primeiras são exatamente o que deixou cinco tags deste repo sem publicar hoje.

## Uma divergência declarada

O `--dry-run` mostrou que o sync **apagaria o job `ValueSet do IG`** do `_checks.yml` — o template não o tem, porque é específico daqui, e o arquivo não estava no `ignoreTemplates`.

Seria uma regressão silenciosa: some o check que impede o `BRLabTestVS.fsh` de congelar como congelou (160 códigos enquanto o catálogo tinha 177, e o LOINC antigo da Lp(a)).

Então `.github/workflows/_checks.yml` entra no `ignoreTemplates`, como divergência deliberada. Conferido depois do sync: o job continua lá e `pnpm valueset:check` sai 0.

## Verificação

- 406 testes passando; `format:check` limpo; `valueset:check` limpo.
- `actionlint` idêntico à `main` em todos os workflows tocados (`review` 16, `publish-tag` 4 — pré-existentes; `ci`, `publish-watch` e `_checks` limpos).
- Cron do `publish-watch` inalterado (`17 6 * * *`); a nota de pós-sync sobre 15 minutos é texto genérico do cli, não uma mudança.