### PR TITLE
fix(ci): publish-watch aceita pacote sem tag quando bate com o package.json

### DIFF
--- a/.github/workflows/publish-watch.yml
+++ b/.github/workflows/publish-watch.yml
@@ -75,9 +75,20 @@ jobs:
             fi
             # Tag convention: semantic-release emits `<name>@<ver>` for
             # monorepos and `v<ver>` for single-package repos. Accept both.
+            #
+            # A terceira condição cobre pacote público em linha de versão
+            # própria, que nunca ganha tag: o repositório etiqueta `v<ver>` da
+            # linha principal, então o @precisa-saude/fhir-rnds-sandbox, em
+            # 0.1.0 num repo cuja tag corrente é v0.17.3, ficaria para sempre
+            # sem tag correspondente e reabriria a issue todo dia. Quando a
+            # versão publicada é exatamente a que o package.json declara, a
+            # publicação está onde o repositório mandou, e a tag deixa de ser
+            # a única prova disso.
             if git rev-parse -q --verify "refs/tags/${name}@${npm_version}" >/dev/null 2>&1 \
                || git rev-parse -q --verify "refs/tags/v${npm_version}" >/dev/null 2>&1; then
               echo "$name@$npm_version: tag found"
+            elif [ -n "$repo_version" ] && [ "$repo_version" = "$npm_version" ]; then
+              echo "$name@$npm_version: sem tag, mas igual ao package.json"
             else
               echo "::warning::$name@$npm_version published on npm but no matching git tag in this repo"
               mismatches="${mismatches}- \`${name}@${npm_version}\` (no matching tag)\n"


### PR DESCRIPTION
Sincroniza os templates do `@precisa-saude/cli@1.13.3`. Um arquivo muda, com 11 linhas acrescentadas: `.github/workflows/publish-watch.yml`.

## O defeito

A conferência da direção original assumia que todo pacote público de um repo compartilha a linha de tags daquele repo. Pacote em linha de versão própria nunca ganha tag correspondente, porque o `semantic-release` corta uma tag por release da linha principal.

É o espelho exato do que foi corrigido no sync anterior, na outra direção.

## A correção

Uma terceira condição de aceitação, antes do aviso:

```bash
elif [ -n "$repo_version" ] && [ "$repo_version" = "$npm_version" ]; then
  echo "$name@$npm_version: sem tag, mas igual ao package.json"
```

## Verificação

Rodado numa branch descartável do fhir-brasil, em runner de verdade, contra o npm de verdade. Duas execuções:

**Estado real, tudo em dia:**

```
@precisa-saude/fhir@0.17.3: tag found
@precisa-saude/fhir-ocr-utils@0.17.3: tag found
@precisa-saude/fhir-rnds@0.17.3: tag found
@precisa-saude/fhir-rnds-sandbox@0.1.0: sem tag, mas igual ao package.json
```

**Com `packages/rnds-sandbox` forçado a 0.2.0, npm em 0.1.0:**

```
::warning::@precisa-saude/fhir-rnds-sandbox: repositório em 0.2.0, npm em 0.1.0
```

A segunda execução é a que importa: ficar quieto é fácil, e o objetivo era confirmar que release perdida continua sendo detectada.

## O que isso custa em detecção

A conferência original existe para pegar publicação fora do fluxo. Continua pegando qualquer versão no npm que não esteja no `package.json` nem tenha tag, que é o formato de quase toda publicação indevida — quem publica fora do fluxo publica algo novo, e o npm recusa sobrescrever versão existente.

Deixa de pegar conteúdo adulterado publicado exatamente na versão que o `package.json` declara e que ainda não foi ao registry. Janela estreita, e o preço de fechá-la é um vigia permanentemente vermelho.
