### PR TITLE
chore(ci): alinha o _release.yml ao template do tooling

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -54,9 +54,8 @@ jobs:
           # one push, so a package change whose own run never reached this job
           # (cancelled by concurrency, cancelled run, failed earlier job) is
           # never reconsidered. Every later push reports its own files, none of
-          # which touch `packages/**`, and the fix sits on main unreleased until
-          # someone happens to touch a package again. That stranded the LDH
-          # LOINC correction in fhir-brasil for three days.
+          # which touch `packages/**`, and the fix sits on the default branch
+          # unreleased until someone happens to touch a package again.
           #
           # Anchoring on the last release makes the guard answer the question it
           # actually means to ask — "is there anything unreleased worth
@@ -78,9 +77,11 @@ jobs:
               });
               base = release.tag_name;
             } catch (err) {
+              // Only a 404 means "never released", which is a valid answer.
+              // Anything else (network, auth, rate limit) is ambiguous, and
+              // ambiguity here must break loudly rather than quietly judge on
+              // the wrong base.
               if (err.status !== 404) throw err;
-              // No release yet — repo was never released. Fall back to the push
-              // range, which is all the history there is to judge by.
               core.info('no published release found; falling back to the push range');
               base = context.payload.before;
             }


### PR DESCRIPTION
## O quê

Só comentário. O comportamento do workflow é **idêntico** antes e depois — `git diff` são 6 linhas de comentário.

## Por quê

A correção do guard de release entrou primeiro aqui (#79), para destravar a v0.17.4 que estava presa. Escrevi o comentário citando o incidente concreto — a correção do código LOINC da LDH que ficou três dias fora do npm.

Quando a mesma correção foi para o template em Precisa-Saude/tooling#53, o comentário virou genérico (o template serve 9 repos; citar um incidente de outro repo em todos eles não ajuda ninguém).

Resultado: `precisa doctor` passou a acusar drift neste arquivo.

```
! .github/workflows/_release.yml — Differs from template (run `precisa sync` to update)
```

Este PR fecha essa divergência. O arquivo volta a ser byte a byte igual ao template — conferido com `diff`.

O contexto do incidente continua registrado onde pertence: no #79 e no ticket.

Refs: PRE-254