### PR TITLE
fix(ci): guard de release compara desde a última release, não o push

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -4,9 +4,10 @@ name: Release
 # Produces outputs so downstream jobs (publish, deploy-site) can gate
 # on whether a release happened and which commit carries the bump.
 #
-# Guards release on `packages/**` or root `package.json` changing in
-# the pushed range. Site-only or docs-only pushes skip the release
-# cycle. Set `require_package_changes: false` to release regardless.
+# Guards release on `packages/**` or root `package.json` changing since
+# the last published release. Site-only or docs-only pushes skip the
+# release cycle. Set `require_package_changes: false` to release
+# regardless.
 
 on:
   workflow_call:
@@ -41,18 +42,49 @@ jobs:
       # guard won't checkout an empty ref.
       release_sha: ${{ steps.semantic.outputs.release_sha || github.sha }}
     steps:
-      - name: Check for package changes across pushed commits
+      - name: Check for package changes since the last release
         id: changes
         if: inputs.require_package_changes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          # Compares `before..after` from the push payload. Paginates explicitly
-          # because `compareCommits` truncates at 300 files per page — a large
-          # push could otherwise silently miss detection.
+          # Compares the last published release against the current commit —
+          # NOT `before..after` from the push payload.
+          #
+          # The push range is the wrong base: it only sees the commits of this
+          # one push, so a package change whose own run never reached this job
+          # (cancelled by concurrency, cancelled run, failed earlier job) is
+          # never reconsidered. Every later push reports its own files, none of
+          # which touch `packages/**`, and the fix sits on main unreleased until
+          # someone happens to touch a package again. That stranded the LDH
+          # LOINC correction in fhir-brasil for three days.
+          #
+          # Anchoring on the last release makes the guard answer the question it
+          # actually means to ask — "is there anything unreleased worth
+          # releasing?" — which is stateless and self-healing: a missed run is
+          # picked up by the next push instead of being lost.
+          #
+          # The tag points at the `chore(release)` commit itself, and
+          # `base...head` excludes the base, so the release commit's own
+          # version bump never counts as a package change.
+          #
+          # Paginates explicitly because `compareCommits` truncates at 300 files
+          # per page — a long backlog could otherwise silently miss detection.
           script: |
-            const before = context.payload.before;
             const after = context.sha;
-            const isInitial = !before || /^0+$/.test(before);
+            let base = null;
+            try {
+              const { data: release } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner, repo: context.repo.repo,
+              });
+              base = release.tag_name;
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              // No release yet — repo was never released. Fall back to the push
+              // range, which is all the history there is to judge by.
+              core.info('no published release found; falling back to the push range');
+              base = context.payload.before;
+            }
+            const isInitial = !base || /^0+$/.test(base);
             let filenames = [];
             if (isInitial) {
               const { data: commit } = await github.rest.repos.getCommit({
@@ -65,7 +97,7 @@ jobs:
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  basehead: `${before}...${after}`,
+                  basehead: `${base}...${after}`,
                   per_page: 100,
                 },
               );
@@ -78,7 +110,7 @@ jobs:
               f => f.startsWith('packages/') || f.startsWith('templates/') || f === 'package.json'
             );
             core.setOutput('packages_changed', packageChanged ? 'true' : 'false');
-            core.info(`inspected ${filenames.length} files, packages_changed=${packageChanged}`);
+            core.info(`base=${base}, inspected ${filenames.length} files, packages_changed=${packageChanged}`);
 
       - name: Generate GitHub App token
         id: app-token
@@ -156,4 +188,4 @@ jobs:
 
       - name: Skip release (no package changes)
         if: inputs.require_package_changes && steps.changes.outputs.packages_changed != 'true'
-        run: echo "No changes under packages/** — release skipped"
+        run: echo "No changes under packages/** since the last release — release skipped"


### PR DESCRIPTION
## Problema

O guard de `packages_changed` em `_release.yml` usa `before..after` do payload do push. Ele só enxerga os commits **daquele push**.

Consequência: uma mudança em `packages/**` cujo run nunca chegou ao job `release` — cancelado por concurrency, run cancelado, job anterior falhando — não é reconsiderada nunca mais. Todo push seguinte reporta os próprios arquivos, nenhum deles em `packages/**`, e a correção fica na `main` sem release por tempo indeterminado.

Não é hipotético. Foi o que aconteceu aqui:

1. O run do merge do #72 (`fix(core)`: troca o código LOINC da LDH) foi **cancelado** às 22:44 de 10/08 — o merge do #73 entrou ~40 s depois e a concurrency matou o run anterior. O job `release` ficou `skipped`.
2. Todos os commits desde então (#73 a #78) tocaram só `.github/**` e `scripts/**`.
3. Último run na `main`: `No changes under packages/** — release skipped`.

O resultado é que **`@precisa-saude/fhir@0.17.3`, o `latest` no npm, ainda publica `2532-0` como código primário da LDH** — o código que o LOINC marca como `DISCOURAGED` e que o verificador do PRE-254 pegou. Conferido no tarball publicado: `2532-0` está no `dist/`, `14804-9` não.

O `publish-watch` está verde porque compara o npm com o `package.json`, e os dois dizem `0.17.3` — ele confirma um estado errado.

## Correção

Ancorar a comparação na **última release publicada** (`repos.getLatestRelease` → `tag_name`) em vez do range do push.

Isso faz o guard responder a pergunta que ele quer fazer — *existe algo não publicado que mereça release?* — em vez de *este push mexeu em pacote?*. A diferença é que a primeira é **sem estado e auto-recuperável**: um run perdido é retomado no push seguinte, sozinho.

Detalhes:

- A tag aponta para o próprio commit `chore(release)`, e `base...head` exclui a base — então o bump de versão da release anterior não conta como mudança de pacote. O guard não vira um "sempre libera".
- `getLatestRelease` devolve 404 em repo que nunca teve release: cai para o range do push, que é toda a história que existe para julgar.
- A paginação explícita continua como estava (o `compareCommits` trunca em 300 arquivos por página).

## Verificação

Executei o script do guard com a API mockada e os dados reais do repo:

| Cenário | `packages_changed` |
| --- | --- |
| Estado de hoje, guard novo | `true` — destrava a 0.17.4 |
| Estado de hoje, guard antigo | `false` — o bug |
| Repo sem release nenhuma (404) | fallback para o push range, sem estourar |

Ao entrar na `main`, este PR deve disparar o `release`, o semantic-release enxerga o `fix(core)` da LDH e corta a **0.17.4** com a correção do código LOINC.

## Alcance

O arquivo vem do template em `tooling/templates/github/workflows/_release.yml` e é **idêntico em 11 repos** do ecossistema. Este PR corrige só o `fhir-brasil`, para destravar a release travada. O template e os demais consumidores vêm em seguida.

Refs: PRE-254